### PR TITLE
feat(genesis): add chain_id config and oracle task/bridge support

### DIFF
--- a/genesis-tool/src/execute.rs
+++ b/genesis-tool/src/execute.rs
@@ -6,8 +6,6 @@ use crate::{
     },
 };
 
-use alloy_chains::NamedChain;
-
 use revm::{
     InMemoryDB,
     db::{BundleState, PlainAccount},
@@ -90,9 +88,9 @@ fn extract_runtime_bytecode(constructor_bytecode: &str) -> Vec<u8> {
     }
 }
 
-pub fn prepare_env() -> Env {
+pub fn prepare_env(chain_id: u64) -> Env {
     let mut env = Env::default();
-    env.cfg.chain_id = NamedChain::Mainnet.into();
+    env.cfg.chain_id = chain_id;
     env.tx.gas_limit = 30_000_000;
     // Set block.timestamp to current time so Genesis.sol's lockedUntil calculation works correctly
     // Genesis.sol calculates: lockedUntil = block.timestamp * 1_000_000 + lockupDuration
@@ -145,7 +143,7 @@ pub fn genesis_generate(
 
     let db = deploy_bsc_style(byte_code_dir, total_stake);
 
-    let env = prepare_env();
+    let env = prepare_env(config.chain_id);
 
     let txs = build_genesis_transactions(config);
 

--- a/genesis-tool/src/genesis.rs
+++ b/genesis-tool/src/genesis.rs
@@ -29,6 +29,10 @@ fn derive_account_address_from_consensus_pubkey(consensus_pubkey: &[u8]) -> [u8;
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct GenesisConfig {
+    /// Chain ID for the network (default: 1 = Mainnet)
+    #[serde(rename = "chainId", default = "default_chain_id")]
+    pub chain_id: u64,
+
     #[serde(rename = "validatorConfig")]
     pub validator_config: ValidatorConfigParams,
 
@@ -60,6 +64,10 @@ pub struct GenesisConfig {
     pub jwk_config: JWKInitParams,
 
     pub validators: Vec<InitialValidator>,
+}
+
+fn default_chain_id() -> u64 {
+    1337
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
@@ -122,10 +130,10 @@ pub struct RandomnessConfigData {
 pub struct ConfigV2Data {
     #[serde(rename = "secrecyThreshold")]
     pub secrecy_threshold: u128,
-    
+
     #[serde(rename = "reconstructionThreshold")]
     pub reconstruction_threshold: u128,
-    
+
     #[serde(rename = "fastPathSecrecyThreshold")]
     pub fast_path_secrecy_threshold: u128,
 }

--- a/genesis-tool/src/post_genesis.rs
+++ b/genesis-tool/src/post_genesis.rs
@@ -51,11 +51,12 @@ fn execute_verification<F>(
     bundle_state: BundleState,
     transaction: TxEnv,
     verification_name: &str,
+    chain_id: u64,
     result_handler: F,
 ) where
     F: FnOnce(&ExecutionResult),
 {
-    let env = prepare_env();
+    let env = prepare_env(chain_id);
     let r = execute_revm_sequential(db, SpecId::LATEST, env, &[transaction], Some(bundle_state));
     
     match r {
@@ -81,6 +82,7 @@ fn verify_active_validators(db: impl DatabaseRef, bundle_state: BundleState, con
         bundle_state,
         get_validators_txn,
         "active validators",
+        config.chain_id,
         |result| print_active_validators_result(result, config),
     );
 }

--- a/src/Genesis.sol
+++ b/src/Genesis.sol
@@ -273,8 +273,8 @@ contract Genesis {
         // Or better, query Timestamp? Timestamp is not initialized yet (Blocker init comes last).
         // So we assume genesis time is 0.
         // lockedUntil must be in the future relative to block.timestamp
-        // Convert block.timestamp (seconds) to microseconds and add lockup duration
-        uint64 initialLockedUntil = uint64(block.timestamp * 1_000_000) + lockupDuration;
+        // 2027-01-01 00:00:00 UTC = 1798761600 seconds
+        uint64 initialLockedUntil = uint64(1798761600 * 1_000_000) + lockupDuration;
 
         for (uint256 i; i < len;) {
             InitialValidator calldata v = validators[i];


### PR DESCRIPTION
- Add chain_id field to GenesisConfig with default value 1337
- Modify prepare_env() to accept chain_id parameter
- Update all call sites in execute.rs, verify.rs, post_genesis.rs
- Fix post_genesis.rs to use config.chain_id instead of hardcoded value
- Fix initialLockedUntil to use 2027-01-01 00:00:00 UTC (1798761600)
  instead of block.timestamp for consistent lockup timing