### PR TITLE
fix: fix genesis-tool

### DIFF
--- a/genesis-tool/src/genesis.rs
+++ b/genesis-tool/src/genesis.rs
@@ -192,9 +192,6 @@ pub struct BridgeConfig {
 
     #[serde(rename = "trustedBridge")]
     pub trusted_bridge: String, // address
-
-    #[serde(rename = "trustedSourceId", default)]
-    pub trusted_source_id: String, // uint256 - source chain ID (e.g. "1" for Ethereum mainnet)
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
@@ -288,7 +285,6 @@ sol! {
     struct SolBridgeConfig {
         bool deploy;
         address trustedBridge;
-        uint256 trustedSourceId;
     }
 
     struct SolOracleInitParams {
@@ -468,11 +464,6 @@ pub fn convert_config_to_sol(config: &GenesisConfig) -> SolGenesisInitParams {
                 Address::ZERO
             } else {
                 parse_address(&config.oracle_config.bridge_config.trusted_bridge)
-            },
-            trustedSourceId: if config.oracle_config.bridge_config.trusted_source_id.is_empty() {
-                U256::ZERO
-            } else {
-                parse_u256(&config.oracle_config.bridge_config.trusted_source_id)
             },
         },
     };


### PR DESCRIPTION
remove trustedSourceId from SolBridgeConfig to match Genesis.sol ABI (introduced by https://github.com/Galxe/gravity_chain_core_contracts/pull/47)