### PR TITLE
  fix(blocker): fix DKG and auto-eviction synchronization bug and stricter eviction rule

### DIFF
--- a/genesis-tool/config/genesis_config.json
+++ b/genesis-tool/config/genesis_config.json
@@ -10,7 +10,7 @@
     "votingPowerIncreaseLimitPct": 20,
     "maxValidatorSetSize": "100",
     "autoEvictEnabled": false,
-    "autoEvictThreshold": "0"
+    "autoEvictThresholdPct": "0"
   },
 
   "stakingConfig": {

--- a/genesis-tool/config/genesis_config_single.json
+++ b/genesis-tool/config/genesis_config_single.json
@@ -10,7 +10,7 @@
     "votingPowerIncreaseLimitPct": 20,
     "maxValidatorSetSize": "100",
     "autoEvictEnabled": false,
-    "autoEvictThreshold": "0"
+    "autoEvictThresholdPct": "0"
   },
 
   "stakingConfig": {

--- a/genesis-tool/src/genesis.rs
+++ b/genesis-tool/src/genesis.rs
@@ -98,7 +98,7 @@ pub struct ValidatorConfigParams {
     pub auto_evict_enabled: bool,
 
     #[serde(rename = "autoEvictThresholdPct", default)]
-    pub auto_evict_threshold_pct: String,
+    pub auto_evict_threshold_pct: u64,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
@@ -382,11 +382,7 @@ pub fn convert_config_to_sol(config: &GenesisConfig) -> SolGenesisInitParams {
         votingPowerIncreaseLimitPct: config.validator_config.voting_power_increase_limit_pct,
         maxValidatorSetSize: parse_u256(&config.validator_config.max_validator_set_size),
         autoEvictEnabled: config.validator_config.auto_evict_enabled,
-        autoEvictThresholdPct: if config.validator_config.auto_evict_threshold_pct.is_empty() {
-            0u64
-        } else {
-            config.validator_config.auto_evict_threshold_pct.parse::<u64>().expect("invalid autoEvictThresholdPct")
-        },
+        autoEvictThresholdPct: config.validator_config.auto_evict_threshold_pct,
     };
 
     // Convert StakingConfig

--- a/genesis-tool/src/genesis.rs
+++ b/genesis-tool/src/genesis.rs
@@ -97,8 +97,8 @@ pub struct ValidatorConfigParams {
     #[serde(rename = "autoEvictEnabled", default)]
     pub auto_evict_enabled: bool,
 
-    #[serde(rename = "autoEvictThreshold", default)]
-    pub auto_evict_threshold: String,
+    #[serde(rename = "autoEvictThresholdPct", default)]
+    pub auto_evict_threshold_pct: String,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
@@ -248,7 +248,7 @@ sol! {
         uint64 votingPowerIncreaseLimitPct;
         uint256 maxValidatorSetSize;
         bool autoEvictEnabled;
-        uint256 autoEvictThreshold;
+        uint64 autoEvictThresholdPct;
     }
 
     struct SolStakingConfigParams {
@@ -382,10 +382,10 @@ pub fn convert_config_to_sol(config: &GenesisConfig) -> SolGenesisInitParams {
         votingPowerIncreaseLimitPct: config.validator_config.voting_power_increase_limit_pct,
         maxValidatorSetSize: parse_u256(&config.validator_config.max_validator_set_size),
         autoEvictEnabled: config.validator_config.auto_evict_enabled,
-        autoEvictThreshold: if config.validator_config.auto_evict_threshold.is_empty() {
-            U256::ZERO
+        autoEvictThresholdPct: if config.validator_config.auto_evict_threshold_pct.is_empty() {
+            0u64
         } else {
-            parse_u256(&config.validator_config.auto_evict_threshold)
+            config.validator_config.auto_evict_threshold_pct.parse::<u64>().expect("invalid autoEvictThresholdPct")
         },
     };
 

--- a/src/Genesis.sol
+++ b/src/Genesis.sol
@@ -44,7 +44,7 @@ contract Genesis {
         uint64 votingPowerIncreaseLimitPct;
         uint256 maxValidatorSetSize;
         bool autoEvictEnabled;
-        uint256 autoEvictThreshold;
+        uint64 autoEvictThresholdPct;
     }
 
     struct StakingConfigParams {
@@ -188,7 +188,7 @@ contract Genesis {
                 params.validatorConfig.votingPowerIncreaseLimitPct,
                 params.validatorConfig.maxValidatorSetSize,
                 params.validatorConfig.autoEvictEnabled,
-                params.validatorConfig.autoEvictThreshold
+                params.validatorConfig.autoEvictThresholdPct
             );
 
         StakingConfig(SystemAddresses.STAKE_CONFIG)

--- a/src/blocker/Reconfiguration.sol
+++ b/src/blocker/Reconfiguration.sol
@@ -95,7 +95,10 @@ contract Reconfiguration is IReconfiguration {
             return false;
         }
 
-        // 3. Get randomness config to check if DKG is enabled
+        // 3. Pre-transition actions: evict underperforming validators based on closing epoch's performance and rules
+        IValidatorManagement(SystemAddresses.VALIDATOR_MANAGER).evictUnderperformingValidators();
+
+        // 4. Get randomness config to check if DKG is enabled
         RandomnessConfig.RandomnessConfigData memory config =
             IRandomnessConfig(SystemAddresses.RANDOMNESS_CONFIG).getCurrentConfig();
 
@@ -143,6 +146,9 @@ contract Reconfiguration is IReconfiguration {
         if (_transitionState == TransitionState.DkgInProgress) {
             revert Errors.ReconfigurationInProgress();
         }
+
+        // Pre-transition actions: evict underperforming validators based on closing epoch's performance and rules
+        IValidatorManagement(SystemAddresses.VALIDATOR_MANAGER).evictUnderperformingValidators();
 
         // Get randomness config to check if DKG is enabled
         RandomnessConfig.RandomnessConfigData memory config =
@@ -257,8 +263,7 @@ contract Reconfiguration is IReconfiguration {
     /// @dev Core reconfiguration logic shared by finishTransition() and _doImmediateReconfigure()
     ///      Following Aptos pattern: all config modules apply pending changes at epoch boundary
     function _applyReconfiguration() internal {
-        // 1. Apply pending configs BEFORE validator changes
-        //    This ensures new configs are active for the new epoch's first block
+        // 1. Apply pending configs
         IRandomnessConfig(SystemAddresses.RANDOMNESS_CONFIG).applyPendingConfig();
         ConsensusConfig(SystemAddresses.CONSENSUS_CONFIG).applyPendingConfig();
         ExecutionConfig(SystemAddresses.EXECUTION_CONFIG).applyPendingConfig();
@@ -268,45 +273,34 @@ contract Reconfiguration is IReconfiguration {
         StakingConfig(SystemAddresses.STAKE_CONFIG).applyPendingConfig();
         EpochConfig(SystemAddresses.EPOCH_CONFIG).applyPendingConfig();
 
-        // 2. Auto-evict underperforming validators based on completed epoch's performance data
-        //    Must happen AFTER config apply (so autoEvictEnabled reflects latest governance decision)
-        //    and BEFORE onNewEpoch() (so evicted validators are processed in this same transition).
-        //    Evicted validators go ACTIVE → PENDING_INACTIVE here, then PENDING_INACTIVE → INACTIVE
-        //    in onNewEpoch() below — all within one epoch transition (no buffer epoch).
-        IValidatorManagement(SystemAddresses.VALIDATOR_MANAGER).evictUnderperformingValidators();
-
-        // 3. Notify validator manager BEFORE incrementing epoch (Aptos pattern)
+        // 2. Notify validator manager BEFORE incrementing epoch (Aptos pattern)
         //    Following Aptos reconfiguration.move: stake::on_new_epoch() is called
         //    before config_ref.epoch is incremented. This ensures validator set
         //    changes are processed in the context of the current epoch.
         IValidatorManagement(SystemAddresses.VALIDATOR_MANAGER).onNewEpoch();
 
-        // 4. Reset performance tracker for the new epoch
+        // 3. Reset performance tracker for the new epoch
         //    ORDERING INVARIANT: This call destructively erases all epoch performance data.
-        //    It MUST be the last consumer-dependent step — specifically AFTER:
-        //      - evictUnderperformingValidators() (step 2), which reads getAllPerformances()
-        //      - ValidatorManagement.onNewEpoch() (step 3), which processes validator changes
-        //    Reordering this before step 2 will silently zero out performance records,
-        //    disabling eviction and any future reward distribution logic.
-        //    Following Aptos pattern: validator_perf.validators is reset and
-        //    re-populated with zeros after on_new_epoch() processes rewards.
+        //    It MUST happen AFTER ValidatorManagement.onNewEpoch().
+        //    Note: evictUnderperformingValidators() is now called BEFORE DKG starts,
+        //    so its readings naturally precede this reset.
         uint256 newValidatorCount = IValidatorManagement(SystemAddresses.VALIDATOR_MANAGER).getActiveValidatorCount();
         IValidatorPerformanceTracker(SystemAddresses.PERFORMANCE_TRACKER).onNewEpoch(newValidatorCount);
 
-        // 5. Increment epoch and update timestamp
+        // 4. Increment epoch and update timestamp
         uint64 newEpoch = currentEpoch + 1;
         currentEpoch = newEpoch;
         lastReconfigurationTime = ITimestamp(SystemAddresses.TIMESTAMP).nowMicroseconds();
 
-        // 6. Reset state
+        // 5. Reset state
         _transitionState = TransitionState.Idle;
 
-        // 7. Get finalized validator set for NewEpochEvent
+        // 6. Get finalized validator set for NewEpochEvent
         ValidatorConsensusInfo[] memory validatorSet =
             IValidatorManagement(SystemAddresses.VALIDATOR_MANAGER).getActiveValidators();
         uint256 totalVotingPower = IValidatorManagement(SystemAddresses.VALIDATOR_MANAGER).getTotalVotingPower();
 
-        // 8. Emit events
+        // 7. Emit events
         //    - EpochTransitioned: simple event for internal tracking
         //    - NewEpochEvent: full validator set for consensus engine
         emit EpochTransitioned(newEpoch, lastReconfigurationTime);

--- a/src/foundation/Errors.sol
+++ b/src/foundation/Errors.sol
@@ -449,10 +449,10 @@ library Errors {
     /// @notice Validator config has not been initialized
     error ValidatorConfigNotInitialized();
 
-    /// @notice Auto-eviction threshold exceeds maximum (must fit in uint64 to match successfulProposals type)
+    /// @notice Auto-eviction threshold percentage exceeds maximum (must be 0-100)
     /// @param value The invalid threshold provided
-    /// @param maximum The maximum allowed threshold (type(uint64).max)
-    error InvalidAutoEvictThreshold(uint256 value, uint256 maximum);
+    /// @param maximum The maximum allowed threshold (100)
+    error InvalidAutoEvictThresholdPct(uint64 value, uint64 maximum);
 
     // ========================================================================
     // GOVERNANCE CONFIG ERRORS

--- a/src/runtime/IValidatorConfig.sol
+++ b/src/runtime/IValidatorConfig.sol
@@ -27,9 +27,9 @@ interface IValidatorConfig {
     /// @notice Whether auto-eviction of underperforming validators is enabled
     function autoEvictEnabled() external view returns (bool);
 
-    /// @notice Minimum successful proposals required to avoid auto-eviction
-    /// @dev Validators with successfulProposals <= this threshold are evicted at epoch boundary
-    function autoEvictThreshold() external view returns (uint256);
+    /// @notice Minimum success percentage required to avoid auto-eviction (0-100)
+    /// @dev Validators with success rate < this threshold are evicted at epoch boundary
+    function autoEvictThresholdPct() external view returns (uint64);
 
     /// @notice Maximum allowed voting power increase limit (50%)
     function MAX_VOTING_POWER_INCREASE_LIMIT() external view returns (uint64);

--- a/src/runtime/ValidatorConfig.sol
+++ b/src/runtime/ValidatorConfig.sol
@@ -38,6 +38,7 @@ contract ValidatorConfig {
         uint64 votingPowerIncreaseLimitPct;
         uint256 maxValidatorSetSize;
         bool autoEvictEnabled;
+        uint256 __deprecated_autoEvictThreshold;
         uint64 autoEvictThresholdPct;
     }
 
@@ -66,10 +67,8 @@ contract ValidatorConfig {
     /// @notice Whether auto-eviction of underperforming validators is enabled
     bool public autoEvictEnabled;
 
-    /// @notice Minimum success percentage required to avoid auto-eviction (0-100)
-    /// @dev Validators with success rate < this threshold are evicted at epoch boundary.
-    ///      E.g., 50 means validators with < 50% success rate are evicted.
-    uint64 public autoEvictThresholdPct;
+    /// @dev Deprecated: preserved for storage layout compatibility. Do not use.
+    uint256 private __deprecated_autoEvictThreshold;
 
     /// @notice Pending configuration for next epoch
     PendingConfig private _pendingConfig;
@@ -79,6 +78,11 @@ contract ValidatorConfig {
 
     /// @notice Whether the contract has been initialized
     bool private _initialized;
+
+    /// @notice Minimum success percentage required to avoid auto-eviction (0-100)
+    /// @dev Validators with success rate < this threshold are evicted at epoch boundary.
+    ///      E.g., 50 means validators with < 50% success rate are evicted.
+    uint64 public autoEvictThresholdPct;
 
     // ========================================================================
     // EVENTS
@@ -210,6 +214,7 @@ contract ValidatorConfig {
             votingPowerIncreaseLimitPct: _votingPowerIncreaseLimitPct,
             maxValidatorSetSize: _maxValidatorSetSize,
             autoEvictEnabled: _autoEvictEnabled,
+            __deprecated_autoEvictThreshold: 0,
             autoEvictThresholdPct: _autoEvictThresholdPct
         });
         hasPendingConfig = true;

--- a/src/runtime/ValidatorConfig.sol
+++ b/src/runtime/ValidatorConfig.sol
@@ -38,7 +38,7 @@ contract ValidatorConfig {
         uint64 votingPowerIncreaseLimitPct;
         uint256 maxValidatorSetSize;
         bool autoEvictEnabled;
-        uint256 autoEvictThreshold;
+        uint64 autoEvictThresholdPct;
     }
 
     // ========================================================================
@@ -66,10 +66,10 @@ contract ValidatorConfig {
     /// @notice Whether auto-eviction of underperforming validators is enabled
     bool public autoEvictEnabled;
 
-    /// @notice Minimum successful proposals required to avoid auto-eviction
-    /// @dev Validators with successfulProposals <= this threshold are evicted at epoch boundary.
-    ///      Default 0 means only validators with zero successful proposals are evicted.
-    uint256 public autoEvictThreshold;
+    /// @notice Minimum success percentage required to avoid auto-eviction (0-100)
+    /// @dev Validators with success rate < this threshold are evicted at epoch boundary.
+    ///      E.g., 50 means validators with < 50% success rate are evicted.
+    uint64 public autoEvictThresholdPct;
 
     /// @notice Pending configuration for next epoch
     PendingConfig private _pendingConfig;
@@ -106,7 +106,7 @@ contract ValidatorConfig {
     /// @param _votingPowerIncreaseLimitPct Max % voting power join per epoch (1-50)
     /// @param _maxValidatorSetSize Max validators in set (1-65536)
     /// @param _autoEvictEnabled Whether auto-eviction is enabled at genesis
-    /// @param _autoEvictThreshold Minimum successful proposals to avoid eviction
+    /// @param _autoEvictThresholdPct Minimum success percentage to avoid eviction (0-100)
     function initialize(
         uint256 _minimumBond,
         uint256 _maximumBond,
@@ -115,7 +115,7 @@ contract ValidatorConfig {
         uint64 _votingPowerIncreaseLimitPct,
         uint256 _maxValidatorSetSize,
         bool _autoEvictEnabled,
-        uint256 _autoEvictThreshold
+        uint64 _autoEvictThresholdPct
     ) external {
         requireAllowed(SystemAddresses.GENESIS);
 
@@ -130,7 +130,7 @@ contract ValidatorConfig {
             _unbondingDelayMicros,
             _votingPowerIncreaseLimitPct,
             _maxValidatorSetSize,
-            _autoEvictThreshold
+            _autoEvictThresholdPct
         );
 
         minimumBond = _minimumBond;
@@ -140,7 +140,7 @@ contract ValidatorConfig {
         votingPowerIncreaseLimitPct = _votingPowerIncreaseLimitPct;
         maxValidatorSetSize = _maxValidatorSetSize;
         autoEvictEnabled = _autoEvictEnabled;
-        autoEvictThreshold = _autoEvictThreshold;
+        autoEvictThresholdPct = _autoEvictThresholdPct;
 
         _initialized = true;
 
@@ -178,7 +178,7 @@ contract ValidatorConfig {
     /// @param _votingPowerIncreaseLimitPct Max % voting power join per epoch (1-50)
     /// @param _maxValidatorSetSize Max validators in set (1-65536)
     /// @param _autoEvictEnabled Whether auto-eviction is enabled
-    /// @param _autoEvictThreshold Minimum successful proposals to avoid eviction
+    /// @param _autoEvictThresholdPct Minimum success percentage to avoid eviction (0-100)
     function setForNextEpoch(
         uint256 _minimumBond,
         uint256 _maximumBond,
@@ -187,7 +187,7 @@ contract ValidatorConfig {
         uint64 _votingPowerIncreaseLimitPct,
         uint256 _maxValidatorSetSize,
         bool _autoEvictEnabled,
-        uint256 _autoEvictThreshold
+        uint64 _autoEvictThresholdPct
     ) external {
         requireAllowed(SystemAddresses.GOVERNANCE);
         _requireInitialized();
@@ -199,7 +199,7 @@ contract ValidatorConfig {
             _unbondingDelayMicros,
             _votingPowerIncreaseLimitPct,
             _maxValidatorSetSize,
-            _autoEvictThreshold
+            _autoEvictThresholdPct
         );
 
         _pendingConfig = PendingConfig({
@@ -210,7 +210,7 @@ contract ValidatorConfig {
             votingPowerIncreaseLimitPct: _votingPowerIncreaseLimitPct,
             maxValidatorSetSize: _maxValidatorSetSize,
             autoEvictEnabled: _autoEvictEnabled,
-            autoEvictThreshold: _autoEvictThreshold
+            autoEvictThresholdPct: _autoEvictThresholdPct
         });
         hasPendingConfig = true;
 
@@ -240,7 +240,7 @@ contract ValidatorConfig {
         votingPowerIncreaseLimitPct = _pendingConfig.votingPowerIncreaseLimitPct;
         maxValidatorSetSize = _pendingConfig.maxValidatorSetSize;
         autoEvictEnabled = _pendingConfig.autoEvictEnabled;
-        autoEvictThreshold = _pendingConfig.autoEvictThreshold;
+        autoEvictThresholdPct = _pendingConfig.autoEvictThresholdPct;
 
         hasPendingConfig = false;
 
@@ -261,14 +261,14 @@ contract ValidatorConfig {
     /// @param _unbondingDelayMicros Unbonding delay
     /// @param _votingPowerIncreaseLimitPct Voting power increase limit
     /// @param _maxValidatorSetSize Max validator set size
-    /// @param _autoEvictThreshold Auto-eviction threshold
+    /// @param _autoEvictThresholdPct Auto-eviction success percentage threshold (0-100)
     function _validateConfig(
         uint256 _minimumBond,
         uint256 _maximumBond,
         uint64 _unbondingDelayMicros,
         uint64 _votingPowerIncreaseLimitPct,
         uint256 _maxValidatorSetSize,
-        uint256 _autoEvictThreshold
+        uint64 _autoEvictThresholdPct
     ) internal pure {
         if (_minimumBond == 0) {
             revert Errors.InvalidMinimumBond();
@@ -293,10 +293,8 @@ contract ValidatorConfig {
             revert Errors.InvalidValidatorSetSize(_maxValidatorSetSize);
         }
 
-        // autoEvictThreshold must fit in uint64 since successfulProposals is uint64.
-        // A threshold of type(uint256).max would cause every validator to be evicted.
-        if (_autoEvictThreshold > type(uint64).max) {
-            revert Errors.InvalidAutoEvictThreshold(_autoEvictThreshold, type(uint64).max);
+        if (_autoEvictThresholdPct > 100) {
+            revert Errors.InvalidAutoEvictThresholdPct(_autoEvictThresholdPct, 100);
         }
     }
 

--- a/src/staking/IValidatorManagement.sol
+++ b/src/staking/IValidatorManagement.sol
@@ -215,7 +215,7 @@ interface IValidatorManagement {
     /// @notice Auto-evict underperforming validators at epoch boundary
     /// @dev Only callable by RECONFIGURATION during epoch transition.
     ///      Reads performance data from ValidatorPerformanceTracker and marks validators
-    ///      with successfulProposals <= autoEvictThreshold as PENDING_INACTIVE.
+    ///      with success rate < autoEvictThresholdPct as PENDING_INACTIVE.
     ///      Note: Unlike leaveValidatorSet, this happens DURING reconfiguration (not between epochs),
     ///      so evicted validators are immediately processed by onNewEpoch() in the same call,
     ///      going directly from ACTIVE → PENDING_INACTIVE → INACTIVE in one epoch transition.

--- a/src/staking/ValidatorManagement.sol
+++ b/src/staking/ValidatorManagement.sol
@@ -659,7 +659,10 @@ contract ValidatorManagement is IValidatorManagement {
             uint256 total = uint256(perfs[i].successfulProposals) + uint256(perfs[i].failedProposals);
             bool shouldEvict = false;
 
-            if (total > 0) {
+            if (total == 0) {
+                // No proposals at all — validator was completely inactive this epoch
+                shouldEvict = true;
+            } else {
                 uint256 successPct = (uint256(perfs[i].successfulProposals) * 100) / total;
                 if (successPct < thresholdPct) {
                     shouldEvict = true;

--- a/src/staking/ValidatorManagement.sol
+++ b/src/staking/ValidatorManagement.sol
@@ -662,6 +662,9 @@ contract ValidatorManagement is IValidatorManagement {
             if (total == 0) {
                 // No proposals at all — validator was completely inactive this epoch
                 shouldEvict = true;
+            } else if (perfs[i].successfulProposals == 0) {
+                // Validator never successfully proposed during the entire epoch
+                shouldEvict = true;
             } else {
                 uint256 successPct = (uint256(perfs[i].successfulProposals) * 100) / total;
                 if (successPct < thresholdPct) {

--- a/src/staking/ValidatorManagement.sol
+++ b/src/staking/ValidatorManagement.sol
@@ -591,7 +591,7 @@ contract ValidatorManagement is IValidatorManagement {
     /// @inheritdoc IValidatorManagement
     /// @dev Called by Reconfiguration BEFORE onNewEpoch() during epoch transition.
     ///      Reads the completed epoch's performance data and marks validators
-    ///      with successfulProposals <= autoEvictThreshold as PENDING_INACTIVE.
+    ///      with success rate < autoEvictThresholdPct as PENDING_INACTIVE.
     ///
     ///      ## Timing Difference from leaveValidatorSet
     ///
@@ -616,7 +616,14 @@ contract ValidatorManagement is IValidatorManagement {
             return;
         }
 
-        uint256 threshold = IValidatorConfig(SystemAddresses.VALIDATOR_CONFIG).autoEvictThreshold();
+        // Skip eviction for epoch 1 — the first epoch after genesis has insufficient
+        // performance data (validators are still bootstrapping), so eviction starts from epoch 2.
+        uint64 closingEpoch = IReconfiguration(SystemAddresses.RECONFIGURATION).currentEpoch();
+        if (closingEpoch <= 1) {
+            return;
+        }
+
+        uint64 thresholdPct = IValidatorConfig(SystemAddresses.VALIDATOR_CONFIG).autoEvictThresholdPct();
 
         // Read performance data from the completed epoch
         IValidatorPerformanceTracker.IndividualPerformance[] memory perfs =
@@ -648,8 +655,18 @@ contract ValidatorManagement is IValidatorManagement {
                 continue;
             }
 
-            // Check if validator meets eviction criteria
-            if (perfs[i].successfulProposals <= threshold) {
+            // Check if validator meets eviction criteria based on success percentage
+            uint256 total = uint256(perfs[i].successfulProposals) + uint256(perfs[i].failedProposals);
+            bool shouldEvict = false;
+
+            if (total > 0) {
+                uint256 successPct = (uint256(perfs[i].successfulProposals) * 100) / total;
+                if (successPct < thresholdPct) {
+                    shouldEvict = true;
+                }
+            }
+
+            if (shouldEvict) {
                 // Preserve liveness: never evict the last active validator
                 if (remainingActive <= 1) {
                     // Cannot evict the last active validator — would halt consensus

--- a/test/unit/blocker/Blocker.t.sol
+++ b/test/unit/blocker/Blocker.t.sol
@@ -159,7 +159,7 @@ contract BlockerTest is Test {
                 20, // votingPowerIncreaseLimitPct
                 100, // maxValidatorSetSize
                 false, // autoEvictEnabled
-                0 // autoEvictThreshold
+                0 // autoEvictThresholdPct
             );
 
         // Initialize VersionConfig

--- a/test/unit/blocker/Reconfiguration.t.sol
+++ b/test/unit/blocker/Reconfiguration.t.sol
@@ -176,7 +176,7 @@ contract ReconfigurationTest is Test {
                 20, // votingPowerIncreaseLimitPct
                 100, // maxValidatorSetSize
                 false, // autoEvictEnabled
-                0 // autoEvictThreshold
+                0 // autoEvictThresholdPct
             );
 
         // Initialize VersionConfig


### PR DESCRIPTION
  Move evictUnderperformingValidators hook from _applyReconfiguration to                     
  checkAndStartTransition and governanceReconfigure. This ensures underperforming validators 
  are correctly marked as PENDING_INACTIVE before DKG target selection, preventing consensus 
  halts caused by mismatched DKG transcripts.                                                
                                                                     
  Additionally, add a stricter eviction condition: validators with zero successful proposals
  during an entire epoch are now evicted regardless of the autoEvictThresholdPct setting.    
  Previously, when thresholdPct was set to 0, a validator with only failed proposals
  (successPct = 0) would pass the 0 < 0 check and avoid eviction. The new condition          
  explicitly catches this edge case.    
