### PR TITLE
fix(verify): fix unbound variable and access-control false negatives in hardfork smoke tests

### DIFF
--- a/scripts/verify_hardfork/hardforks/epsilon.sh
+++ b/scripts/verify_hardfork/hardforks/epsilon.sh
@@ -61,15 +61,20 @@ run_smoke_tests() {
     echo "--- ValidatorManagement (PR #56) ---"
     # No new public getters; codehash check is the primary signal. The function
     # signature itself must still resolve so its selector is in the dispatcher.
-    check_exists  "evictUnderperformingValidators() ABI"  "$VALIDATOR_MANAGER" "evictUnderperformingValidators()"
+    # evictUnderperformingValidators() requires caller == Reconfiguration (requireAllowed),
+    # so we use --from to impersonate the allowed caller; the call may still revert
+    # due to state (e.g. epoch <= 1), but a NotAllowed revert means the selector exists.
+    check_exists  "evictUnderperformingValidators() ABI"  "$VALIDATOR_MANAGER" "evictUnderperformingValidators()" --from "$RECONFIGURATION"
     check_exists  "getActiveValidatorCount()"             "$VALIDATOR_MANAGER" "getActiveValidatorCount()(uint256)"
     echo ""
 
     echo "--- Reconfiguration (PR #63) ---"
     # Call sites moved but ABI unchanged; ensure dispatcher still has both entry points.
+    # checkAndStartTransition() requires caller == Blocker; governanceReconfigure() requires
+    # caller == Governance. Use --from to satisfy requireAllowed access control.
     check_exists  "currentEpoch()"                        "$RECONFIGURATION" "currentEpoch()(uint64)"
-    check_exists  "checkAndStartTransition() ABI"         "$RECONFIGURATION" "checkAndStartTransition()"
-    check_exists  "governanceReconfigure() ABI"           "$RECONFIGURATION" "governanceReconfigure()"
+    check_exists  "checkAndStartTransition() ABI"         "$RECONFIGURATION" "checkAndStartTransition()" --from "$BLOCKER"
+    check_exists  "governanceReconfigure() ABI"           "$RECONFIGURATION" "governanceReconfigure()" --from "$GOVERNANCE"
     echo ""
 
     echo "--- GBridgeReceiver (PR #66) ---"

--- a/scripts/verify_hardfork/lib/helpers.sh
+++ b/scripts/verify_hardfork/lib/helpers.sh
@@ -43,7 +43,7 @@ check_call() {
     shift 4
     local args=("$@")
 
-    result=$(cast call "$addr" "$sig" "${args[@]}" --rpc-url "$RPC_URL" 2>/dev/null || echo "REVERT")
+    result=$(cast call "$addr" "$sig" ${args[@]+"${args[@]}"} --rpc-url "$RPC_URL" 2>/dev/null || echo "REVERT")
 
     if [ "$result" = "REVERT" ]; then
         fail "${label}: call reverted"
@@ -69,7 +69,7 @@ check_reverts() {
     shift 3
     local args=("$@")
 
-    result=$(cast call "$addr" "$sig" "${args[@]}" --rpc-url "$RPC_URL" 2>&1 || true)
+    result=$(cast call "$addr" "$sig" ${args[@]+"${args[@]}"} --rpc-url "$RPC_URL" 2>&1 || true)
 
     if echo "$result" | grep -qi "revert\|error\|execution reverted"; then
         pass "${label}: correctly reverts"
@@ -87,7 +87,7 @@ check_exists() {
     shift 3
     local args=("$@")
 
-    result=$(cast call "$addr" "$sig" "${args[@]}" --rpc-url "$RPC_URL" 2>/dev/null || echo "REVERT")
+    result=$(cast call "$addr" "$sig" ${args[@]+"${args[@]}"} --rpc-url "$RPC_URL" 2>/dev/null || echo "REVERT")
 
     if [ "$result" = "REVERT" ]; then
         fail "${label}: call reverted (function may not exist)"


### PR DESCRIPTION
## Summary

- **Fix `set -u` crash in helpers.sh**: `check_call`, `check_reverts`, and `check_exists` used `${args[@]}` which triggers an `unbound variable` error when no extra args are passed. Replaced with `${args[@]+"${args[@]}"}` for safe empty-array expansion.
- **Fix false negatives in Epsilon smoke tests**: Three access-controlled functions (`evictUnderperformingValidators`, `checkAndStartTransition`, `governanceReconfigure`) were reported as "function may not exist" because bare `cast call` (sender `0x0`) hits `requireAllowed` before any logic runs. Added `--from <allowed_caller>` so the check correctly distinguishes "selector missing" from "access denied".

## Changes

| File | Change |
|------|--------|
| `lib/helpers.sh` | `${args[@]}` → `${args[@]+"${args[@]}"}` in 3 functions |
| `hardforks/epsilon.sh` | `--from $RECONFIGURATION` / `$BLOCKER` / `$GOVERNANCE` for restricted functions |

## Test plan

- [x] `bash scripts/verify_hardfork/verify.sh epsilon http://127.0.0.1:8545` — all 17 checks pass (14→17 ✅, 3→0 ❌)

🤖 Generated with [Claude Code](https://claude.com/claude-code)