### PR TITLE
fix(staking): implement D3-2 underbonded validator eviction

### DIFF
--- a/src/staking/IValidatorManagement.sol
+++ b/src/staking/IValidatorManagement.sol
@@ -67,6 +67,12 @@ interface IValidatorManagement {
     /// @param successfulProposals Number of successful proposals the validator had
     event ValidatorAutoEvicted(address indexed stakePool, uint256 successfulProposals);
 
+    /// @notice Emitted when a validator is evicted for dropping below minimum bond
+    /// @param stakePool Address of the validator's stake pool
+    /// @param votingPower The validator's current voting power
+    /// @param minimumBond The expected minimum bond threshold
+    event ValidatorUnderbondedEvicted(address indexed stakePool, uint256 votingPower, uint256 minimumBond);
+
     /// @notice Emitted when performance data array length doesn't match active validator count
     event PerformanceLengthMismatch(uint256 activeCount, uint256 perfCount);
 

--- a/src/staking/ValidatorManagement.sol
+++ b/src/staking/ValidatorManagement.sol
@@ -610,12 +610,6 @@ contract ValidatorManagement is IValidatorManagement {
     function evictUnderperformingValidators() external {
         requireAllowed(SystemAddresses.RECONFIGURATION);
 
-        // Check if auto-eviction is enabled
-        bool enabled = IValidatorConfig(SystemAddresses.VALIDATOR_CONFIG).autoEvictEnabled();
-        if (!enabled) {
-            return;
-        }
-
         // Skip eviction for epoch 1 — the first epoch after genesis has insufficient
         // performance data (validators are still bootstrapping), so eviction starts from epoch 2.
         uint64 closingEpoch = IReconfiguration(SystemAddresses.RECONFIGURATION).currentEpoch();
@@ -623,22 +617,11 @@ contract ValidatorManagement is IValidatorManagement {
             return;
         }
 
-        uint64 thresholdPct = IValidatorConfig(SystemAddresses.VALIDATOR_CONFIG).autoEvictThresholdPct();
-
-        // Read performance data from the completed epoch
-        IValidatorPerformanceTracker.IndividualPerformance[] memory perfs =
-            IValidatorPerformanceTracker(SystemAddresses.PERFORMANCE_TRACKER).getAllPerformances();
-
         uint256 activeLen = _activeValidators.length;
-        uint256 perfLen = perfs.length;
+        uint256 minimumBond = IValidatorConfig(SystemAddresses.VALIDATOR_CONFIG).minimumBond();
 
-        // Strict equality check: perf array length must match active validator count.
-        if (activeLen != perfLen) {
-            emit PerformanceLengthMismatch(activeLen, perfLen);
-            return;
-        }
-
-        // Initialize counter once and decrement per eviction instead of O(n) inner loop
+        // --- Phase 1: Underbonded eviction (always runs) ---
+        // Initialize counter: count currently ACTIVE validators (exclude already PENDING_INACTIVE)
         uint256 remainingActive = 0;
         for (uint256 i = 0; i < activeLen; i++) {
             if (_validators[_activeValidators[i]].status == ValidatorStatus.ACTIVE) {
@@ -650,7 +633,52 @@ contract ValidatorManagement is IValidatorManagement {
             address pool = _activeValidators[i];
             ValidatorRecord storage validator = _validators[pool];
 
-            // Only evict ACTIVE validators (skip if already PENDING_INACTIVE from manual leave)
+            // Only evaluate ACTIVE validators
+            if (validator.status != ValidatorStatus.ACTIVE) {
+                continue;
+            }
+
+            uint256 power = _getValidatorVotingPower(pool);
+            if (power < minimumBond) {
+                // Preserve liveness: never evict the last active validator
+                if (remainingActive <= 1) {
+                    continue;
+                }
+
+                validator.status = ValidatorStatus.PENDING_INACTIVE;
+                _pendingInactive.push(pool);
+                remainingActive--;
+
+                emit ValidatorUnderbondedEvicted(pool, power, minimumBond);
+            }
+        }
+
+        // --- Phase 2: Performance eviction (only if autoEvictEnabled) ---
+        bool enabled = IValidatorConfig(SystemAddresses.VALIDATOR_CONFIG).autoEvictEnabled();
+        if (!enabled) {
+            return;
+        }
+
+        uint64 thresholdPct = IValidatorConfig(SystemAddresses.VALIDATOR_CONFIG).autoEvictThresholdPct();
+
+        // Read performance data from the completed epoch
+        IValidatorPerformanceTracker.IndividualPerformance[] memory perfs =
+            IValidatorPerformanceTracker(SystemAddresses.PERFORMANCE_TRACKER).getAllPerformances();
+
+        uint256 perfLen = perfs.length;
+
+        // Strict equality check: perf array length must match active validator count.
+        if (activeLen != perfLen) {
+            emit PerformanceLengthMismatch(activeLen, perfLen);
+            return;
+        }
+
+        // Note: remainingActive counter is shared and correctly reflects remaining ACTIVE validators after Phase 1
+        for (uint256 i = 0; i < activeLen; i++) {
+            address pool = _activeValidators[i];
+            ValidatorRecord storage validator = _validators[pool];
+
+            // Only evaluate ACTIVE validators (skipping those evicted in Phase 1)
             if (validator.status != ValidatorStatus.ACTIVE) {
                 continue;
             }
@@ -675,9 +703,6 @@ contract ValidatorManagement is IValidatorManagement {
             if (shouldEvict) {
                 // Preserve liveness: never evict the last active validator
                 if (remainingActive <= 1) {
-                    // Cannot evict the last active validator — would halt consensus
-                    // Use continue instead of break to avoid giving tail-index validators
-                    // positional immunity from eviction
                     continue;
                 }
 

--- a/test/unit/staking/ValidatorManagement.t.sol
+++ b/test/unit/staking/ValidatorManagement.t.sol
@@ -14,6 +14,7 @@ import { SystemAddresses } from "../../../src/foundation/SystemAddresses.sol";
 import { Errors } from "../../../src/foundation/Errors.sol";
 import { ValidatorRecord, ValidatorStatus, ValidatorConsensusInfo } from "../../../src/foundation/Types.sol";
 import { IReconfiguration } from "../../../src/blocker/IReconfiguration.sol";
+import { IValidatorPerformanceTracker } from "../../../src/blocker/IValidatorPerformanceTracker.sol";
 import { MockBlsPopVerify } from "../../utils/MockBlsPopVerify.sol";
 
 /// @notice Mock Reconfiguration contract for testing
@@ -2294,6 +2295,235 @@ contract ValidatorManagementTest is Test {
 
         ValidatorRecord memory aliceRecord = validatorManager.getValidator(pool);
         assertEq(aliceRecord.pendingConsensusPubkey, key2, "Alice pending should be key2");
+    }
+
+    // ========================================================================
+    // D3-2 UNDERBONDED VALIDATOR EVICTION TESTS
+    // ========================================================================
+
+    /// @notice Test that raising minimumBond evicts underbonded validators
+    function test_d3_2_governanceRaisesMinimumBond_evictsUnderbonded() public {
+        address alicePool = _createRegisterAndJoin(alice, 20 ether, "alice");
+        address bobPool = _createRegisterAndJoin(bob, 30 ether, "bob");
+        address charliePool = _createRegisterAndJoin(charlie, 50 ether, "charlie");
+        _processEpoch();
+        _processEpoch(); // Advance to epoch 2 (eviction skips epoch <= 1)
+
+        // Ensure all are active
+        assertEq(validatorManager.getActiveValidatorCount(), 3);
+
+        // Governance raises minimumBond to 40 ether
+        vm.prank(SystemAddresses.GOVERNANCE);
+        validatorConfig.setForNextEpoch(
+            40 ether, MAX_BOND, UNBONDING_DELAY, true, VOTING_POWER_INCREASE_LIMIT, MAX_VALIDATOR_SET_SIZE, false, 0
+        );
+        vm.prank(SystemAddresses.RECONFIGURATION);
+        validatorConfig.applyPendingConfig();
+
+        // Run eviction phase + epoch transition
+        vm.prank(SystemAddresses.RECONFIGURATION);
+        validatorManager.evictUnderperformingValidators();
+        _processEpoch();
+
+        // Alice (20) and Bob (30) should be eviced, Charlie (50) remains
+        assertEq(validatorManager.getActiveValidatorCount(), 1);
+        assertEq(uint8(validatorManager.getValidatorStatus(alicePool)), uint8(ValidatorStatus.INACTIVE));
+        assertEq(uint8(validatorManager.getValidatorStatus(bobPool)), uint8(ValidatorStatus.INACTIVE));
+        assertEq(uint8(validatorManager.getValidatorStatus(charliePool)), uint8(ValidatorStatus.ACTIVE));
+    }
+
+    /// @notice Test that if all validators are underbonded, safety guard keeps one
+    function test_d3_2_allUnderbonded_safetyGuardKeepsOne() public {
+        address alicePool = _createRegisterAndJoin(alice, 20 ether, "alice");
+        address bobPool = _createRegisterAndJoin(bob, 30 ether, "bob");
+        _processEpoch();
+        _processEpoch(); // Advance to epoch 2 (eviction skips epoch <= 1)
+
+        // Governance raises minimumBond to 100 ether (both are under)
+        vm.prank(SystemAddresses.GOVERNANCE);
+        validatorConfig.setForNextEpoch(
+            100 ether, MAX_BOND, UNBONDING_DELAY, true, VOTING_POWER_INCREASE_LIMIT, MAX_VALIDATOR_SET_SIZE, false, 0
+        );
+        vm.prank(SystemAddresses.RECONFIGURATION);
+        validatorConfig.applyPendingConfig();
+
+        vm.prank(SystemAddresses.RECONFIGURATION);
+        validatorManager.evictUnderperformingValidators();
+        _processEpoch();
+
+        // One validator should be kept due to liveness guard
+        assertEq(validatorManager.getActiveValidatorCount(), 1);
+
+        // Either Alice or Bob was kept. Verify that whoever wasn't kept is INACTIVE
+        uint8 aliceStatus = uint8(validatorManager.getValidatorStatus(alicePool));
+        uint8 bobStatus = uint8(validatorManager.getValidatorStatus(bobPool));
+
+        assertTrue(
+            (aliceStatus == uint8(ValidatorStatus.INACTIVE) && bobStatus == uint8(ValidatorStatus.ACTIVE))
+                || (aliceStatus == uint8(ValidatorStatus.ACTIVE) && bobStatus == uint8(ValidatorStatus.INACTIVE)),
+            "Exactly one must be ACTIVE"
+        );
+    }
+
+    /// @notice Test that an evicted validator can add stake and rejoin
+    function test_d3_2_evictedValidator_canRejoin() public {
+        address alicePool = _createRegisterAndJoin(alice, 20 ether, "alice");
+        address bobPool = _createRegisterAndJoin(bob, 50 ether, "bob");
+        _processEpoch();
+        _processEpoch(); // Advance to epoch 2 (eviction skips epoch <= 1)
+
+        // Raise minimum to 40
+        vm.prank(SystemAddresses.GOVERNANCE);
+        validatorConfig.setForNextEpoch(
+            40 ether, MAX_BOND, UNBONDING_DELAY, true, VOTING_POWER_INCREASE_LIMIT, MAX_VALIDATOR_SET_SIZE, false, 0
+        );
+        vm.prank(SystemAddresses.RECONFIGURATION);
+        validatorConfig.applyPendingConfig();
+
+        vm.prank(SystemAddresses.RECONFIGURATION);
+        validatorManager.evictUnderperformingValidators();
+        _processEpoch();
+
+        assertEq(uint8(validatorManager.getValidatorStatus(alicePool)), uint8(ValidatorStatus.INACTIVE));
+
+        // Alice adds stake
+        vm.prank(alice);
+        IStakePool(alicePool).addStake{ value: 30 ether }();
+        assertEq(IStakePool(alicePool).getActiveStake(), 50 ether);
+
+        // Alice rejoins
+        vm.prank(alice);
+        validatorManager.joinValidatorSet(alicePool);
+
+        _processEpoch();
+
+        assertEq(uint8(validatorManager.getValidatorStatus(alicePool)), uint8(ValidatorStatus.ACTIVE));
+        assertEq(validatorManager.getActiveValidatorCount(), 2);
+    }
+
+    /// @notice Test that minimumBond unchanged has no eviction effect
+    function test_d3_2_minimumBondUnchanged_noEffect() public {
+        address alicePool = _createRegisterAndJoin(alice, MIN_BOND, "alice");
+        address bobPool = _createRegisterAndJoin(bob, MIN_BOND, "bob");
+        _processEpoch();
+        _processEpoch(); // Advance to epoch 2 (eviction skips epoch <= 1)
+
+        vm.prank(SystemAddresses.RECONFIGURATION);
+        validatorManager.evictUnderperformingValidators();
+        _processEpoch();
+
+        assertEq(validatorManager.getActiveValidatorCount(), 2);
+        assertEq(uint8(validatorManager.getValidatorStatus(alicePool)), uint8(ValidatorStatus.ACTIVE));
+        assertEq(uint8(validatorManager.getValidatorStatus(bobPool)), uint8(ValidatorStatus.ACTIVE));
+    }
+
+    /// @notice Test underbonded execution concurrent with a pending active joining
+    function test_d3_2_underbondedWithPendingActivation() public {
+        address alicePool = _createRegisterAndJoin(alice, 20 ether, "alice");
+        address bobPool = _createRegisterAndJoin(bob, 30 ether, "bob");
+        address charliePool = _createRegisterAndJoin(charlie, 50 ether, "charlie");
+        _processEpoch();
+        _processEpoch(); // Advance to epoch 2 (eviction skips epoch <= 1)
+
+        // David joins (pending)
+        address davidPool = _createAndRegisterValidator(david, 60 ether, "david");
+        vm.prank(david);
+        validatorManager.joinValidatorSet(davidPool);
+
+        // Gov raises limit to 40
+        vm.prank(SystemAddresses.GOVERNANCE);
+        validatorConfig.setForNextEpoch(
+            40 ether, MAX_BOND, UNBONDING_DELAY, true, VOTING_POWER_INCREASE_LIMIT, MAX_VALIDATOR_SET_SIZE, false, 0
+        );
+        vm.prank(SystemAddresses.RECONFIGURATION);
+        validatorConfig.applyPendingConfig();
+
+        vm.prank(SystemAddresses.RECONFIGURATION);
+        validatorManager.evictUnderperformingValidators();
+        _processEpoch();
+
+        // Alice & Bob out; Charlie & David active
+        assertEq(validatorManager.getActiveValidatorCount(), 2);
+        assertEq(uint8(validatorManager.getValidatorStatus(alicePool)), uint8(ValidatorStatus.INACTIVE));
+        assertEq(uint8(validatorManager.getValidatorStatus(bobPool)), uint8(ValidatorStatus.INACTIVE));
+        assertEq(uint8(validatorManager.getValidatorStatus(charliePool)), uint8(ValidatorStatus.ACTIVE));
+        assertEq(uint8(validatorManager.getValidatorStatus(davidPool)), uint8(ValidatorStatus.ACTIVE));
+    }
+
+    /// @notice Test that underbond eviction runs even if autoEvictEnabled is false
+    function test_d3_2_underbondedEviction_independentOfAutoEvictEnabled() public {
+        address alicePool = _createRegisterAndJoin(alice, 20 ether, "alice");
+        address bobPool = _createRegisterAndJoin(bob, 50 ether, "bob");
+        _processEpoch();
+        _processEpoch(); // Advance to epoch 2 (eviction skips epoch <= 1)
+
+        // Gov raises limit to 40, disables autoEvict explicitly
+        vm.prank(SystemAddresses.GOVERNANCE);
+        validatorConfig.setForNextEpoch(
+            40 ether, MAX_BOND, UNBONDING_DELAY, true, VOTING_POWER_INCREASE_LIMIT, MAX_VALIDATOR_SET_SIZE, false, 0
+        );
+        vm.prank(SystemAddresses.RECONFIGURATION);
+        validatorConfig.applyPendingConfig();
+
+        vm.prank(SystemAddresses.RECONFIGURATION);
+        validatorManager.evictUnderperformingValidators();
+        _processEpoch();
+
+        assertEq(validatorManager.getActiveValidatorCount(), 1);
+        assertEq(uint8(validatorManager.getValidatorStatus(alicePool)), uint8(ValidatorStatus.INACTIVE));
+        assertEq(uint8(validatorManager.getValidatorStatus(bobPool)), uint8(ValidatorStatus.ACTIVE));
+    }
+
+    /// @notice Test that both underbonded and underperforming validators are evicted
+    function test_d3_2_underbondedAndUnderperforming_bothEvicted() public {
+        address alicePool = _createRegisterAndJoin(alice, 20 ether, "alice");
+        address bobPool = _createRegisterAndJoin(bob, 50 ether, "bob");
+        address charliePool = _createRegisterAndJoin(charlie, 80 ether, "charlie");
+        _processEpoch();
+        _processEpoch(); // Advance to epoch 2 (eviction skips epoch <= 1)
+
+        // Gov raises limit to 40, enables autoEvict with threshold 10
+        vm.prank(SystemAddresses.GOVERNANCE);
+        validatorConfig.setForNextEpoch(
+            40 ether, MAX_BOND, UNBONDING_DELAY, true, VOTING_POWER_INCREASE_LIMIT, MAX_VALIDATOR_SET_SIZE, true, 10
+        );
+        vm.prank(SystemAddresses.RECONFIGURATION);
+        validatorConfig.applyPendingConfig();
+
+        // Mock performance: arrays match active length.
+        // Active validators are Alice, Bob, Charlie (in whatever order they are indexed).
+        // For simplicity, we get and match their indices if we want precise tests, but Mocking all helps.
+        // Get actual indices to mock correctly.
+        uint256 len = validatorManager.getActiveValidatorCount();
+        IValidatorPerformanceTracker.IndividualPerformance[] memory perfs =
+            new IValidatorPerformanceTracker.IndividualPerformance[](len);
+
+        for (uint64 i = 0; i < len; i++) {
+            ValidatorConsensusInfo memory info = validatorManager.getActiveValidatorByIndex(i);
+            if (info.validator == alicePool) {
+                perfs[i] = IValidatorPerformanceTracker.IndividualPerformance(0, 0); // Alice: underbonded & underperforming
+            } else if (info.validator == bobPool) {
+                perfs[i] = IValidatorPerformanceTracker.IndividualPerformance(0, 0); // Bob: underperforming
+            } else if (info.validator == charliePool) {
+                perfs[i] = IValidatorPerformanceTracker.IndividualPerformance(15, 0); // Charlie: good
+            }
+        }
+
+        vm.mockCall(
+            SystemAddresses.PERFORMANCE_TRACKER,
+            abi.encodeWithSelector(IValidatorPerformanceTracker.getAllPerformances.selector),
+            abi.encode(perfs)
+        );
+
+        vm.prank(SystemAddresses.RECONFIGURATION);
+        validatorManager.evictUnderperformingValidators();
+        _processEpoch();
+
+        // Alice (underbonded), Bob (underperforming) are out. Charlie remains
+        assertEq(validatorManager.getActiveValidatorCount(), 1);
+        assertEq(uint8(validatorManager.getValidatorStatus(alicePool)), uint8(ValidatorStatus.INACTIVE));
+        assertEq(uint8(validatorManager.getValidatorStatus(bobPool)), uint8(ValidatorStatus.INACTIVE));
+        assertEq(uint8(validatorManager.getValidatorStatus(charliePool)), uint8(ValidatorStatus.ACTIVE));
     }
 }
 


### PR DESCRIPTION
## Description
Resolves Coacker V3.5 audit finding **D3-2 (Medium)**.

### Changes
* **ValidatorUnderbondedEvicted**: Added new event for underbonded evictions.
* **evictUnderperformingValidators**: Restructured to include a Phase 1 check for `minimumBond` and Phase 2 check for `autoEvictThreshold`.
* **Liveness Guard**: Shared `remainingActive` counter across both phases ensures at least one validator is always active to prevent consensus halts.
* **Testing**: Added 7 new unit tests for edge cases (auto-rejoin, autoEvict independence, etc).