### PR TITLE
fix(genesis-tool): add missing trustedSourceId to BridgeConfig ABI

### DIFF
--- a/genesis-tool/src/execute.rs
+++ b/genesis-tool/src/execute.rs
@@ -44,10 +44,14 @@ fn deploy_bsc_style(byte_code_dir: &str, total_stake: U256) -> InMemoryDB {
             U256::ZERO
         };
 
+        let bytecode = Bytecode::new_raw(Bytes::from(runtime_bytecode));
+        let code_hash = bytecode.hash_slow();
+
         db.insert_account_info(
             target_address,
             AccountInfo {
-                code: Some(Bytecode::new_raw(Bytes::from(runtime_bytecode))),
+                code: Some(bytecode),
+                code_hash,
                 balance,
                 ..AccountInfo::default()
             },

--- a/genesis-tool/src/genesis.rs
+++ b/genesis-tool/src/genesis.rs
@@ -192,6 +192,9 @@ pub struct BridgeConfig {
 
     #[serde(rename = "trustedBridge")]
     pub trusted_bridge: String, // address
+
+    #[serde(rename = "trustedSourceId", default)]
+    pub trusted_source_id: String, // uint256
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
@@ -285,6 +288,7 @@ sol! {
     struct SolBridgeConfig {
         bool deploy;
         address trustedBridge;
+        uint256 trustedSourceId;
     }
 
     struct SolOracleInitParams {
@@ -464,6 +468,11 @@ pub fn convert_config_to_sol(config: &GenesisConfig) -> SolGenesisInitParams {
                 Address::ZERO
             } else {
                 parse_address(&config.oracle_config.bridge_config.trusted_bridge)
+            },
+            trustedSourceId: if config.oracle_config.bridge_config.trusted_source_id.is_empty() {
+                U256::ZERO
+            } else {
+                parse_u256(&config.oracle_config.bridge_config.trusted_source_id)
             },
         },
     };


### PR DESCRIPTION
The Solidity BridgeConfig struct added a `trustedSourceId` field but the Rust ABI definition was not updated, causing ABI encoding mismatch and Genesis.initialize to revert at 130,850 gas.
Changes:
- Add trustedSourceId to SolBridgeConfig ABI and BridgeConfig serde struct
- Compute proper code_hash via hash_slow() in deploy_bsc_style to fix extcodesize returning 0 for pre-deployed contracts
- Update aggregate_genesis.py to pass through trustedSourceId
- Add trusted_source_id to genesis.toml and validator_genesis.json
