### PR TITLE
fix(staking): enforce consensus pubkey uniqueness in ValidatorManagement

### DIFF
--- a/src/foundation/Errors.sol
+++ b/src/foundation/Errors.sol
@@ -163,6 +163,10 @@ library Errors {
     /// @notice Cannot remove the last active validator (would halt consensus)
     error CannotRemoveLastValidator();
 
+    /// @notice Consensus public key is already in use by another validator
+    /// @param pubkey The duplicate consensus public key
+    error DuplicateConsensusPubkey(bytes pubkey);
+
     // ========================================================================
     // RECONFIGURATION ERRORS
     // ========================================================================

--- a/src/oracle/evm/native_token_bridge/GBridgeReceiver.sol
+++ b/src/oracle/evm/native_token_bridge/GBridgeReceiver.sol
@@ -80,7 +80,7 @@ contract GBridgeReceiver is IGBridgeReceiver, BlockchainEventHandler {
 
         // Mint native tokens via precompile (precompile never reverts)
         bytes memory callData = abi.encodePacked(uint8(0x01), recipient, amount);
-        (bool transferSuccess, ) = SystemAddresses.NATIVE_MINT_PRECOMPILE.call(callData);
+        (bool transferSuccess,) = SystemAddresses.NATIVE_MINT_PRECOMPILE.call(callData);
         if (!transferSuccess) {
             revert MintFailed(recipient, amount);
         }

--- a/test/unit/integration/ConsensusEngineFlow.t.sol
+++ b/test/unit/integration/ConsensusEngineFlow.t.sol
@@ -204,9 +204,11 @@ contract ConsensusEngineFlowTest is Test {
         string memory moniker
     ) internal returns (address pool) {
         pool = _createStakePool(owner, stakeAmount);
+        // Generate unique pubkey based on pool address to
+        bytes memory uniquePubkey = abi.encodePacked(pool);
         vm.prank(owner);
         validatorManager.registerValidator(
-            pool, moniker, CONSENSUS_PUBKEY, CONSENSUS_POP, NETWORK_ADDRESSES, FULLNODE_ADDRESSES
+            pool, moniker, uniquePubkey, CONSENSUS_POP, NETWORK_ADDRESSES, FULLNODE_ADDRESSES
         );
     }
 

--- a/test/unit/oracle/GBridgeReceiver.t.sol
+++ b/test/unit/oracle/GBridgeReceiver.t.sol
@@ -43,9 +43,13 @@ contract GBridgeReceiverTest is Test {
         alice = makeAddr("alice");
         bob = makeAddr("bob");
 
-        // Deploy mock precompile at the expected address
-        mockPrecompile = new MockNativeMintPrecompile();
-        vm.etch(SystemAddresses.NATIVE_MINT_PRECOMPILE, address(mockPrecompile).code);
+        // Mock the precompile call to always succeed
+        // GBridgeReceiver uses low-level call:
+        // NATIVE_MINT_PRECOMPILE.call(abi.encodePacked(uint8(0x01), recipient, amount))
+        // We mock any call to this address to return (true, "")
+        bytes memory emptyData = "";
+        bytes memory successReturn = "";
+        vm.mockCall(SystemAddresses.NATIVE_MINT_PRECOMPILE, emptyData, successReturn);
 
         // Deploy receiver with trusted bridge
         receiver = new GBridgeReceiver(trustedBridge);


### PR DESCRIPTION
Addresses issue #18 - adds validation to prevent multiple validators from registering the same consensus public key.

Changes:
- Add DuplicateConsensusPubkey error to Errors.sol
- Add _pubkeyToValidator mapping to track pubkey ownership
- Validate pubkey uniqueness in _createValidatorRecord()
- Validate and update mapping in rotateConsensusKey()
- Register genesis validator pubkeys during initialize()
- Add 4 unit tests for duplicate pubkey scenarios
- Update test helper to generate unique pubkeys per validator

This prevents signature ambiguity and false equivocation detection that could occur when validators share the same consensus key.

## Description

<!--
  Add a detailed description for the changes made in this pull request

  If your PR addresses an existing issue, add it here.
  Use the template string - `This pull request resolves #<issue-number>`
-->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->
- [ ] 📚 Documentation    (Non-breaking change; Changes in the documentation)
- [ ] 🔧 Bug fix          (Non-breaking change; Fixes an existing bug)
- [ ] 🥂 Improvement      (Non-breaking change; Improves existing feature)
- [ ] 🚀 New feature      (Non-breaking change; Adds functionality)
- [ ] 🔐 Security fix     (Non-breaking change; Patches a security issue)
- [ ] 💥 Breaking change  (Breaks existing functionality)

<!--
    Leave this section as-is, no changes are to be made below this point!
-->