### PR TITLE
fix(genesis-tool): add terminalTotalDifficulty to mark chain post-merge

### DIFF
--- a/genesis-tool/config/genesis_template.json
+++ b/genesis-tool/config/genesis_template.json
@@ -26,7 +26,8 @@
         "mergeNetsplitBlock": 0,
         "shanghaiTime": 0,
         "cancunTime": 0,
-        "terminalTotalDifficultyPassed": false,
+        "terminalTotalDifficulty": 0,
+        "terminalTotalDifficultyPassed": true,
         "extraFields": {},
         "depositContractAddress": null
     },


### PR DESCRIPTION
The genesis template was missing the `terminalTotalDifficulty` field, so reth's `ChainSpec::from_genesis` never added Paris to the hardforks list (see crates/chainspec/src/spec.rs:665-684 — Paris activation is gated on `terminal_total_difficulty.is_some()`, NOT on the similarly-named `terminalTotalDifficultyPassed`). With Paris never active, `calc::base_block_reward` returned Some(2 ETH) for every block, and the post-block balance increment in parallel_execute.rs added 2 ETH to each proposer on top of gas fees — breaking Gravity's deflationary invariant that all rewards must come solely from gas fees.

The misleading part is that `terminalTotalDifficultyPassed: false` was already set, which looks like an explicit "pre-merge" toggle. But reth only uses that field as an OUTPUT in admin_nodeInfo (see crates/rpc/rpc/src/admin.rs:114-119); it has no input semantics. Setting it to false silently did nothing.

Fix:
- Add `terminalTotalDifficulty: 0` (the actual fix that makes reth treat this chain as post-merge from block 0).
- Flip `terminalTotalDifficultyPassed` to true to keep the two fields semantically paired for tooling that DOES read it (geth, indexers).

A complementary defensive patch lives in https://github.com/Galxe/gravity-reth/pull/293 that hard-disables PoW rewards in the executor regardless of chainspec. That patch is intentionally kept as defense-in-depth: "no block rewards" is a consensus-critical invariant for Gravity and must not depend on a single chainspec field being correct. This commit fixes the upstream cause; the executor patch fixes the safety floor.

DAO fork fields are intentionally NOT touched in this commit — they map to a no-op in Gravity (the DAO branch in parallel_execute.rs only fires at transitions_at_block(0), and block 0 is genesis which never executes through the EVM), and removing them would expand the diff beyond the bug fix.