### PR TITLE
revert: revert GBridgeReceiver changes to v1.0.0 for testnet-v1.2 hardfork

### DIFF
--- a/src/Genesis.sol
+++ b/src/Genesis.sol
@@ -70,7 +70,6 @@ contract Genesis {
     struct BridgeConfig {
         bool deploy;
         address trustedBridge;
-        uint256 trustedSourceId;
     }
 
     struct OracleInitParams {
@@ -229,8 +228,7 @@ contract Genesis {
 
         if (oracleConfig.bridgeConfig.deploy) {
             // Deploy GBridgeReceiver
-            GBridgeReceiver receiver =
-                new GBridgeReceiver(oracleConfig.bridgeConfig.trustedBridge, oracleConfig.bridgeConfig.trustedSourceId);
+            GBridgeReceiver receiver = new GBridgeReceiver(oracleConfig.bridgeConfig.trustedBridge);
 
             // Construct new arrays with extra slot for GBridgeReceiver (sourceType=0)
             sourceTypes = new uint32[](length + 1);

--- a/src/oracle/evm/native_token_bridge/GBridgeReceiver.sol
+++ b/src/oracle/evm/native_token_bridge/GBridgeReceiver.sol
@@ -4,7 +4,6 @@ pragma solidity ^0.8.30;
 import { IGBridgeReceiver, INativeMintPrecompile } from "./IGBridgeReceiver.sol";
 import { BlockchainEventHandler } from "../BlockchainEventHandler.sol";
 import { SystemAddresses } from "@src/foundation/SystemAddresses.sol";
-import { Errors } from "@src/foundation/Errors.sol";
 
 /// @title GBridgeReceiver
 /// @author Gravity Team
@@ -20,9 +19,6 @@ contract GBridgeReceiver is IGBridgeReceiver, BlockchainEventHandler {
     /// @dev Only messages from this sender are processed
     address public immutable trustedBridge;
 
-    /// @notice Trusted source chain ID (e.g., Ethereum mainnet = 1)
-    uint256 public immutable trustedSourceId;
-
     // ========================================================================
     // STATE
     // ========================================================================
@@ -36,14 +32,10 @@ contract GBridgeReceiver is IGBridgeReceiver, BlockchainEventHandler {
 
     /// @notice Deploy the GBridgeReceiver
     /// @param trustedBridge_ The trusted GBridgeSender address on Ethereum
-    /// @param trustedSourceId_ The trusted source chain ID (e.g., 1 for Ethereum mainnet)
     constructor(
-        address trustedBridge_,
-        uint256 trustedSourceId_
+        address trustedBridge_
     ) {
-        if (trustedBridge_ == address(0)) revert Errors.ZeroAddress();
         trustedBridge = trustedBridge_;
-        trustedSourceId = trustedSourceId_;
     }
 
     // ========================================================================
@@ -53,7 +45,7 @@ contract GBridgeReceiver is IGBridgeReceiver, BlockchainEventHandler {
     /// @notice Handle a parsed portal message from BlockchainEventHandler
     /// @dev Called after BlockchainEventHandler parses the oracle payload
     /// @param sourceType The source type from NativeOracle (unused, for future extensibility)
-    /// @param sourceId The source identifier (chain ID, validated against trustedSourceId)
+    /// @param sourceId The source identifier (chain ID, unused)
     /// @param oracleNonce The oracle nonce for this record (unused)
     /// @param sender The sender address on Ethereum (must be trusted bridge)
     /// @param messageNonce The message nonce from the source chain
@@ -68,12 +60,7 @@ contract GBridgeReceiver is IGBridgeReceiver, BlockchainEventHandler {
         bytes memory message
     ) internal override returns (bool shouldStore) {
         // Silence unused variable warnings - these are for future extensibility
-        (sourceType, oracleNonce);
-
-        // Verify source chain ID
-        if (sourceId != trustedSourceId) {
-            revert InvalidSourceChain(sourceId, trustedSourceId);
-        }
+        (sourceType, sourceId, oracleNonce);
 
         // Verify sender is the trusted bridge (defense in depth)
         if (sender != trustedBridge) {
@@ -87,10 +74,6 @@ contract GBridgeReceiver is IGBridgeReceiver, BlockchainEventHandler {
 
         // Decode message: (amount, recipient)
         (uint256 amount, address recipient) = abi.decode(message, (uint256, address));
-
-        // Validate decoded data to prevent no-op mints and burns to address(0)
-        if (amount == 0) revert Errors.ZeroAmount();
-        if (recipient == address(0)) revert Errors.ZeroAddress();
 
         // Mark nonce as processed BEFORE minting (CEI pattern)
         _processedNonces[messageNonce] = true;

--- a/src/oracle/evm/native_token_bridge/IGBridgeReceiver.sol
+++ b/src/oracle/evm/native_token_bridge/IGBridgeReceiver.sol
@@ -36,11 +36,6 @@ interface IGBridgeReceiver {
     /// @param amount The amount that failed to mint
     error MintFailed(address recipient, uint256 amount);
 
-    /// @notice Source chain ID does not match trusted source
-    /// @param provided The provided source chain ID
-    /// @param expected The expected trusted source chain ID
-    error InvalidSourceChain(uint256 provided, uint256 expected);
-
     // ========================================================================
     // VIEW FUNCTIONS
     // ========================================================================
@@ -55,10 +50,6 @@ interface IGBridgeReceiver {
     /// @notice Get the trusted bridge address on Ethereum
     /// @return The trusted GBridgeSender address
     function trustedBridge() external view returns (address);
-
-    /// @notice Get the trusted source chain ID
-    /// @return The trusted source chain ID
-    function trustedSourceId() external view returns (uint256);
 }
 
 /// @title INativeMintPrecompile

--- a/test/unit/GenesisTest.t.sol
+++ b/test/unit/GenesisTest.t.sol
@@ -118,7 +118,7 @@ contract GenesisTest is Test {
         address[] memory callbacks = new address[](1);
         callbacks[0] = SystemAddresses.JWK_MANAGER;
         Genesis.OracleTaskParams[] memory tasks = new Genesis.OracleTaskParams[](0);
-        Genesis.BridgeConfig memory bridgeConfig = Genesis.BridgeConfig(false, address(0), 0);
+        Genesis.BridgeConfig memory bridgeConfig = Genesis.BridgeConfig(false, address(0));
         params.oracleConfig = Genesis.OracleInitParams(sourceTypes, callbacks, tasks, bridgeConfig);
 
         // JWK Config

--- a/test/unit/oracle/GBridgeReceiver.t.sol
+++ b/test/unit/oracle/GBridgeReceiver.t.sol
@@ -7,7 +7,6 @@ import { IGBridgeReceiver, INativeMintPrecompile } from "@src/oracle/evm/native_
 import { PortalMessage } from "@src/oracle/evm/PortalMessage.sol";
 import { SystemAddresses } from "@src/foundation/SystemAddresses.sol";
 import { NotAllowed } from "@src/foundation/SystemAccessControl.sol";
-import { Errors } from "@src/foundation/Errors.sol";
 
 /// @title MockNativeMintPrecompile
 /// @notice Mock precompile for testing native token minting
@@ -53,7 +52,7 @@ contract GBridgeReceiverTest is Test {
         vm.mockCall(SystemAddresses.NATIVE_MINT_PRECOMPILE, emptyData, successReturn);
 
         // Deploy receiver with trusted bridge
-        receiver = new GBridgeReceiver(trustedBridge, ETHEREUM_SOURCE_ID);
+        receiver = new GBridgeReceiver(trustedBridge);
     }
 
     // ========================================================================
@@ -77,11 +76,6 @@ contract GBridgeReceiverTest is Test {
 
     function test_Constructor() public view {
         assertEq(receiver.trustedBridge(), trustedBridge);
-    }
-
-    function test_Constructor_RevertWhenZeroTrustedBridge() public {
-        vm.expectRevert(Errors.ZeroAddress.selector);
-        new GBridgeReceiver(address(0), ETHEREUM_SOURCE_ID);
     }
 
     // ========================================================================
@@ -180,7 +174,6 @@ contract GBridgeReceiverTest is Test {
         uint128 messageNonce
     ) public {
         vm.assume(recipient != address(0));
-        vm.assume(amount > 0); // amount=0 now reverts
         vm.assume(!receiver.isProcessed(messageNonce));
 
         bytes memory payload = _createOraclePayload(trustedBridge, messageNonce, amount, recipient);


### PR DESCRIPTION
Revert all GBridgeReceiver contract changes made after gravity-testnet-v1.0.0 to avoid bridge receiver hardfork complexity in testnet-v1.2 upgrade.

Reverted changes:
- Remove trustedSourceId immutable and constructor param
- Remove InvalidSourceChain error
- Remove zero-amount/zero-address validation in handlePortalMessage
- Revert Genesis.sol BridgeConfig struct and constructor call
- Update tests to match reverted contract interface

## Description

<!--
  Add a detailed description for the changes made in this pull request

  If your PR addresses an existing issue, add it here.
  Use the template string - `This pull request resolves #<issue-number>`
-->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->
- [ ] 📚 Documentation    (Non-breaking change; Changes in the documentation)
- [ ] 🔧 Bug fix          (Non-breaking change; Fixes an existing bug)
- [ ] 🥂 Improvement      (Non-breaking change; Improves existing feature)
- [ ] 🚀 New feature      (Non-breaking change; Adds functionality)
- [ ] 🔐 Security fix     (Non-breaking change; Patches a security issue)
- [ ] 💥 Breaking change  (Breaks existing functionality)

<!--
    Leave this section as-is, no changes are to be made below this point!
-->