### PR TITLE
feat(bridge): add NativeMintWrapper to decouple mint precompile authorization

### DIFF
--- a/genesis-tool/src/utils.rs
+++ b/genesis-tool/src/utils.rs
@@ -98,6 +98,10 @@ pub const JWK_MANAGER_ADDR: Address = address!("00000000000000000000000000000001
 /// Oracle request queue contract
 pub const ORACLE_REQUEST_QUEUE_ADDR: Address = address!("00000000000000000000000000000001625F4002");
 
+/// Native mint wrapper contract
+/// Wraps native mint precompile with access control for multiple callers
+pub const NATIVE_MINT_WRAPPER_ADDR: Address = address!("00000000000000000000000000000001625F4003");
+
 // Precompiles (0x1625F5xxx)
 /// Native mint precompile
 pub const NATIVE_MINT_PRECOMPILE_ADDR: Address = address!("00000000000000000000000000000001625F5000");
@@ -107,7 +111,7 @@ pub const NATIVE_MINT_PRECOMPILE_ADDR: Address = address!("000000000000000000000
 // Note: StakePool is created dynamically during Genesis.initialize, not pre-deployed
 // ============================================================================
 
-pub const CONTRACTS: [(&str, Address); 21] = [
+pub const CONTRACTS: [(&str, Address); 22] = [
     ("Genesis", GENESIS_ADDR),
     ("Reconfiguration", RECONFIGURATION_ADDR),
     ("StakingConfig", STAKE_CONFIG_ADDR),
@@ -129,6 +133,7 @@ pub const CONTRACTS: [(&str, Address); 21] = [
     ("ExecutionConfig", EXECUTION_CONFIG_ADDR),
     ("OracleTaskConfig", ORACLE_TASK_CONFIG_ADDR),
     ("OnDemandOracleTaskConfig", ON_DEMAND_ORACLE_TASK_CONFIG_ADDR),
+    ("NativeMintWrapper", NATIVE_MINT_WRAPPER_ADDR),
 ];
 
 pub const SYSTEM_ACCOUNT_INFO: AccountInfo = AccountInfo {

--- a/src/Genesis.sol
+++ b/src/Genesis.sol
@@ -26,6 +26,7 @@ import { NativeOracle } from "./oracle/NativeOracle.sol";
 import { JWKManager, IJWKManager } from "./oracle/jwk/JWKManager.sol";
 import { OracleTaskConfig } from "./oracle/OracleTaskConfig.sol";
 import { GBridgeReceiver } from "./oracle/evm/native_token_bridge/GBridgeReceiver.sol";
+import { NativeMintWrapper } from "./oracle/evm/native_token_bridge/NativeMintWrapper.sol";
 
 /// @title Genesis
 /// @author Gravity Team
@@ -243,6 +244,13 @@ contract Genesis {
 
             sourceTypes[length] = 0; // Blockchain Events
             callbacks[length] = address(receiver);
+
+            // Initialize NativeMintWrapper with SYSTEM_CALLER as owner
+            // and the newly deployed GBridgeReceiver as initial minter
+            address[] memory initialMinters = new address[](1);
+            initialMinters[0] = address(receiver);
+            NativeMintWrapper(SystemAddresses.NATIVE_MINT_WRAPPER)
+                .initialize(SystemAddresses.SYSTEM_CALLER, initialMinters);
         } else {
             sourceTypes = oracleConfig.sourceTypes;
             callbacks = oracleConfig.callbacks;

--- a/src/foundation/SystemAddresses.sol
+++ b/src/foundation/SystemAddresses.sol
@@ -118,6 +118,11 @@ library SystemAddresses {
     /// @dev Accepts user-initiated on-demand oracle requests with fee payment
     address internal constant ORACLE_REQUEST_QUEUE = address(0x0000000000000000000000000001625F4002);
 
+    /// @notice Native mint wrapper contract
+    /// @dev Wraps native mint precompile with access control for multiple callers.
+    ///      Only authorized minters (e.g., bridge receivers) can mint through this wrapper.
+    address internal constant NATIVE_MINT_WRAPPER = address(0x0000000000000000000000000001625F4003);
+
     // ==================== Precompiles (0x1625F5xxx) ====================
 
     /// @notice Native mint precompile

--- a/src/oracle/evm/native_token_bridge/GBridgeReceiver.sol
+++ b/src/oracle/evm/native_token_bridge/GBridgeReceiver.sol
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.30;
 
-import { IGBridgeReceiver, INativeMintPrecompile } from "./IGBridgeReceiver.sol";
+import { IGBridgeReceiver } from "./IGBridgeReceiver.sol";
+import { INativeMintWrapper } from "./INativeMintWrapper.sol";
 import { BlockchainEventHandler } from "../BlockchainEventHandler.sol";
 import { SystemAddresses } from "@src/foundation/SystemAddresses.sol";
 import { Errors } from "@src/foundation/Errors.sol";
@@ -95,12 +96,8 @@ contract GBridgeReceiver is IGBridgeReceiver, BlockchainEventHandler {
         // Mark nonce as processed BEFORE minting (CEI pattern)
         _processedNonces[messageNonce] = true;
 
-        // Mint native tokens via precompile (precompile never reverts)
-        bytes memory callData = abi.encodePacked(uint8(0x01), recipient, amount);
-        (bool transferSuccess,) = SystemAddresses.NATIVE_MINT_PRECOMPILE.call(callData);
-        if (!transferSuccess) {
-            revert MintFailed(recipient, amount);
-        }
+        // Mint native tokens via wrapper (wrapper calls precompile)
+        INativeMintWrapper(SystemAddresses.NATIVE_MINT_WRAPPER).mint(recipient, amount);
 
         emit NativeMinted(recipient, amount, messageNonce);
 

--- a/src/oracle/evm/native_token_bridge/IGBridgeReceiver.sol
+++ b/src/oracle/evm/native_token_bridge/IGBridgeReceiver.sol
@@ -6,7 +6,7 @@ pragma solidity ^0.8.30;
 /// @notice Interface for the GBridgeReceiver contract on Gravity
 /// @dev Mints native G tokens when bridge messages are received from GBridgeSender.
 ///      Inherits from BlockchainEventHandler to receive routed messages from NativeOracle.
-///      Uses a system precompile to mint native tokens.
+///      Uses NativeMintWrapper to mint native tokens via the system precompile.
 interface IGBridgeReceiver {
     // ========================================================================
     // EVENTS
@@ -31,11 +31,6 @@ interface IGBridgeReceiver {
     /// @param nonce The duplicate nonce
     error AlreadyProcessed(uint128 nonce);
 
-    /// @notice Native token mint via precompile failed
-    /// @param recipient The intended recipient
-    /// @param amount The amount that failed to mint
-    error MintFailed(address recipient, uint256 amount);
-
     /// @notice Source chain ID does not match trusted source
     /// @param provided The provided source chain ID
     /// @param expected The expected trusted source chain ID
@@ -59,19 +54,5 @@ interface IGBridgeReceiver {
     /// @notice Get the trusted source chain ID
     /// @return The trusted source chain ID
     function trustedSourceId() external view returns (uint256);
-}
-
-/// @title INativeMintPrecompile
-/// @author Gravity Team
-/// @notice Interface for the system precompile that mints native tokens
-/// @dev This is a privileged precompile that only authorized contracts can call
-interface INativeMintPrecompile {
-    /// @notice Mint native tokens to a recipient
-    /// @param recipient The address to receive the tokens
-    /// @param amount The amount to mint (in wei)
-    function mint(
-        address recipient,
-        uint256 amount
-    ) external;
 }
 

--- a/src/oracle/evm/native_token_bridge/INativeMintWrapper.sol
+++ b/src/oracle/evm/native_token_bridge/INativeMintWrapper.sol
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+/// @title INativeMintWrapper
+/// @author Gravity Team
+/// @notice Interface for the NativeMintWrapper contract
+/// @dev Wraps the native mint precompile with multi-caller access control.
+///      Only authorized minters can call mint(). The owner manages the minter list.
+interface INativeMintWrapper {
+    // ========================================================================
+    // EVENTS
+    // ========================================================================
+
+    /// @notice Emitted when a new minter is authorized
+    /// @param minter The address that was granted minting rights
+    event MinterAdded(address indexed minter);
+
+    /// @notice Emitted when a minter's authorization is revoked
+    /// @param minter The address that lost minting rights
+    event MinterRemoved(address indexed minter);
+
+    // ========================================================================
+    // ERRORS
+    // ========================================================================
+
+    /// @notice Caller is not an authorized minter
+    /// @param caller The unauthorized caller address
+    error UnauthorizedMinter(address caller);
+
+    /// @notice Caller is not the owner
+    /// @param caller The unauthorized caller address
+    error OnlyOwner(address caller);
+
+    /// @notice Native token mint via precompile failed
+    /// @param recipient The intended recipient
+    /// @param amount The amount that failed to mint
+    error MintFailed(address recipient, uint256 amount);
+
+    // ========================================================================
+    // MINTER MANAGEMENT
+    // ========================================================================
+
+    /// @notice Add an authorized minter
+    /// @dev Only callable by the owner
+    /// @param minter The address to authorize
+    function addMinter(address minter) external;
+
+    /// @notice Remove an authorized minter
+    /// @dev Only callable by the owner
+    /// @param minter The address to deauthorize
+    function removeMinter(address minter) external;
+
+    // ========================================================================
+    // MINT
+    // ========================================================================
+
+    /// @notice Mint native tokens to a recipient
+    /// @dev Only callable by authorized minters
+    /// @param recipient The address to receive the tokens
+    /// @param amount The amount to mint (in wei)
+    function mint(address recipient, uint256 amount) external;
+
+    // ========================================================================
+    // VIEW FUNCTIONS
+    // ========================================================================
+
+    /// @notice Check if an address is an authorized minter
+    /// @param account The address to check
+    /// @return True if the address is an authorized minter
+    function isMinter(address account) external view returns (bool);
+
+    /// @notice Get the owner address
+    /// @return The owner address
+    function owner() external view returns (address);
+}

--- a/src/oracle/evm/native_token_bridge/INativeMintWrapper.sol
+++ b/src/oracle/evm/native_token_bridge/INativeMintWrapper.sol
@@ -43,12 +43,16 @@ interface INativeMintWrapper {
     /// @notice Add an authorized minter
     /// @dev Only callable by the owner
     /// @param minter The address to authorize
-    function addMinter(address minter) external;
+    function addMinter(
+        address minter
+    ) external;
 
     /// @notice Remove an authorized minter
     /// @dev Only callable by the owner
     /// @param minter The address to deauthorize
-    function removeMinter(address minter) external;
+    function removeMinter(
+        address minter
+    ) external;
 
     // ========================================================================
     // MINT
@@ -58,7 +62,10 @@ interface INativeMintWrapper {
     /// @dev Only callable by authorized minters
     /// @param recipient The address to receive the tokens
     /// @param amount The amount to mint (in wei)
-    function mint(address recipient, uint256 amount) external;
+    function mint(
+        address recipient,
+        uint256 amount
+    ) external;
 
     // ========================================================================
     // VIEW FUNCTIONS
@@ -67,7 +74,9 @@ interface INativeMintWrapper {
     /// @notice Check if an address is an authorized minter
     /// @param account The address to check
     /// @return True if the address is an authorized minter
-    function isMinter(address account) external view returns (bool);
+    function isMinter(
+        address account
+    ) external view returns (bool);
 
     /// @notice Get the owner address
     /// @return The owner address

--- a/src/oracle/evm/native_token_bridge/NativeMintWrapper.sol
+++ b/src/oracle/evm/native_token_bridge/NativeMintWrapper.sol
@@ -55,7 +55,10 @@ contract NativeMintWrapper is INativeMintWrapper {
     ///      bytecode injection (BSC-style), not via CREATE.
     /// @param owner_ The owner address (manages minter list)
     /// @param initialMinters The initial set of authorized minters
-    function initialize(address owner_, address[] calldata initialMinters) external {
+    function initialize(
+        address owner_,
+        address[] calldata initialMinters
+    ) external {
         requireAllowed(SystemAddresses.GENESIS);
         if (_initialized) revert Errors.AlreadyInitialized();
         if (owner_ == address(0)) revert Errors.ZeroAddress();
@@ -75,14 +78,18 @@ contract NativeMintWrapper is INativeMintWrapper {
     // ========================================================================
 
     /// @inheritdoc INativeMintWrapper
-    function addMinter(address minter) external onlyOwner {
+    function addMinter(
+        address minter
+    ) external onlyOwner {
         if (minter == address(0)) revert Errors.ZeroAddress();
         _minters[minter] = true;
         emit MinterAdded(minter);
     }
 
     /// @inheritdoc INativeMintWrapper
-    function removeMinter(address minter) external onlyOwner {
+    function removeMinter(
+        address minter
+    ) external onlyOwner {
         _minters[minter] = false;
         emit MinterRemoved(minter);
     }
@@ -92,7 +99,10 @@ contract NativeMintWrapper is INativeMintWrapper {
     // ========================================================================
 
     /// @inheritdoc INativeMintWrapper
-    function mint(address recipient, uint256 amount) external onlyMinter {
+    function mint(
+        address recipient,
+        uint256 amount
+    ) external onlyMinter {
         if (recipient == address(0)) revert Errors.ZeroAddress();
         if (amount == 0) revert Errors.ZeroAmount();
 
@@ -108,7 +118,9 @@ contract NativeMintWrapper is INativeMintWrapper {
     // ========================================================================
 
     /// @inheritdoc INativeMintWrapper
-    function isMinter(address account) external view returns (bool) {
+    function isMinter(
+        address account
+    ) external view returns (bool) {
         return _minters[account];
     }
 

--- a/src/oracle/evm/native_token_bridge/NativeMintWrapper.sol
+++ b/src/oracle/evm/native_token_bridge/NativeMintWrapper.sol
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import { INativeMintWrapper } from "./INativeMintWrapper.sol";
+import { SystemAddresses } from "@src/foundation/SystemAddresses.sol";
+import { Errors } from "@src/foundation/Errors.sol";
+import { requireAllowed } from "@src/foundation/SystemAccessControl.sol";
+
+/// @title NativeMintWrapper
+/// @author Gravity Team
+/// @notice Wraps the native mint precompile with multi-caller access control
+/// @dev Deployed at a fixed system address (0x1625F4003). Only authorized minters
+///      can call mint(). The Genesis contract initializes owner and initial minters.
+///      This contract is the sole AUTHORIZED_CALLER in reth's mint precompile,
+///      allowing multiple contracts (e.g., bridge receivers) to mint through it.
+contract NativeMintWrapper is INativeMintWrapper {
+    // ========================================================================
+    // STATE
+    // ========================================================================
+
+    /// @notice Owner who can manage the minter list
+    address private _owner;
+
+    /// @notice Authorized minters
+    mapping(address => bool) private _minters;
+
+    /// @notice Whether the contract has been initialized
+    bool private _initialized;
+
+    // ========================================================================
+    // MODIFIERS
+    // ========================================================================
+
+    modifier onlyOwner() {
+        if (msg.sender != _owner) {
+            revert OnlyOwner(msg.sender);
+        }
+        _;
+    }
+
+    modifier onlyMinter() {
+        if (!_minters[msg.sender]) {
+            revert UnauthorizedMinter(msg.sender);
+        }
+        _;
+    }
+
+    // ========================================================================
+    // INITIALIZATION
+    // ========================================================================
+
+    /// @notice Initialize the wrapper with owner and initial minters
+    /// @dev Called by Genesis during chain initialization. Can only be called once.
+    ///      Constructor is not used because system contracts are deployed via
+    ///      bytecode injection (BSC-style), not via CREATE.
+    /// @param owner_ The owner address (manages minter list)
+    /// @param initialMinters The initial set of authorized minters
+    function initialize(address owner_, address[] calldata initialMinters) external {
+        requireAllowed(SystemAddresses.GENESIS);
+        if (_initialized) revert Errors.AlreadyInitialized();
+        if (owner_ == address(0)) revert Errors.ZeroAddress();
+
+        _owner = owner_;
+        _initialized = true;
+
+        for (uint256 i = 0; i < initialMinters.length; i++) {
+            if (initialMinters[i] == address(0)) revert Errors.ZeroAddress();
+            _minters[initialMinters[i]] = true;
+            emit MinterAdded(initialMinters[i]);
+        }
+    }
+
+    // ========================================================================
+    // MINTER MANAGEMENT
+    // ========================================================================
+
+    /// @inheritdoc INativeMintWrapper
+    function addMinter(address minter) external onlyOwner {
+        if (minter == address(0)) revert Errors.ZeroAddress();
+        _minters[minter] = true;
+        emit MinterAdded(minter);
+    }
+
+    /// @inheritdoc INativeMintWrapper
+    function removeMinter(address minter) external onlyOwner {
+        _minters[minter] = false;
+        emit MinterRemoved(minter);
+    }
+
+    // ========================================================================
+    // MINT
+    // ========================================================================
+
+    /// @inheritdoc INativeMintWrapper
+    function mint(address recipient, uint256 amount) external onlyMinter {
+        if (recipient == address(0)) revert Errors.ZeroAddress();
+        if (amount == 0) revert Errors.ZeroAmount();
+
+        bytes memory callData = abi.encodePacked(uint8(0x01), recipient, amount);
+        (bool success,) = SystemAddresses.NATIVE_MINT_PRECOMPILE.call(callData);
+        if (!success) {
+            revert MintFailed(recipient, amount);
+        }
+    }
+
+    // ========================================================================
+    // VIEW FUNCTIONS
+    // ========================================================================
+
+    /// @inheritdoc INativeMintWrapper
+    function isMinter(address account) external view returns (bool) {
+        return _minters[account];
+    }
+
+    /// @inheritdoc INativeMintWrapper
+    function owner() external view returns (address) {
+        return _owner;
+    }
+}

--- a/test/unit/oracle/GBridgeReceiver.t.sol
+++ b/test/unit/oracle/GBridgeReceiver.t.sol
@@ -3,32 +3,16 @@ pragma solidity ^0.8.30;
 
 import { Test } from "forge-std/Test.sol";
 import { GBridgeReceiver } from "@src/oracle/evm/native_token_bridge/GBridgeReceiver.sol";
-import { IGBridgeReceiver, INativeMintPrecompile } from "@src/oracle/evm/native_token_bridge/IGBridgeReceiver.sol";
+import { IGBridgeReceiver } from "@src/oracle/evm/native_token_bridge/IGBridgeReceiver.sol";
 import { PortalMessage } from "@src/oracle/evm/PortalMessage.sol";
 import { SystemAddresses } from "@src/foundation/SystemAddresses.sol";
 import { NotAllowed } from "@src/foundation/SystemAccessControl.sol";
 import { Errors } from "@src/foundation/Errors.sol";
 
-/// @title MockNativeMintPrecompile
-/// @notice Mock precompile for testing native token minting
-contract MockNativeMintPrecompile is INativeMintPrecompile {
-    mapping(address => uint256) public balances;
-    uint256 public totalMinted;
-
-    function mint(
-        address recipient,
-        uint256 amount
-    ) external override {
-        balances[recipient] += amount;
-        totalMinted += amount;
-    }
-}
-
 /// @title GBridgeReceiverTest
 /// @notice Unit tests for GBridgeReceiver contract
 contract GBridgeReceiverTest is Test {
     GBridgeReceiver public receiver;
-    MockNativeMintPrecompile public mockPrecompile;
 
     address public nativeOracle;
     address public trustedBridge;
@@ -44,13 +28,12 @@ contract GBridgeReceiverTest is Test {
         alice = makeAddr("alice");
         bob = makeAddr("bob");
 
-        // Mock the precompile call to always succeed
-        // GBridgeReceiver uses low-level call:
-        // NATIVE_MINT_PRECOMPILE.call(abi.encodePacked(uint8(0x01), recipient, amount))
-        // We mock any call to this address to return (true, "")
+        // Mock the NativeMintWrapper.mint() call to always succeed
+        // GBridgeReceiver now calls:
+        // INativeMintWrapper(SystemAddresses.NATIVE_MINT_WRAPPER).mint(recipient, amount)
         bytes memory emptyData = "";
         bytes memory successReturn = "";
-        vm.mockCall(SystemAddresses.NATIVE_MINT_PRECOMPILE, emptyData, successReturn);
+        vm.mockCall(SystemAddresses.NATIVE_MINT_WRAPPER, emptyData, successReturn);
 
         // Deploy receiver with trusted bridge
         receiver = new GBridgeReceiver(trustedBridge, ETHEREUM_SOURCE_ID);

--- a/test/unit/oracle/NativeMintWrapper.t.sol
+++ b/test/unit/oracle/NativeMintWrapper.t.sol
@@ -1,0 +1,222 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import { Test } from "forge-std/Test.sol";
+import { NativeMintWrapper } from "@src/oracle/evm/native_token_bridge/NativeMintWrapper.sol";
+import { INativeMintWrapper } from "@src/oracle/evm/native_token_bridge/INativeMintWrapper.sol";
+import { SystemAddresses } from "@src/foundation/SystemAddresses.sol";
+import { NotAllowed } from "@src/foundation/SystemAccessControl.sol";
+import { Errors } from "@src/foundation/Errors.sol";
+
+/// @title NativeMintWrapperTest
+/// @notice Unit tests for NativeMintWrapper contract
+contract NativeMintWrapperTest is Test {
+    NativeMintWrapper public wrapper;
+
+    address public owner;
+    address public minterA;
+    address public minterB;
+    address public alice;
+
+    function setUp() public {
+        owner = makeAddr("owner");
+        minterA = makeAddr("minterA");
+        minterB = makeAddr("minterB");
+        alice = makeAddr("alice");
+
+        // Deploy wrapper (simulates bytecode injection)
+        wrapper = new NativeMintWrapper();
+
+        // Mock the precompile call to always succeed
+        bytes memory emptyData = "";
+        bytes memory successReturn = "";
+        vm.mockCall(SystemAddresses.NATIVE_MINT_PRECOMPILE, emptyData, successReturn);
+
+        // Initialize as Genesis (matching system contract pattern)
+        address[] memory initialMinters = new address[](1);
+        initialMinters[0] = minterA;
+
+        vm.prank(SystemAddresses.GENESIS);
+        wrapper.initialize(owner, initialMinters);
+    }
+
+    // ========================================================================
+    // INITIALIZATION TESTS
+    // ========================================================================
+
+    function test_Initialize() public view {
+        assertEq(wrapper.owner(), owner);
+        assertTrue(wrapper.isMinter(minterA));
+    }
+
+    function test_Initialize_RevertWhenNotGenesis() public {
+        NativeMintWrapper wrapper2 = new NativeMintWrapper();
+        address[] memory minters = new address[](0);
+
+        vm.prank(alice);
+        vm.expectRevert(abi.encodeWithSelector(NotAllowed.selector, alice, SystemAddresses.GENESIS));
+        wrapper2.initialize(owner, minters);
+    }
+
+    function test_Initialize_RevertWhenAlreadyInitialized() public {
+        address[] memory minters = new address[](0);
+
+        vm.prank(SystemAddresses.GENESIS);
+        vm.expectRevert(Errors.AlreadyInitialized.selector);
+        wrapper.initialize(owner, minters);
+    }
+
+    function test_Initialize_RevertWhenZeroOwner() public {
+        NativeMintWrapper wrapper2 = new NativeMintWrapper();
+        address[] memory minters = new address[](0);
+
+        vm.prank(SystemAddresses.GENESIS);
+        vm.expectRevert(Errors.ZeroAddress.selector);
+        wrapper2.initialize(address(0), minters);
+    }
+
+    function test_Initialize_MultipleMinters() public {
+        NativeMintWrapper wrapper2 = new NativeMintWrapper();
+        address[] memory minters = new address[](2);
+        minters[0] = minterA;
+        minters[1] = minterB;
+
+        vm.prank(SystemAddresses.GENESIS);
+        wrapper2.initialize(owner, minters);
+
+        assertTrue(wrapper2.isMinter(minterA));
+        assertTrue(wrapper2.isMinter(minterB));
+    }
+
+    // ========================================================================
+    // ADD MINTER TESTS
+    // ========================================================================
+
+    function test_AddMinter() public {
+        vm.prank(owner);
+        vm.expectEmit(true, true, true, true);
+        emit INativeMintWrapper.MinterAdded(minterB);
+        wrapper.addMinter(minterB);
+
+        assertTrue(wrapper.isMinter(minterB));
+    }
+
+    function test_AddMinter_RevertWhenNotOwner() public {
+        vm.prank(alice);
+        vm.expectRevert(abi.encodeWithSelector(INativeMintWrapper.OnlyOwner.selector, alice));
+        wrapper.addMinter(minterB);
+    }
+
+    function test_AddMinter_RevertWhenZeroAddress() public {
+        vm.prank(owner);
+        vm.expectRevert(Errors.ZeroAddress.selector);
+        wrapper.addMinter(address(0));
+    }
+
+    // ========================================================================
+    // REMOVE MINTER TESTS
+    // ========================================================================
+
+    function test_RemoveMinter() public {
+        assertTrue(wrapper.isMinter(minterA));
+
+        vm.prank(owner);
+        vm.expectEmit(true, true, true, true);
+        emit INativeMintWrapper.MinterRemoved(minterA);
+        wrapper.removeMinter(minterA);
+
+        assertFalse(wrapper.isMinter(minterA));
+    }
+
+    function test_RemoveMinter_RevertWhenNotOwner() public {
+        vm.prank(alice);
+        vm.expectRevert(abi.encodeWithSelector(INativeMintWrapper.OnlyOwner.selector, alice));
+        wrapper.removeMinter(minterA);
+    }
+
+    // ========================================================================
+    // MINT TESTS
+    // ========================================================================
+
+    function test_Mint_Success() public {
+        vm.prank(minterA);
+        wrapper.mint(alice, 100 ether);
+    }
+
+    function test_Mint_RevertWhenUnauthorized() public {
+        vm.prank(alice);
+        vm.expectRevert(abi.encodeWithSelector(INativeMintWrapper.UnauthorizedMinter.selector, alice));
+        wrapper.mint(alice, 100 ether);
+    }
+
+    function test_Mint_RevertWhenZeroRecipient() public {
+        vm.prank(minterA);
+        vm.expectRevert(Errors.ZeroAddress.selector);
+        wrapper.mint(address(0), 100 ether);
+    }
+
+    function test_Mint_RevertWhenZeroAmount() public {
+        vm.prank(minterA);
+        vm.expectRevert(Errors.ZeroAmount.selector);
+        wrapper.mint(alice, 0);
+    }
+
+    function test_Mint_RevertAfterMinterRemoved() public {
+        // Mint succeeds
+        vm.prank(minterA);
+        wrapper.mint(alice, 100 ether);
+
+        // Remove minter
+        vm.prank(owner);
+        wrapper.removeMinter(minterA);
+
+        // Mint fails
+        vm.prank(minterA);
+        vm.expectRevert(abi.encodeWithSelector(INativeMintWrapper.UnauthorizedMinter.selector, minterA));
+        wrapper.mint(alice, 100 ether);
+    }
+
+    // ========================================================================
+    // MULTI MINTER TESTS
+    // ========================================================================
+
+    function test_MultipleMinters() public {
+        vm.prank(owner);
+        wrapper.addMinter(minterB);
+
+        // Both minters can mint
+        vm.prank(minterA);
+        wrapper.mint(alice, 50 ether);
+
+        vm.prank(minterB);
+        wrapper.mint(alice, 75 ether);
+    }
+
+    // ========================================================================
+    // VIEW TESTS
+    // ========================================================================
+
+    function test_IsMinter_False() public view {
+        assertFalse(wrapper.isMinter(alice));
+    }
+
+    function test_IsMinter_True() public view {
+        assertTrue(wrapper.isMinter(minterA));
+    }
+
+    // ========================================================================
+    // FUZZ TESTS
+    // ========================================================================
+
+    function testFuzz_AddAndMint(address minter, address recipient, uint256 amount) public {
+        vm.assume(minter != address(0));
+        vm.assume(recipient != address(0));
+        vm.assume(amount > 0);
+
+        vm.prank(owner);
+        wrapper.addMinter(minter);
+
+        vm.prank(minter);
+        wrapper.mint(recipient, amount);
+    }
+}

--- a/test/unit/oracle/NativeMintWrapper.t.sol
+++ b/test/unit/oracle/NativeMintWrapper.t.sol
@@ -208,7 +208,11 @@ contract NativeMintWrapperTest is Test {
     // FUZZ TESTS
     // ========================================================================
 
-    function testFuzz_AddAndMint(address minter, address recipient, uint256 amount) public {
+    function testFuzz_AddAndMint(
+        address minter,
+        address recipient,
+        uint256 amount
+    ) public {
         vm.assume(minter != address(0));
         vm.assume(recipient != address(0));
         vm.assume(amount > 0);


### PR DESCRIPTION
Introduce NativeMintWrapper contract at system address 0x1625F4003 to wrap NATIVE_MINT_PRECOMPILE with mapping-based multi-caller access control. This replaces the hardcoded single AUTHORIZED_CALLER in reth, allowing multiple bridge receivers to mint native tokens.

Changes:
- Add INativeMintWrapper interface and NativeMintWrapper contract with initialize() pattern (for bytecode injection deployment)
- Add NATIVE_MINT_WRAPPER to SystemAddresses (0x1625F4003)
- Modify GBridgeReceiver to call wrapper instead of precompile directly
- Wire NativeMintWrapper.initialize() into Genesis.sol after GBridgeReceiver deployment
- Update genesis-tool utils.rs: add address constant and CONTRACTS[22]
- Update reth AUTHORIZED_CALLER to NativeMintWrapper address
- Clean up IGBridgeReceiver: remove unused MintFailed and INativeMintPrecompile (now in INativeMintWrapper)
- Add NativeMintWrapper unit tests (19 tests)
- Update GBridgeReceiver tests for wrapper mocking

## Description

<!--
  Add a detailed description for the changes made in this pull request

  If your PR addresses an existing issue, add it here.
  Use the template string - `This pull request resolves #<issue-number>`
-->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->
- [ ] 📚 Documentation    (Non-breaking change; Changes in the documentation)
- [ ] 🔧 Bug fix          (Non-breaking change; Fixes an existing bug)
- [ ] 🥂 Improvement      (Non-breaking change; Improves existing feature)
- [ ] 🚀 New feature      (Non-breaking change; Adds functionality)
- [ ] 🔐 Security fix     (Non-breaking change; Patches a security issue)
- [ ] 💥 Breaking change  (Breaks existing functionality)

<!--
    Leave this section as-is, no changes are to be made below this point!
-->