### PR TITLE
refactor: apply pending config pattern to StakingConfig (GCC-004)

### DIFF
--- a/src/blocker/Reconfiguration.sol
+++ b/src/blocker/Reconfiguration.sol
@@ -18,6 +18,7 @@ import { ExecutionConfig } from "../runtime/ExecutionConfig.sol";
 import { ValidatorConfig } from "../runtime/ValidatorConfig.sol";
 import { VersionConfig } from "../runtime/VersionConfig.sol";
 import { GovernanceConfig } from "../runtime/GovernanceConfig.sol";
+import { StakingConfig } from "../runtime/StakingConfig.sol";
 
 /// @title Reconfiguration
 /// @author Gravity Team
@@ -264,6 +265,7 @@ contract Reconfiguration is IReconfiguration {
         ValidatorConfig(SystemAddresses.VALIDATOR_CONFIG).applyPendingConfig();
         VersionConfig(SystemAddresses.VERSION_CONFIG).applyPendingConfig();
         GovernanceConfig(SystemAddresses.GOVERNANCE_CONFIG).applyPendingConfig();
+        StakingConfig(SystemAddresses.STAKE_CONFIG).applyPendingConfig();
         EpochConfig(SystemAddresses.EPOCH_CONFIG).applyPendingConfig();
 
         // 2. Auto-evict underperforming validators based on completed epoch's performance data

--- a/src/foundation/Errors.sol
+++ b/src/foundation/Errors.sol
@@ -326,6 +326,15 @@ library Errors {
     /// @notice Minimum bond must be greater than zero
     error InvalidMinimumBond();
 
+    /// @notice Minimum stake must be greater than zero
+    error InvalidMinimumStake();
+
+    /// @notice Minimum proposal stake must be greater than zero
+    error InvalidMinimumProposalStake();
+
+    /// @notice Staking config has not been initialized
+    error StakingConfigNotInitialized();
+
     /// @notice Voting power increase limit out of range (1-50)
     /// @param value The invalid value provided
     error InvalidVotingPowerIncreaseLimit(uint64 value);

--- a/src/runtime/StakingConfig.sol
+++ b/src/runtime/StakingConfig.sol
@@ -9,8 +9,7 @@ import { Errors } from "../foundation/Errors.sol";
 /// @author Gravity Team
 /// @notice Configuration parameters for governance staking
 /// @dev Initialized at genesis, updatable via governance (GOVERNANCE).
-///      Anyone can stake tokens to participate in governance voting.
-///      TODO(yxia): onNewEpoch() and pending config pattern?
+///      Uses pending config pattern: changes are queued and applied at epoch boundaries.
 contract StakingConfig {
     // ========================================================================
     // CONSTANTS
@@ -21,6 +20,18 @@ contract StakingConfig {
 
     /// @notice Maximum unbonding delay: 1 year in microseconds
     uint64 public constant MAX_UNBONDING_DELAY = uint64(365 days) * 1_000_000;
+
+    // ========================================================================
+    // TYPES
+    // ========================================================================
+
+    /// @notice Pending configuration data structure
+    struct PendingConfig {
+        uint256 minimumStake;
+        uint64 lockupDurationMicros;
+        uint64 unbondingDelayMicros;
+        uint256 minimumProposalStake;
+    }
 
     // ========================================================================
     // STATE
@@ -38,6 +49,12 @@ contract StakingConfig {
     /// @notice Minimum stake required to create governance proposals
     uint256 public minimumProposalStake;
 
+    /// @notice Pending configuration for next epoch
+    PendingConfig private _pendingConfig;
+
+    /// @notice Whether a pending configuration exists
+    bool public hasPendingConfig;
+
     /// @notice Whether the contract has been initialized
     bool private _initialized;
 
@@ -45,11 +62,14 @@ contract StakingConfig {
     // EVENTS
     // ========================================================================
 
-    /// @notice Emitted when a configuration parameter is updated
-    /// @param param Parameter name hash
-    /// @param oldValue Previous value
-    /// @param newValue New value
-    event ConfigUpdated(bytes32 indexed param, uint256 oldValue, uint256 newValue);
+    /// @notice Emitted when configuration is applied at epoch boundary
+    event StakingConfigUpdated();
+
+    /// @notice Emitted when pending configuration is set by governance
+    event PendingStakingConfigSet();
+
+    /// @notice Emitted when pending configuration is cleared (applied or removed)
+    event PendingStakingConfigCleared();
 
     // ========================================================================
     // INITIALIZATION
@@ -57,10 +77,10 @@ contract StakingConfig {
 
     /// @notice Initialize the staking configuration
     /// @dev Can only be called once by GENESIS
-    /// @param _minimumStake Minimum stake for governance participation
+    /// @param _minimumStake Minimum stake for governance participation (must be > 0)
     /// @param _lockupDurationMicros Lockup duration in microseconds (must be > 0)
     /// @param _unbondingDelayMicros Unbonding delay in microseconds (must be > 0)
-    /// @param _minimumProposalStake Minimum stake to create proposals
+    /// @param _minimumProposalStake Minimum stake to create proposals (must be > 0)
     function initialize(
         uint256 _minimumStake,
         uint64 _lockupDurationMicros,
@@ -68,106 +88,120 @@ contract StakingConfig {
         uint256 _minimumProposalStake
     ) external {
         requireAllowed(SystemAddresses.GENESIS);
-
-        if (_initialized) {
-            revert Errors.AlreadyInitialized();
-        }
-
-        if (_lockupDurationMicros == 0) {
-            revert Errors.InvalidLockupDuration();
-        }
-        if (_lockupDurationMicros > MAX_LOCKUP_DURATION) {
-            revert Errors.ExcessiveDuration(_lockupDurationMicros, MAX_LOCKUP_DURATION);
-        }
-
-        if (_unbondingDelayMicros == 0) {
-            revert Errors.InvalidUnbondingDelay();
-        }
-        if (_unbondingDelayMicros > MAX_UNBONDING_DELAY) {
-            revert Errors.ExcessiveDuration(_unbondingDelayMicros, MAX_UNBONDING_DELAY);
-        }
+        if (_initialized) revert Errors.AlreadyInitialized();
+        _validateConfig(_minimumStake, _lockupDurationMicros, _unbondingDelayMicros, _minimumProposalStake);
 
         minimumStake = _minimumStake;
         lockupDurationMicros = _lockupDurationMicros;
         unbondingDelayMicros = _unbondingDelayMicros;
         minimumProposalStake = _minimumProposalStake;
-
         _initialized = true;
+
+        emit StakingConfigUpdated();
     }
 
     // ========================================================================
-    // GOVERNANCE SETTERS (GOVERNANCE only)
+    // VIEW FUNCTIONS
     // ========================================================================
 
-    /// @notice Update minimum stake
-    /// @dev Only callable by GOVERNANCE
-    /// @param _minimumStake New minimum stake value
-    function setMinimumStake(
-        uint256 _minimumStake
-    ) external {
-        requireAllowed(SystemAddresses.GOVERNANCE);
-
-        uint256 oldValue = minimumStake;
-        minimumStake = _minimumStake;
-
-        emit ConfigUpdated("minimumStake", oldValue, _minimumStake);
+    /// @notice Get pending configuration if any
+    /// @return hasPending Whether a pending config exists
+    /// @return config The pending configuration (only valid if hasPending is true)
+    function getPendingConfig() external view returns (bool hasPending, PendingConfig memory config) {
+        _requireInitialized();
+        return (hasPendingConfig, _pendingConfig);
     }
 
-    /// @notice Update lockup duration
-    /// @dev Only callable by GOVERNANCE
-    /// @param _lockupDurationMicros New lockup duration in microseconds (must be > 0)
-    function setLockupDurationMicros(
-        uint64 _lockupDurationMicros
-    ) external {
-        requireAllowed(SystemAddresses.GOVERNANCE);
-
-        if (_lockupDurationMicros == 0) {
-            revert Errors.InvalidLockupDuration();
-        }
-        if (_lockupDurationMicros > MAX_LOCKUP_DURATION) {
-            revert Errors.ExcessiveDuration(_lockupDurationMicros, MAX_LOCKUP_DURATION);
-        }
-
-        uint256 oldValue = lockupDurationMicros;
-        lockupDurationMicros = _lockupDurationMicros;
-
-        emit ConfigUpdated("lockupDurationMicros", oldValue, _lockupDurationMicros);
+    /// @notice Check if the contract has been initialized
+    /// @return True if initialized
+    function isInitialized() external view returns (bool) {
+        return _initialized;
     }
 
-    /// @notice Update unbonding delay
-    /// @dev Only callable by GOVERNANCE
-    /// @param _unbondingDelayMicros New unbonding delay in microseconds (must be > 0)
-    function setUnbondingDelayMicros(
-        uint64 _unbondingDelayMicros
-    ) external {
-        requireAllowed(SystemAddresses.GOVERNANCE);
+    // ========================================================================
+    // GOVERNANCE FUNCTIONS (GOVERNANCE only)
+    // ========================================================================
 
-        if (_unbondingDelayMicros == 0) {
-            revert Errors.InvalidUnbondingDelay();
-        }
-        if (_unbondingDelayMicros > MAX_UNBONDING_DELAY) {
-            revert Errors.ExcessiveDuration(_unbondingDelayMicros, MAX_UNBONDING_DELAY);
-        }
-
-        uint256 oldValue = unbondingDelayMicros;
-        unbondingDelayMicros = _unbondingDelayMicros;
-
-        emit ConfigUpdated("unbondingDelayMicros", oldValue, _unbondingDelayMicros);
-    }
-
-    /// @notice Update minimum proposal stake
-    /// @dev Only callable by GOVERNANCE
-    /// @param _minimumProposalStake New minimum proposal stake value
-    function setMinimumProposalStake(
+    /// @notice Set configuration for next epoch
+    /// @dev Only callable by GOVERNANCE. Config will be applied at epoch boundary.
+    /// @param _minimumStake Minimum stake for governance participation (must be > 0)
+    /// @param _lockupDurationMicros Lockup duration in microseconds (must be > 0)
+    /// @param _unbondingDelayMicros Unbonding delay in microseconds (must be > 0)
+    /// @param _minimumProposalStake Minimum stake to create proposals (must be > 0)
+    function setForNextEpoch(
+        uint256 _minimumStake,
+        uint64 _lockupDurationMicros,
+        uint64 _unbondingDelayMicros,
         uint256 _minimumProposalStake
     ) external {
-        // TODO(yxia): should be moved to GovernanceConfig.
         requireAllowed(SystemAddresses.GOVERNANCE);
+        _requireInitialized();
+        _validateConfig(_minimumStake, _lockupDurationMicros, _unbondingDelayMicros, _minimumProposalStake);
 
-        uint256 oldValue = minimumProposalStake;
-        minimumProposalStake = _minimumProposalStake;
+        _pendingConfig = PendingConfig({
+            minimumStake: _minimumStake,
+            lockupDurationMicros: _lockupDurationMicros,
+            unbondingDelayMicros: _unbondingDelayMicros,
+            minimumProposalStake: _minimumProposalStake
+        });
+        hasPendingConfig = true;
+        emit PendingStakingConfigSet();
+    }
 
-        emit ConfigUpdated("minimumProposalStake", oldValue, _minimumProposalStake);
+    // ========================================================================
+    // EPOCH TRANSITION (RECONFIGURATION only)
+    // ========================================================================
+
+    /// @notice Apply pending configuration at epoch boundary
+    /// @dev Only callable by RECONFIGURATION during epoch transition.
+    ///      If no pending config exists, this is a no-op.
+    function applyPendingConfig() external {
+        requireAllowed(SystemAddresses.RECONFIGURATION);
+        _requireInitialized();
+        if (!hasPendingConfig) return;
+
+        minimumStake = _pendingConfig.minimumStake;
+        lockupDurationMicros = _pendingConfig.lockupDurationMicros;
+        unbondingDelayMicros = _pendingConfig.unbondingDelayMicros;
+        minimumProposalStake = _pendingConfig.minimumProposalStake;
+        hasPendingConfig = false;
+
+        // Clear pending config storage
+        delete _pendingConfig;
+
+        emit StakingConfigUpdated();
+        emit PendingStakingConfigCleared();
+    }
+
+    // ========================================================================
+    // INTERNAL FUNCTIONS
+    // ========================================================================
+
+    /// @notice Validate configuration parameters
+    /// @param _minimumStake Minimum stake
+    /// @param _lockupDurationMicros Lockup duration
+    /// @param _unbondingDelayMicros Unbonding delay
+    /// @param _minimumProposalStake Minimum proposal stake
+    function _validateConfig(
+        uint256 _minimumStake,
+        uint64 _lockupDurationMicros,
+        uint64 _unbondingDelayMicros,
+        uint256 _minimumProposalStake
+    ) internal pure {
+        if (_minimumStake == 0) revert Errors.InvalidMinimumStake();
+        if (_lockupDurationMicros == 0) revert Errors.InvalidLockupDuration();
+        if (_lockupDurationMicros > MAX_LOCKUP_DURATION) {
+            revert Errors.ExcessiveDuration(_lockupDurationMicros, MAX_LOCKUP_DURATION);
+        }
+        if (_unbondingDelayMicros == 0) revert Errors.InvalidUnbondingDelay();
+        if (_unbondingDelayMicros > MAX_UNBONDING_DELAY) {
+            revert Errors.ExcessiveDuration(_unbondingDelayMicros, MAX_UNBONDING_DELAY);
+        }
+        if (_minimumProposalStake == 0) revert Errors.InvalidMinimumProposalStake();
+    }
+
+    /// @notice Require the contract to be initialized
+    function _requireInitialized() internal view {
+        if (!_initialized) revert Errors.StakingConfigNotInitialized();
     }
 }
-

--- a/test/unit/blocker/Blocker.t.sol
+++ b/test/unit/blocker/Blocker.t.sol
@@ -13,6 +13,7 @@ import { ExecutionConfig } from "../../../src/runtime/ExecutionConfig.sol";
 import { ValidatorConfig } from "../../../src/runtime/ValidatorConfig.sol";
 import { VersionConfig } from "../../../src/runtime/VersionConfig.sol";
 import { GovernanceConfig } from "../../../src/runtime/GovernanceConfig.sol";
+import { StakingConfig } from "../../../src/runtime/StakingConfig.sol";
 import { SystemAddresses } from "../../../src/foundation/SystemAddresses.sol";
 import { Errors } from "../../../src/foundation/Errors.sol";
 import { ValidatorConsensusInfo } from "../../../src/foundation/Types.sol";
@@ -137,6 +138,7 @@ contract BlockerTest is Test {
         vm.etch(SystemAddresses.VALIDATOR_CONFIG, address(new ValidatorConfig()).code);
         vm.etch(SystemAddresses.VERSION_CONFIG, address(new VersionConfig()).code);
         vm.etch(SystemAddresses.GOVERNANCE_CONFIG, address(new GovernanceConfig()).code);
+        vm.etch(SystemAddresses.STAKE_CONFIG, address(new StakingConfig()).code);
 
         // Initialize ConsensusConfig
         vm.prank(SystemAddresses.GENESIS);
@@ -171,6 +173,16 @@ contract BlockerTest is Test {
                 1000 ether, // minVotingThreshold
                 100 ether, // requiredProposerStake
                 7 days * 1_000_000 // votingDurationMicros
+            );
+
+        // Initialize StakingConfig
+        vm.prank(SystemAddresses.GENESIS);
+        StakingConfig(SystemAddresses.STAKE_CONFIG)
+            .initialize(
+                1 ether, // minimumStake
+                30 days * 1_000_000, // lockupDurationMicros
+                7 days * 1_000_000, // unbondingDelayMicros
+                10 ether // minimumProposalStake
             );
 
         // Setup mock validators

--- a/test/unit/blocker/Reconfiguration.t.sol
+++ b/test/unit/blocker/Reconfiguration.t.sol
@@ -13,6 +13,7 @@ import { ExecutionConfig } from "../../../src/runtime/ExecutionConfig.sol";
 import { ValidatorConfig } from "../../../src/runtime/ValidatorConfig.sol";
 import { VersionConfig } from "../../../src/runtime/VersionConfig.sol";
 import { GovernanceConfig } from "../../../src/runtime/GovernanceConfig.sol";
+import { StakingConfig } from "../../../src/runtime/StakingConfig.sol";
 import { SystemAddresses } from "../../../src/foundation/SystemAddresses.sol";
 import { Errors } from "../../../src/foundation/Errors.sol";
 import { ValidatorConsensusInfo } from "../../../src/foundation/Types.sol";
@@ -154,6 +155,7 @@ contract ReconfigurationTest is Test {
         vm.etch(SystemAddresses.VALIDATOR_CONFIG, address(new ValidatorConfig()).code);
         vm.etch(SystemAddresses.VERSION_CONFIG, address(new VersionConfig()).code);
         vm.etch(SystemAddresses.GOVERNANCE_CONFIG, address(new GovernanceConfig()).code);
+        vm.etch(SystemAddresses.STAKE_CONFIG, address(new StakingConfig()).code);
 
         // Initialize ConsensusConfig
         vm.prank(SystemAddresses.GENESIS);
@@ -188,6 +190,16 @@ contract ReconfigurationTest is Test {
                 1000 ether, // minVotingThreshold
                 100 ether, // requiredProposerStake
                 7 days * 1_000_000 // votingDurationMicros
+            );
+
+        // Initialize StakingConfig
+        vm.prank(SystemAddresses.GENESIS);
+        StakingConfig(SystemAddresses.STAKE_CONFIG)
+            .initialize(
+                1 ether, // minimumStake
+                30 days * 1_000_000, // lockupDurationMicros
+                7 days * 1_000_000, // unbondingDelayMicros
+                10 ether // minimumProposalStake
             );
 
         // Setup mock validators


### PR DESCRIPTION
Replace 4 immediate-apply governance setters (setMinimumStake, setLockupDurationMicros, setUnbondingDelayMicros, setMinimumProposalStake) with setForNextEpoch() and applyPendingConfig(), mirroring the epoch- boundary pending config pattern used by GovernanceConfig, ValidatorConfig, and other config contracts.

Changes are now queued via governance and applied atomically by Reconfiguration during epoch transitions, preventing mid-epoch parameter changes that could cause inconsistent staking behavior.

Add PendingConfig struct, getPendingConfig() view function, and StakingConfigUpdated/PendingStakingConfigSet/PendingStakingConfigCleared events. Add _validateConfig() shared validation for both initialize() and setForNextEpoch().

## Description

<!--
  Add a detailed description for the changes made in this pull request

  If your PR addresses an existing issue, add it here.
  Use the template string - `This pull request resolves #<issue-number>`
-->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->
- [ ] 📚 Documentation    (Non-breaking change; Changes in the documentation)
- [ ] 🔧 Bug fix          (Non-breaking change; Fixes an existing bug)
- [ ] 🥂 Improvement      (Non-breaking change; Improves existing feature)
- [ ] 🚀 New feature      (Non-breaking change; Adds functionality)
- [ ] 🔐 Security fix     (Non-breaking change; Patches a security issue)
- [ ] 💥 Breaking change  (Breaks existing functionality)

<!--
    Leave this section as-is, no changes are to be made below this point!
-->