### PR TITLE
fix(bridge): remove redundant _processedNonces from GBridgeReceiver

### DIFF
--- a/src/oracle/evm/native_token_bridge/GBridgeReceiver.sol
+++ b/src/oracle/evm/native_token_bridge/GBridgeReceiver.sol
@@ -27,8 +27,9 @@ contract GBridgeReceiver is IGBridgeReceiver, BlockchainEventHandler {
     // STATE
     // ========================================================================
 
-    /// @notice Processed nonces for replay protection
-    mapping(uint128 => bool) private _processedNonces;
+    // @deprecated Kept for storage layout compatibility after hardfork.
+    // Replay protection is already guaranteed by NativeOracle's sequential nonce enforcement.
+    uint256 private __deprecated_processedNonces;
 
     // ========================================================================
     // CONSTRUCTOR
@@ -80,10 +81,8 @@ contract GBridgeReceiver is IGBridgeReceiver, BlockchainEventHandler {
             revert InvalidSender(sender, trustedBridge);
         }
 
-        // Check for replay
-        if (_processedNonces[messageNonce]) {
-            revert AlreadyProcessed(messageNonce);
-        }
+        // Replay protection is handled by NativeOracle's sequential nonce enforcement
+        // (nonce must equal currentNonce + 1), so no duplicate check is needed here.
 
         // Decode message: (amount, recipient)
         (uint256 amount, address recipient) = abi.decode(message, (uint256, address));
@@ -91,9 +90,6 @@ contract GBridgeReceiver is IGBridgeReceiver, BlockchainEventHandler {
         // Validate decoded data to prevent no-op mints and burns to address(0)
         if (amount == 0) revert Errors.ZeroAmount();
         if (recipient == address(0)) revert Errors.ZeroAddress();
-
-        // Mark nonce as processed BEFORE minting (CEI pattern)
-        _processedNonces[messageNonce] = true;
 
         // Mint native tokens via precompile (precompile never reverts)
         bytes memory callData = abi.encodePacked(uint8(0x01), recipient, amount);
@@ -107,16 +103,4 @@ contract GBridgeReceiver is IGBridgeReceiver, BlockchainEventHandler {
         // Store bridge events in NativeOracle for verification and audit trail
         return true;
     }
-
-    // ========================================================================
-    // VIEW FUNCTIONS
-    // ========================================================================
-
-    /// @inheritdoc IGBridgeReceiver
-    function isProcessed(
-        uint128 nonce
-    ) external view returns (bool) {
-        return _processedNonces[nonce];
-    }
 }
-

--- a/src/oracle/evm/native_token_bridge/IGBridgeReceiver.sol
+++ b/src/oracle/evm/native_token_bridge/IGBridgeReceiver.sol
@@ -27,10 +27,6 @@ interface IGBridgeReceiver {
     /// @param expected The expected trusted bridge address
     error InvalidSender(address sender, address expected);
 
-    /// @notice Nonce has already been processed (replay protection)
-    /// @param nonce The duplicate nonce
-    error AlreadyProcessed(uint128 nonce);
-
     /// @notice Native token mint via precompile failed
     /// @param recipient The intended recipient
     /// @param amount The amount that failed to mint
@@ -44,13 +40,6 @@ interface IGBridgeReceiver {
     // ========================================================================
     // VIEW FUNCTIONS
     // ========================================================================
-
-    /// @notice Check if a nonce has been processed
-    /// @param nonce The nonce to check
-    /// @return True if the nonce has been processed
-    function isProcessed(
-        uint128 nonce
-    ) external view returns (bool);
 
     /// @notice Get the trusted bridge address on Ethereum
     /// @return The trusted GBridgeSender address

--- a/test/unit/oracle/GBridgeReceiver.t.sol
+++ b/test/unit/oracle/GBridgeReceiver.t.sol
@@ -98,8 +98,6 @@ contract GBridgeReceiverTest is Test {
         vm.expectEmit(true, true, true, true);
         emit IGBridgeReceiver.NativeMinted(alice, amount, messageNonce);
         receiver.onOracleEvent(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, oracleNonce, payload);
-
-        assertTrue(receiver.isProcessed(messageNonce));
     }
 
     function test_OnOracleEvent_RevertWhenNotNativeOracle() public {
@@ -119,20 +117,31 @@ contract GBridgeReceiverTest is Test {
         receiver.onOracleEvent(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, 1000, payload);
     }
 
-    function test_OnOracleEvent_RevertWhenAlreadyProcessed() public {
-        uint256 amount = 100 ether;
-        uint128 messageNonce = 42;
-        uint128 oracleNonce = 1000;
-        bytes memory payload = _createOraclePayload(trustedBridge, messageNonce, amount, alice);
+    function test_OnOracleEvent_RevertWhenInvalidSourceChain() public {
+        uint256 wrongSourceId = 56; // BSC instead of Ethereum
+        bytes memory payload = _createOraclePayload(trustedBridge, 1, 100 ether, alice);
 
-        // First call succeeds
         vm.prank(nativeOracle);
-        receiver.onOracleEvent(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, oracleNonce, payload);
+        vm.expectRevert(
+            abi.encodeWithSelector(IGBridgeReceiver.InvalidSourceChain.selector, wrongSourceId, ETHEREUM_SOURCE_ID)
+        );
+        receiver.onOracleEvent(SOURCE_TYPE_BLOCKCHAIN, wrongSourceId, 1000, payload);
+    }
 
-        // Second call with same message nonce fails
+    function test_OnOracleEvent_RevertWhenZeroAmount() public {
+        bytes memory payload = _createOraclePayload(trustedBridge, 1, 0, alice);
+
         vm.prank(nativeOracle);
-        vm.expectRevert(abi.encodeWithSelector(IGBridgeReceiver.AlreadyProcessed.selector, messageNonce));
-        receiver.onOracleEvent(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, oracleNonce + 1, payload);
+        vm.expectRevert(Errors.ZeroAmount.selector);
+        receiver.onOracleEvent(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, 1000, payload);
+    }
+
+    function test_OnOracleEvent_RevertWhenZeroRecipient() public {
+        bytes memory payload = _createOraclePayload(trustedBridge, 1, 100 ether, address(0));
+
+        vm.prank(nativeOracle);
+        vm.expectRevert(Errors.ZeroAddress.selector);
+        receiver.onOracleEvent(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, 1000, payload);
     }
 
     function test_OnOracleEvent_DifferentNonces() public {
@@ -144,8 +153,6 @@ contract GBridgeReceiverTest is Test {
 
             vm.prank(nativeOracle);
             receiver.onOracleEvent(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, oracleNonce, payload);
-
-            assertTrue(receiver.isProcessed(i));
         }
     }
 
@@ -153,21 +160,12 @@ contract GBridgeReceiverTest is Test {
     // VIEW TESTS
     // ========================================================================
 
-    function test_IsProcessed_False() public view {
-        assertFalse(receiver.isProcessed(999));
-    }
-
-    function test_IsProcessed_True() public {
-        bytes memory payload = _createOraclePayload(trustedBridge, 123, 100, alice);
-
-        vm.prank(nativeOracle);
-        receiver.onOracleEvent(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, 1000, payload);
-
-        assertTrue(receiver.isProcessed(123));
-    }
-
     function test_TrustedBridge() public view {
         assertEq(receiver.trustedBridge(), trustedBridge);
+    }
+
+    function test_TrustedSourceId() public view {
+        assertEq(receiver.trustedSourceId(), ETHEREUM_SOURCE_ID);
     }
 
     // ========================================================================
@@ -180,32 +178,12 @@ contract GBridgeReceiverTest is Test {
         uint128 messageNonce
     ) public {
         vm.assume(recipient != address(0));
-        vm.assume(amount > 0); // amount=0 now reverts
-        vm.assume(!receiver.isProcessed(messageNonce));
+        vm.assume(amount > 0);
 
         bytes memory payload = _createOraclePayload(trustedBridge, messageNonce, amount, recipient);
         uint128 oracleNonce = 1000;
 
         vm.prank(nativeOracle);
         receiver.onOracleEvent(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, oracleNonce, payload);
-
-        assertTrue(receiver.isProcessed(messageNonce));
-    }
-
-    function testFuzz_ReplayProtection(
-        uint128 messageNonce
-    ) public {
-        bytes memory payload = _createOraclePayload(trustedBridge, messageNonce, 100, alice);
-        uint128 oracleNonce = 1000;
-
-        // First call succeeds
-        vm.prank(nativeOracle);
-        receiver.onOracleEvent(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, oracleNonce, payload);
-
-        // Second call fails
-        vm.prank(nativeOracle);
-        vm.expectRevert(abi.encodeWithSelector(IGBridgeReceiver.AlreadyProcessed.selector, messageNonce));
-        receiver.onOracleEvent(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, oracleNonce + 1, payload);
     }
 }
-


### PR DESCRIPTION
## Summary
- Remove redundant `_processedNonces` mapping from `GBridgeReceiver` — replay protection is already guaranteed by NativeOracle's sequential nonce enforcement (`nonce == currentNonce + 1`), since the oracle nonce and portal `messageNonce` are the same value
- Replace the mapping with a `uint256` deprecated storage gap at slot 0 for hardfork storage layout compatibility
- Remove `AlreadyProcessed` error and `isProcessed` view function from interface
- Update tests to reflect the removal

## Context
The `GravityPortal` on Ethereum assigns a sequential `uint128 nonce` to each message, which is both embedded in the `PortalMessage` payload and used as the `NativeOracle.record()` nonce parameter by validators. Since `NativeOracle._updateNonce()` enforces strict sequentiality, duplicate nonces are impossible at the oracle layer, making `GBridgeReceiver._processedNonces` redundant.

Ref: keanji-x/gravity_chain_core_contracts#21

## Test plan
- [x] All `GBridgeReceiverTest` tests pass (12/12)
- [x] Full `forge build` compiles without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)