### PR TITLE
fix(staking): add deprecated storage gap for hardfork compatibility

### DIFF
--- a/src/runtime/StakingConfig.sol
+++ b/src/runtime/StakingConfig.sol
@@ -30,6 +30,8 @@ contract StakingConfig {
         uint256 minimumStake;
         uint64 lockupDurationMicros;
         uint64 unbondingDelayMicros;
+        /// @dev DEPRECATED: kept as storage gap to preserve slot layout for hardfork compatibility.
+        uint256 __deprecated_minimumProposalStake;
     }
 
     // ========================================================================
@@ -44,6 +46,11 @@ contract StakingConfig {
 
     /// @notice Unbonding delay in microseconds (additional wait after lockedUntil before withdrawal)
     uint64 public unbondingDelayMicros;
+
+    /// @notice DEPRECATED: kept as storage gap to preserve slot layout for hardfork compatibility.
+    /// @dev Was `minimumProposalStake` in v1.2.0; removed functionally but retained to avoid
+    ///      shifting subsequent storage slots (_initialized, _pendingConfig, hasPendingConfig).
+    uint256 private __deprecated_minimumProposalStake;
 
     /// @notice Whether the contract has been initialized
     bool private _initialized;
@@ -132,7 +139,8 @@ contract StakingConfig {
         _pendingConfig = PendingConfig({
             minimumStake: _minimumStake,
             lockupDurationMicros: _lockupDurationMicros,
-            unbondingDelayMicros: _unbondingDelayMicros
+            unbondingDelayMicros: _unbondingDelayMicros,
+            __deprecated_minimumProposalStake: 0
         });
         hasPendingConfig = true;
         emit PendingStakingConfigSet();


### PR DESCRIPTION
## Summary
- Add `__deprecated_minimumProposalStake` storage gap in `StakingConfig` state variables and `PendingConfig` struct
- Prevents storage slot collision during hardfork upgrade by preserving the original slot layout after `minimumProposalStake` was functionally removed
- Ensures `_initialized`, `_pendingConfig`, and `hasPendingConfig` remain at their original storage slots

## Context
The previous commit removed `minimumProposalStake` entirely, which shifts all subsequent storage slots. During a hardfork the on-chain storage layout must remain compatible with the pre-upgrade contract. This PR introduces a deprecated placeholder to occupy the original slot, matching the approach used in the upstream `gravity_chain_core_contracts` repo.

## Test plan
- [ ] Verify `forge build` compiles successfully
- [ ] Verify storage layout matches the pre-removal layout (slots for `_initialized`, `_pendingConfig`, `hasPendingConfig` unchanged)
- [ ] Run existing StakingConfig test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)