### PR TITLE
fix(staking): 2-step timelock for StakePool role changes (#251, #259)

### DIFF
--- a/src/foundation/Errors.sol
+++ b/src/foundation/Errors.sol
@@ -535,6 +535,32 @@ library Errors {
     error JWKProviderIndexOutOfBounds(uint256 index, uint256 count);
 
     // ========================================================================
+    // ROLE CHANGE ERRORS
+    // ========================================================================
+
+    /// @notice Role change delay is below the minimum allowed
+    /// @param provided Delay provided (seconds)
+    /// @param minimum Minimum allowed delay (seconds)
+    error RoleChangeDelayTooShort(uint64 provided, uint64 minimum);
+
+    /// @notice Role change has not reached the required delay
+    /// @param effectiveAt When the role change becomes effective (timestamp)
+    /// @param currentTime Current block timestamp
+    error RoleChangeTooEarly(uint64 effectiveAt, uint64 currentTime);
+
+    /// @notice Caller is not the pending role recipient
+    /// @param caller Actual caller address
+    /// @param expected Expected pending role address
+    error NotPendingRole(address caller, address expected);
+
+    /// @notice Cannot change staker while there are unclaimed pending withdrawals
+    /// @param pendingAmount Total unclaimed pending withdrawal amount
+    error HasPendingWithdrawals(uint256 pendingAmount);
+
+    /// @notice No pending role change to accept or cancel
+    error NoPendingRoleChange();
+
+    // ========================================================================
     // GENERAL ERRORS
     // ========================================================================
 

--- a/src/foundation/Errors.sol
+++ b/src/foundation/Errors.sol
@@ -560,6 +560,9 @@ library Errors {
     /// @notice No pending role change to accept or cancel
     error NoPendingRoleChange();
 
+    /// @notice Proposed role address is the same as the current holder
+    error RoleAlreadySet();
+
     // ========================================================================
     // GENERAL ERRORS
     // ========================================================================

--- a/src/staking/IStakePool.sol
+++ b/src/staking/IStakePool.sol
@@ -86,11 +86,12 @@ interface IStakePool {
     /// @param role The role whose change was cancelled
     event RoleChangeCancelled(address indexed pool, string role);
 
-    /// @notice Emitted when the role change delay is updated
+    /// @notice Emitted when a per-role change delay is updated
     /// @param pool Address of this pool
+    /// @param role The role whose delay was changed ("staker", "operator", or "voter")
     /// @param oldDelay Previous delay in seconds
     /// @param newDelay New delay in seconds
-    event RoleChangeDelayUpdated(address indexed pool, uint64 oldDelay, uint64 newDelay);
+    event RoleChangeDelayUpdated(address indexed pool, string role, uint64 oldDelay, uint64 newDelay);
 
 
     /// @notice Emitted when rewards are withdrawn
@@ -232,12 +233,20 @@ interface IStakePool {
     /// @dev Only callable by owner
     function cancelVoterChange() external;
 
-    /// @notice Update the role change delay
+    /// @notice Update the staker role change delay
     /// @dev Only callable by owner. Cannot be set below MIN_ROLE_CHANGE_DELAY.
     /// @param newDelay New delay in seconds
-    function setRoleChangeDelay(
-        uint64 newDelay
-    ) external;
+    function setStakerChangeDelay(uint64 newDelay) external;
+
+    /// @notice Update the operator role change delay
+    /// @dev Only callable by owner. Cannot be set below MIN_ROLE_CHANGE_DELAY.
+    /// @param newDelay New delay in seconds
+    function setOperatorChangeDelay(uint64 newDelay) external;
+
+    /// @notice Update the voter role change delay
+    /// @dev Only callable by owner. Cannot be set below MIN_ROLE_CHANGE_DELAY.
+    /// @param newDelay New delay in seconds
+    function setVoterChangeDelay(uint64 newDelay) external;
 
 
     // ========================================================================

--- a/src/staking/IStakePool.sol
+++ b/src/staking/IStakePool.sol
@@ -93,7 +93,6 @@ interface IStakePool {
     /// @param newDelay New delay in seconds
     event RoleChangeDelayUpdated(address indexed pool, string role, uint64 oldDelay, uint64 newDelay);
 
-
     /// @notice Emitted when rewards are withdrawn
     /// @param pool Address of this pool
     /// @param amount Amount of rewards withdrawn
@@ -236,18 +235,23 @@ interface IStakePool {
     /// @notice Update the staker role change delay
     /// @dev Only callable by owner. Cannot be set below MIN_ROLE_CHANGE_DELAY.
     /// @param newDelay New delay in seconds
-    function setStakerChangeDelay(uint64 newDelay) external;
+    function setStakerChangeDelay(
+        uint64 newDelay
+    ) external;
 
     /// @notice Update the operator role change delay
     /// @dev Only callable by owner. Cannot be set below MIN_ROLE_CHANGE_DELAY.
     /// @param newDelay New delay in seconds
-    function setOperatorChangeDelay(uint64 newDelay) external;
+    function setOperatorChangeDelay(
+        uint64 newDelay
+    ) external;
 
     /// @notice Update the voter role change delay
     /// @dev Only callable by owner. Cannot be set below MIN_ROLE_CHANGE_DELAY.
     /// @param newDelay New delay in seconds
-    function setVoterChangeDelay(uint64 newDelay) external;
-
+    function setVoterChangeDelay(
+        uint64 newDelay
+    ) external;
 
     // ========================================================================
     // STAKER FUNCTIONS

--- a/src/staking/IStakePool.sol
+++ b/src/staking/IStakePool.sol
@@ -16,6 +16,17 @@ pragma solidity ^0.8.30;
 ///      - All operations are O(log n) using prefix-sum buckets with binary search
 interface IStakePool {
     // ========================================================================
+    // ENUMS
+    // ========================================================================
+
+    /// @notice Role identifier for role-change events and helpers
+    enum Role {
+        Staker,
+        Operator,
+        Voter
+    }
+
+    // ========================================================================
     // STRUCTS
     // ========================================================================
 
@@ -76,22 +87,22 @@ interface IStakePool {
 
     /// @notice Emitted when a role change is proposed
     /// @param pool Address of this pool
-    /// @param role The role being changed ("staker", "operator", or "voter")
+    /// @param role The role being changed
     /// @param newAddress Proposed new address for the role
     /// @param effectiveAt Timestamp when the change can be accepted
-    event RoleChangeProposed(address indexed pool, string role, address indexed newAddress, uint64 effectiveAt);
+    event RoleChangeProposed(address indexed pool, Role indexed role, address indexed newAddress, uint64 effectiveAt);
 
     /// @notice Emitted when a pending role change is cancelled
     /// @param pool Address of this pool
     /// @param role The role whose change was cancelled
-    event RoleChangeCancelled(address indexed pool, string role);
+    event RoleChangeCancelled(address indexed pool, Role indexed role);
 
     /// @notice Emitted when a per-role change delay is updated
     /// @param pool Address of this pool
-    /// @param role The role whose delay was changed ("staker", "operator", or "voter")
+    /// @param role The role whose delay was changed
     /// @param oldDelay Previous delay in seconds
     /// @param newDelay New delay in seconds
-    event RoleChangeDelayUpdated(address indexed pool, string role, uint64 oldDelay, uint64 newDelay);
+    event RoleChangeDelayUpdated(address indexed pool, Role indexed role, uint64 oldDelay, uint64 newDelay);
 
     /// @notice Emitted when rewards are withdrawn
     /// @param pool Address of this pool

--- a/src/staking/IStakePool.sol
+++ b/src/staking/IStakePool.sol
@@ -92,6 +92,7 @@ interface IStakePool {
     /// @param newDelay New delay in seconds
     event RoleChangeDelayUpdated(address indexed pool, uint64 oldDelay, uint64 newDelay);
 
+
     /// @notice Emitted when rewards are withdrawn
     /// @param pool Address of this pool
     /// @param amount Amount of rewards withdrawn
@@ -237,6 +238,7 @@ interface IStakePool {
     function setRoleChangeDelay(
         uint64 newDelay
     ) external;
+
 
     // ========================================================================
     // STAKER FUNCTIONS

--- a/src/staking/IStakePool.sol
+++ b/src/staking/IStakePool.sol
@@ -74,6 +74,24 @@ interface IStakePool {
     /// @param newStaker New staker address
     event StakerChanged(address indexed pool, address oldStaker, address newStaker);
 
+    /// @notice Emitted when a role change is proposed
+    /// @param pool Address of this pool
+    /// @param role The role being changed ("staker", "operator", or "voter")
+    /// @param newAddress Proposed new address for the role
+    /// @param effectiveAt Timestamp when the change can be accepted
+    event RoleChangeProposed(address indexed pool, string role, address indexed newAddress, uint64 effectiveAt);
+
+    /// @notice Emitted when a pending role change is cancelled
+    /// @param pool Address of this pool
+    /// @param role The role whose change was cancelled
+    event RoleChangeCancelled(address indexed pool, string role);
+
+    /// @notice Emitted when the role change delay is updated
+    /// @param pool Address of this pool
+    /// @param oldDelay Previous delay in seconds
+    /// @param newDelay New delay in seconds
+    event RoleChangeDelayUpdated(address indexed pool, uint64 oldDelay, uint64 newDelay);
+
     /// @notice Emitted when rewards are withdrawn
     /// @param pool Address of this pool
     /// @param amount Amount of rewards withdrawn
@@ -167,26 +185,50 @@ interface IStakePool {
     // OWNER FUNCTIONS (via Ownable2Step)
     // ========================================================================
 
-    /// @notice Change the operator address
-    /// @dev Only callable by owner
-    /// @param newOperator New operator address
-    function setOperator(
-        address newOperator
-    ) external;
+    /// @notice Propose a new staker address (starts timelock)
+    /// @dev Only callable by owner. The new staker must call acceptStaker() after the delay.
+    /// @param newStaker Proposed new staker address
+    function proposeStaker(address newStaker) external;
 
-    /// @notice Change the delegated voter address
-    /// @dev Only callable by owner
-    /// @param newVoter New voter address
-    function setVoter(
-        address newVoter
-    ) external;
+    /// @notice Accept the pending staker role change
+    /// @dev Only callable by the pending staker, after the timelock delay has elapsed.
+    ///      Reverts if there are unclaimed pending withdrawals (protects old staker's funds).
+    function acceptStaker() external;
 
-    /// @notice Change the staker address
+    /// @notice Cancel the pending staker change
     /// @dev Only callable by owner
-    /// @param newStaker New staker address
-    function setStaker(
-        address newStaker
-    ) external;
+    function cancelStakerChange() external;
+
+    /// @notice Propose a new operator address (starts timelock)
+    /// @dev Only callable by owner. The new operator must call acceptOperator() after the delay.
+    /// @param newOperator Proposed new operator address
+    function proposeOperator(address newOperator) external;
+
+    /// @notice Accept the pending operator role change
+    /// @dev Only callable by the pending operator, after the timelock delay has elapsed.
+    function acceptOperator() external;
+
+    /// @notice Cancel the pending operator change
+    /// @dev Only callable by owner
+    function cancelOperatorChange() external;
+
+    /// @notice Propose a new voter address (starts timelock)
+    /// @dev Only callable by owner. The new voter must call acceptVoter() after the delay.
+    /// @param newVoter Proposed new voter address
+    function proposeVoter(address newVoter) external;
+
+    /// @notice Accept the pending voter role change
+    /// @dev Only callable by the pending voter, after the timelock delay has elapsed.
+    function acceptVoter() external;
+
+    /// @notice Cancel the pending voter change
+    /// @dev Only callable by owner
+    function cancelVoterChange() external;
+
+    /// @notice Update the role change delay
+    /// @dev Only callable by owner. Cannot be set below MIN_ROLE_CHANGE_DELAY.
+    /// @param newDelay New delay in seconds
+    function setRoleChangeDelay(uint64 newDelay) external;
 
     // ========================================================================
     // STAKER FUNCTIONS

--- a/src/staking/IStakePool.sol
+++ b/src/staking/IStakePool.sol
@@ -188,7 +188,9 @@ interface IStakePool {
     /// @notice Propose a new staker address (starts timelock)
     /// @dev Only callable by owner. The new staker must call acceptStaker() after the delay.
     /// @param newStaker Proposed new staker address
-    function proposeStaker(address newStaker) external;
+    function proposeStaker(
+        address newStaker
+    ) external;
 
     /// @notice Accept the pending staker role change
     /// @dev Only callable by the pending staker, after the timelock delay has elapsed.
@@ -202,7 +204,9 @@ interface IStakePool {
     /// @notice Propose a new operator address (starts timelock)
     /// @dev Only callable by owner. The new operator must call acceptOperator() after the delay.
     /// @param newOperator Proposed new operator address
-    function proposeOperator(address newOperator) external;
+    function proposeOperator(
+        address newOperator
+    ) external;
 
     /// @notice Accept the pending operator role change
     /// @dev Only callable by the pending operator, after the timelock delay has elapsed.
@@ -215,7 +219,9 @@ interface IStakePool {
     /// @notice Propose a new voter address (starts timelock)
     /// @dev Only callable by owner. The new voter must call acceptVoter() after the delay.
     /// @param newVoter Proposed new voter address
-    function proposeVoter(address newVoter) external;
+    function proposeVoter(
+        address newVoter
+    ) external;
 
     /// @notice Accept the pending voter role change
     /// @dev Only callable by the pending voter, after the timelock delay has elapsed.
@@ -228,7 +234,9 @@ interface IStakePool {
     /// @notice Update the role change delay
     /// @dev Only callable by owner. Cannot be set below MIN_ROLE_CHANGE_DELAY.
     /// @param newDelay New delay in seconds
-    function setRoleChangeDelay(uint64 newDelay) external;
+    function setRoleChangeDelay(
+        uint64 newDelay
+    ) external;
 
     // ========================================================================
     // STAKER FUNCTIONS

--- a/src/staking/StakePool.sol
+++ b/src/staking/StakePool.sol
@@ -74,9 +74,6 @@ contract StakePool is IStakePool, Ownable2Step, ReentrancyGuard {
     /// @dev Acts as a claim pointer - no need to delete buckets
     uint256 public claimedAmount;
 
-    /// @notice Configurable delay for role changes (seconds)
-    uint64 public roleChangeDelay;
-
     /// @notice Pending staker role change
     address public pendingStaker;
     uint64 public stakerChangeAt;
@@ -88,6 +85,11 @@ contract StakePool is IStakePool, Ownable2Step, ReentrancyGuard {
     /// @notice Pending voter role change
     address public pendingVoter;
     uint64 public voterChangeAt;
+
+    /// @notice Per-role configurable delays (seconds)
+    uint64 public stakerChangeDelay;
+    uint64 public operatorChangeDelay;
+    uint64 public voterChangeDelay;
 
     // ========================================================================
     // MODIFIERS
@@ -153,7 +155,9 @@ contract StakePool is IStakePool, Ownable2Step, ReentrancyGuard {
         voter = _voter;
         lockedUntil = _lockedUntil;
         activeStake = msg.value;
-        roleChangeDelay = MIN_ROLE_CHANGE_DELAY;
+        stakerChangeDelay = MIN_ROLE_CHANGE_DELAY;
+        operatorChangeDelay = MIN_ROLE_CHANGE_DELAY;
+        voterChangeDelay = MIN_ROLE_CHANGE_DELAY;
 
         emit StakeAdded(address(this), msg.value);
     }
@@ -268,7 +272,7 @@ contract StakePool is IStakePool, Ownable2Step, ReentrancyGuard {
         address newStaker
     ) external onlyOwner {
         if (newStaker == address(0)) revert Errors.ZeroAddress();
-        uint64 effectiveAt = uint64(block.timestamp) + roleChangeDelay;
+        uint64 effectiveAt = uint64(block.timestamp) + stakerChangeDelay;
         pendingStaker = newStaker;
         stakerChangeAt = effectiveAt;
         emit RoleChangeProposed(address(this), "staker", newStaker, effectiveAt);
@@ -308,7 +312,7 @@ contract StakePool is IStakePool, Ownable2Step, ReentrancyGuard {
         address newOperator
     ) external onlyOwner {
         if (newOperator == address(0)) revert Errors.ZeroAddress();
-        uint64 effectiveAt = uint64(block.timestamp) + roleChangeDelay;
+        uint64 effectiveAt = uint64(block.timestamp) + operatorChangeDelay;
         pendingOperator = newOperator;
         operatorChangeAt = effectiveAt;
         emit RoleChangeProposed(address(this), "operator", newOperator, effectiveAt);
@@ -344,7 +348,7 @@ contract StakePool is IStakePool, Ownable2Step, ReentrancyGuard {
         address newVoter
     ) external onlyOwner {
         if (newVoter == address(0)) revert Errors.ZeroAddress();
-        uint64 effectiveAt = uint64(block.timestamp) + roleChangeDelay;
+        uint64 effectiveAt = uint64(block.timestamp) + voterChangeDelay;
         pendingVoter = newVoter;
         voterChangeAt = effectiveAt;
         emit RoleChangeProposed(address(this), "voter", newVoter, effectiveAt);
@@ -374,13 +378,27 @@ contract StakePool is IStakePool, Ownable2Step, ReentrancyGuard {
     // ── Role change delay configuration ─────────────────────────────────
 
     /// @inheritdoc IStakePool
-    function setRoleChangeDelay(
-        uint64 newDelay
-    ) external onlyOwner {
+    function setStakerChangeDelay(uint64 newDelay) external onlyOwner {
         if (newDelay < MIN_ROLE_CHANGE_DELAY) revert Errors.RoleChangeDelayTooShort(newDelay, MIN_ROLE_CHANGE_DELAY);
-        uint64 oldDelay = roleChangeDelay;
-        roleChangeDelay = newDelay;
-        emit RoleChangeDelayUpdated(address(this), oldDelay, newDelay);
+        uint64 oldDelay = stakerChangeDelay;
+        stakerChangeDelay = newDelay;
+        emit RoleChangeDelayUpdated(address(this), "staker", oldDelay, newDelay);
+    }
+
+    /// @inheritdoc IStakePool
+    function setOperatorChangeDelay(uint64 newDelay) external onlyOwner {
+        if (newDelay < MIN_ROLE_CHANGE_DELAY) revert Errors.RoleChangeDelayTooShort(newDelay, MIN_ROLE_CHANGE_DELAY);
+        uint64 oldDelay = operatorChangeDelay;
+        operatorChangeDelay = newDelay;
+        emit RoleChangeDelayUpdated(address(this), "operator", oldDelay, newDelay);
+    }
+
+    /// @inheritdoc IStakePool
+    function setVoterChangeDelay(uint64 newDelay) external onlyOwner {
+        if (newDelay < MIN_ROLE_CHANGE_DELAY) revert Errors.RoleChangeDelayTooShort(newDelay, MIN_ROLE_CHANGE_DELAY);
+        uint64 oldDelay = voterChangeDelay;
+        voterChangeDelay = newDelay;
+        emit RoleChangeDelayUpdated(address(this), "voter", oldDelay, newDelay);
     }
 
     // ========================================================================

--- a/src/staking/StakePool.sol
+++ b/src/staking/StakePool.sol
@@ -271,20 +271,16 @@ contract StakePool is IStakePool, Ownable2Step, ReentrancyGuard {
     function proposeStaker(
         address newStaker
     ) external onlyOwner {
-        if (newStaker == address(0)) revert Errors.ZeroAddress();
-        uint64 effectiveAt = uint64(block.timestamp) + stakerChangeDelay;
+        if (newStaker == staker) revert Errors.RoleAlreadySet();
+        uint64 effectiveAt = _validateProposal(newStaker, pendingStaker, stakerChangeDelay, Role.Staker);
         pendingStaker = newStaker;
         stakerChangeAt = effectiveAt;
-        emit RoleChangeProposed(address(this), "staker", newStaker, effectiveAt);
+        emit RoleChangeProposed(address(this), Role.Staker, newStaker, effectiveAt);
     }
 
     /// @inheritdoc IStakePool
     function acceptStaker() external {
-        if (pendingStaker == address(0)) revert Errors.NoPendingRoleChange();
-        if (msg.sender != pendingStaker) revert Errors.NotPendingRole(msg.sender, pendingStaker);
-        if (block.timestamp < stakerChangeAt) {
-            revert Errors.RoleChangeTooEarly(stakerChangeAt, uint64(block.timestamp));
-        }
+        _validateAccept(pendingStaker, stakerChangeAt);
 
         // Guard: no unclaimed pending withdrawals from the old staker
         uint256 totalPending = _totalPendingAmount();
@@ -302,7 +298,7 @@ contract StakePool is IStakePool, Ownable2Step, ReentrancyGuard {
         if (pendingStaker == address(0)) revert Errors.NoPendingRoleChange();
         pendingStaker = address(0);
         stakerChangeAt = 0;
-        emit RoleChangeCancelled(address(this), "staker");
+        emit RoleChangeCancelled(address(this), Role.Staker);
     }
 
     // ── Operator role change (2-step + timelock) ────────────────────────
@@ -311,20 +307,16 @@ contract StakePool is IStakePool, Ownable2Step, ReentrancyGuard {
     function proposeOperator(
         address newOperator
     ) external onlyOwner {
-        if (newOperator == address(0)) revert Errors.ZeroAddress();
-        uint64 effectiveAt = uint64(block.timestamp) + operatorChangeDelay;
+        if (newOperator == operator) revert Errors.RoleAlreadySet();
+        uint64 effectiveAt = _validateProposal(newOperator, pendingOperator, operatorChangeDelay, Role.Operator);
         pendingOperator = newOperator;
         operatorChangeAt = effectiveAt;
-        emit RoleChangeProposed(address(this), "operator", newOperator, effectiveAt);
+        emit RoleChangeProposed(address(this), Role.Operator, newOperator, effectiveAt);
     }
 
     /// @inheritdoc IStakePool
     function acceptOperator() external {
-        if (pendingOperator == address(0)) revert Errors.NoPendingRoleChange();
-        if (msg.sender != pendingOperator) revert Errors.NotPendingRole(msg.sender, pendingOperator);
-        if (block.timestamp < operatorChangeAt) {
-            revert Errors.RoleChangeTooEarly(operatorChangeAt, uint64(block.timestamp));
-        }
+        _validateAccept(pendingOperator, operatorChangeAt);
 
         address oldOperator = operator;
         operator = pendingOperator;
@@ -338,7 +330,7 @@ contract StakePool is IStakePool, Ownable2Step, ReentrancyGuard {
         if (pendingOperator == address(0)) revert Errors.NoPendingRoleChange();
         pendingOperator = address(0);
         operatorChangeAt = 0;
-        emit RoleChangeCancelled(address(this), "operator");
+        emit RoleChangeCancelled(address(this), Role.Operator);
     }
 
     // ── Voter role change (2-step + timelock) ───────────────────────────
@@ -347,18 +339,16 @@ contract StakePool is IStakePool, Ownable2Step, ReentrancyGuard {
     function proposeVoter(
         address newVoter
     ) external onlyOwner {
-        if (newVoter == address(0)) revert Errors.ZeroAddress();
-        uint64 effectiveAt = uint64(block.timestamp) + voterChangeDelay;
+        if (newVoter == voter) revert Errors.RoleAlreadySet();
+        uint64 effectiveAt = _validateProposal(newVoter, pendingVoter, voterChangeDelay, Role.Voter);
         pendingVoter = newVoter;
         voterChangeAt = effectiveAt;
-        emit RoleChangeProposed(address(this), "voter", newVoter, effectiveAt);
+        emit RoleChangeProposed(address(this), Role.Voter, newVoter, effectiveAt);
     }
 
     /// @inheritdoc IStakePool
     function acceptVoter() external {
-        if (pendingVoter == address(0)) revert Errors.NoPendingRoleChange();
-        if (msg.sender != pendingVoter) revert Errors.NotPendingRole(msg.sender, pendingVoter);
-        if (block.timestamp < voterChangeAt) revert Errors.RoleChangeTooEarly(voterChangeAt, uint64(block.timestamp));
+        _validateAccept(pendingVoter, voterChangeAt);
 
         address oldVoter = voter;
         voter = pendingVoter;
@@ -372,7 +362,7 @@ contract StakePool is IStakePool, Ownable2Step, ReentrancyGuard {
         if (pendingVoter == address(0)) revert Errors.NoPendingRoleChange();
         pendingVoter = address(0);
         voterChangeAt = 0;
-        emit RoleChangeCancelled(address(this), "voter");
+        emit RoleChangeCancelled(address(this), Role.Voter);
     }
 
     // ── Role change delay configuration ─────────────────────────────────
@@ -384,7 +374,7 @@ contract StakePool is IStakePool, Ownable2Step, ReentrancyGuard {
         if (newDelay < MIN_ROLE_CHANGE_DELAY) revert Errors.RoleChangeDelayTooShort(newDelay, MIN_ROLE_CHANGE_DELAY);
         uint64 oldDelay = stakerChangeDelay;
         stakerChangeDelay = newDelay;
-        emit RoleChangeDelayUpdated(address(this), "staker", oldDelay, newDelay);
+        emit RoleChangeDelayUpdated(address(this), Role.Staker, oldDelay, newDelay);
     }
 
     /// @inheritdoc IStakePool
@@ -394,7 +384,7 @@ contract StakePool is IStakePool, Ownable2Step, ReentrancyGuard {
         if (newDelay < MIN_ROLE_CHANGE_DELAY) revert Errors.RoleChangeDelayTooShort(newDelay, MIN_ROLE_CHANGE_DELAY);
         uint64 oldDelay = operatorChangeDelay;
         operatorChangeDelay = newDelay;
-        emit RoleChangeDelayUpdated(address(this), "operator", oldDelay, newDelay);
+        emit RoleChangeDelayUpdated(address(this), Role.Operator, oldDelay, newDelay);
     }
 
     /// @inheritdoc IStakePool
@@ -404,7 +394,7 @@ contract StakePool is IStakePool, Ownable2Step, ReentrancyGuard {
         if (newDelay < MIN_ROLE_CHANGE_DELAY) revert Errors.RoleChangeDelayTooShort(newDelay, MIN_ROLE_CHANGE_DELAY);
         uint64 oldDelay = voterChangeDelay;
         voterChangeDelay = newDelay;
-        emit RoleChangeDelayUpdated(address(this), "voter", oldDelay, newDelay);
+        emit RoleChangeDelayUpdated(address(this), Role.Voter, oldDelay, newDelay);
     }
 
     // ========================================================================
@@ -530,6 +520,42 @@ contract StakePool is IStakePool, Ownable2Step, ReentrancyGuard {
     // ========================================================================
     // INTERNAL FUNCTIONS
     // ========================================================================
+
+    /// @notice Returns the effective delay, treating 0 as MIN_ROLE_CHANGE_DELAY.
+    /// @dev On hardfork-upgraded pools the constructor does not run, so delay slots
+    ///      remain at 0.  This lazy default ensures the timelock is always enforced
+    ///      without requiring a state-patching step in the fork's apply function.
+    function _effectiveDelay(
+        uint64 delay
+    ) internal pure returns (uint64) {
+        return delay == 0 ? MIN_ROLE_CHANGE_DELAY : delay;
+    }
+
+    /// @notice Shared validation for propose* functions.
+    /// @dev Reverts on zero address.  If a prior proposal exists for this role,
+    ///      emits RoleChangeCancelled before the caller emits the new proposal.
+    /// @return effectiveAt Timestamp when the role change can be accepted
+    function _validateProposal(
+        address newAddress,
+        address currentPending,
+        uint64 delay,
+        Role role
+    ) internal returns (uint64 effectiveAt) {
+        if (newAddress == address(0)) revert Errors.ZeroAddress();
+        if (currentPending != address(0)) {
+            emit RoleChangeCancelled(address(this), role);
+        }
+        effectiveAt = uint64(block.timestamp) + _effectiveDelay(delay);
+    }
+
+    /// @notice Shared validation for accept* functions.
+    function _validateAccept(address pendingAddr, uint64 changeAt) internal view {
+        if (pendingAddr == address(0)) revert Errors.NoPendingRoleChange();
+        if (msg.sender != pendingAddr) revert Errors.NotPendingRole(msg.sender, pendingAddr);
+        if (block.timestamp < changeAt) {
+            revert Errors.RoleChangeTooEarly(changeAt, uint64(block.timestamp));
+        }
+    }
 
     /// @notice Get the total cumulative pending amount (before subtracting claimed)
     /// @return Total cumulative pending amount

--- a/src/staking/StakePool.sol
+++ b/src/staking/StakePool.sol
@@ -264,7 +264,9 @@ contract StakePool is IStakePool, Ownable2Step, ReentrancyGuard {
     // ── Staker role change (2-step + timelock + pending withdrawal guard) ──
 
     /// @inheritdoc IStakePool
-    function proposeStaker(address newStaker) external onlyOwner {
+    function proposeStaker(
+        address newStaker
+    ) external onlyOwner {
         if (newStaker == address(0)) revert Errors.ZeroAddress();
         uint64 effectiveAt = uint64(block.timestamp) + roleChangeDelay;
         pendingStaker = newStaker;
@@ -276,7 +278,9 @@ contract StakePool is IStakePool, Ownable2Step, ReentrancyGuard {
     function acceptStaker() external {
         if (pendingStaker == address(0)) revert Errors.NoPendingRoleChange();
         if (msg.sender != pendingStaker) revert Errors.NotPendingRole(msg.sender, pendingStaker);
-        if (block.timestamp < stakerChangeAt) revert Errors.RoleChangeTooEarly(stakerChangeAt, uint64(block.timestamp));
+        if (block.timestamp < stakerChangeAt) {
+            revert Errors.RoleChangeTooEarly(stakerChangeAt, uint64(block.timestamp));
+        }
 
         // Guard: no unclaimed pending withdrawals from the old staker
         uint256 totalPending = _totalPendingAmount();
@@ -300,7 +304,9 @@ contract StakePool is IStakePool, Ownable2Step, ReentrancyGuard {
     // ── Operator role change (2-step + timelock) ────────────────────────
 
     /// @inheritdoc IStakePool
-    function proposeOperator(address newOperator) external onlyOwner {
+    function proposeOperator(
+        address newOperator
+    ) external onlyOwner {
         if (newOperator == address(0)) revert Errors.ZeroAddress();
         uint64 effectiveAt = uint64(block.timestamp) + roleChangeDelay;
         pendingOperator = newOperator;
@@ -312,7 +318,9 @@ contract StakePool is IStakePool, Ownable2Step, ReentrancyGuard {
     function acceptOperator() external {
         if (pendingOperator == address(0)) revert Errors.NoPendingRoleChange();
         if (msg.sender != pendingOperator) revert Errors.NotPendingRole(msg.sender, pendingOperator);
-        if (block.timestamp < operatorChangeAt) revert Errors.RoleChangeTooEarly(operatorChangeAt, uint64(block.timestamp));
+        if (block.timestamp < operatorChangeAt) {
+            revert Errors.RoleChangeTooEarly(operatorChangeAt, uint64(block.timestamp));
+        }
 
         address oldOperator = operator;
         operator = pendingOperator;
@@ -332,7 +340,9 @@ contract StakePool is IStakePool, Ownable2Step, ReentrancyGuard {
     // ── Voter role change (2-step + timelock) ───────────────────────────
 
     /// @inheritdoc IStakePool
-    function proposeVoter(address newVoter) external onlyOwner {
+    function proposeVoter(
+        address newVoter
+    ) external onlyOwner {
         if (newVoter == address(0)) revert Errors.ZeroAddress();
         uint64 effectiveAt = uint64(block.timestamp) + roleChangeDelay;
         pendingVoter = newVoter;
@@ -364,7 +374,9 @@ contract StakePool is IStakePool, Ownable2Step, ReentrancyGuard {
     // ── Role change delay configuration ─────────────────────────────────
 
     /// @inheritdoc IStakePool
-    function setRoleChangeDelay(uint64 newDelay) external onlyOwner {
+    function setRoleChangeDelay(
+        uint64 newDelay
+    ) external onlyOwner {
         if (newDelay < MIN_ROLE_CHANGE_DELAY) revert Errors.RoleChangeDelayTooShort(newDelay, MIN_ROLE_CHANGE_DELAY);
         uint64 oldDelay = roleChangeDelay;
         roleChangeDelay = newDelay;

--- a/src/staking/StakePool.sol
+++ b/src/staking/StakePool.sol
@@ -37,11 +37,8 @@ contract StakePool is IStakePool, Ownable2Step, ReentrancyGuard {
     /// @notice Maximum number of pending withdrawal buckets
     uint256 public constant MAX_PENDING_BUCKETS = 1000;
 
-    /// @notice Minimum allowed role change delay (2 days)
-    uint64 public constant MIN_ROLE_CHANGE_DELAY = 2 days;
-
-    /// @notice Default role change delay (7 days)
-    uint64 public constant DEFAULT_ROLE_CHANGE_DELAY = 7 days;
+    /// @notice Minimum allowed role change delay (cannot set roleChangeDelay below this)
+    uint64 public constant MIN_ROLE_CHANGE_DELAY = 1 days;
 
     // ========================================================================
     // IMMUTABLES
@@ -78,7 +75,7 @@ contract StakePool is IStakePool, Ownable2Step, ReentrancyGuard {
     uint256 public claimedAmount;
 
     /// @notice Configurable delay for role changes (seconds)
-    uint64 public roleChangeDelay = DEFAULT_ROLE_CHANGE_DELAY;
+    uint64 public roleChangeDelay;
 
     /// @notice Pending staker role change
     address public pendingStaker;
@@ -132,7 +129,9 @@ contract StakePool is IStakePool, Ownable2Step, ReentrancyGuard {
     /// @param _operator Operator address (for validator operations)
     /// @param _voter Voter address (for governance voting)
     /// @param _lockedUntil Initial lockup expiration (must be >= now + minLockup)
-    /// @dev Called by factory during CREATE2 deployment
+    /// @dev Called by factory during CREATE2 deployment.
+    ///      Role change delays default to DEFAULT_ROLE_CHANGE_DELAY (1 day).
+    ///      Owner can adjust via setRoleChangeDelay() / setMinRoleChangeDelay() after creation.
     constructor(
         address _owner,
         address _staker,
@@ -154,6 +153,7 @@ contract StakePool is IStakePool, Ownable2Step, ReentrancyGuard {
         voter = _voter;
         lockedUntil = _lockedUntil;
         activeStake = msg.value;
+        roleChangeDelay = MIN_ROLE_CHANGE_DELAY;
 
         emit StakeAdded(address(this), msg.value);
     }

--- a/src/staking/StakePool.sol
+++ b/src/staking/StakePool.sol
@@ -378,7 +378,9 @@ contract StakePool is IStakePool, Ownable2Step, ReentrancyGuard {
     // ── Role change delay configuration ─────────────────────────────────
 
     /// @inheritdoc IStakePool
-    function setStakerChangeDelay(uint64 newDelay) external onlyOwner {
+    function setStakerChangeDelay(
+        uint64 newDelay
+    ) external onlyOwner {
         if (newDelay < MIN_ROLE_CHANGE_DELAY) revert Errors.RoleChangeDelayTooShort(newDelay, MIN_ROLE_CHANGE_DELAY);
         uint64 oldDelay = stakerChangeDelay;
         stakerChangeDelay = newDelay;
@@ -386,7 +388,9 @@ contract StakePool is IStakePool, Ownable2Step, ReentrancyGuard {
     }
 
     /// @inheritdoc IStakePool
-    function setOperatorChangeDelay(uint64 newDelay) external onlyOwner {
+    function setOperatorChangeDelay(
+        uint64 newDelay
+    ) external onlyOwner {
         if (newDelay < MIN_ROLE_CHANGE_DELAY) revert Errors.RoleChangeDelayTooShort(newDelay, MIN_ROLE_CHANGE_DELAY);
         uint64 oldDelay = operatorChangeDelay;
         operatorChangeDelay = newDelay;
@@ -394,7 +398,9 @@ contract StakePool is IStakePool, Ownable2Step, ReentrancyGuard {
     }
 
     /// @inheritdoc IStakePool
-    function setVoterChangeDelay(uint64 newDelay) external onlyOwner {
+    function setVoterChangeDelay(
+        uint64 newDelay
+    ) external onlyOwner {
         if (newDelay < MIN_ROLE_CHANGE_DELAY) revert Errors.RoleChangeDelayTooShort(newDelay, MIN_ROLE_CHANGE_DELAY);
         uint64 oldDelay = voterChangeDelay;
         voterChangeDelay = newDelay;

--- a/src/staking/StakePool.sol
+++ b/src/staking/StakePool.sol
@@ -549,7 +549,10 @@ contract StakePool is IStakePool, Ownable2Step, ReentrancyGuard {
     }
 
     /// @notice Shared validation for accept* functions.
-    function _validateAccept(address pendingAddr, uint64 changeAt) internal view {
+    function _validateAccept(
+        address pendingAddr,
+        uint64 changeAt
+    ) internal view {
         if (pendingAddr == address(0)) revert Errors.NoPendingRoleChange();
         if (msg.sender != pendingAddr) revert Errors.NotPendingRole(msg.sender, pendingAddr);
         if (block.timestamp < changeAt) {

--- a/src/staking/StakePool.sol
+++ b/src/staking/StakePool.sol
@@ -37,6 +37,12 @@ contract StakePool is IStakePool, Ownable2Step, ReentrancyGuard {
     /// @notice Maximum number of pending withdrawal buckets
     uint256 public constant MAX_PENDING_BUCKETS = 1000;
 
+    /// @notice Minimum allowed role change delay (2 days)
+    uint64 public constant MIN_ROLE_CHANGE_DELAY = 2 days;
+
+    /// @notice Default role change delay (7 days)
+    uint64 public constant DEFAULT_ROLE_CHANGE_DELAY = 7 days;
+
     // ========================================================================
     // IMMUTABLES
     // ========================================================================
@@ -70,6 +76,21 @@ contract StakePool is IStakePool, Ownable2Step, ReentrancyGuard {
     /// @notice Cumulative amount that has been claimed from pending buckets
     /// @dev Acts as a claim pointer - no need to delete buckets
     uint256 public claimedAmount;
+
+    /// @notice Configurable delay for role changes (seconds)
+    uint64 public roleChangeDelay = DEFAULT_ROLE_CHANGE_DELAY;
+
+    /// @notice Pending staker role change
+    address public pendingStaker;
+    uint64 public stakerChangeAt;
+
+    /// @notice Pending operator role change
+    address public pendingOperator;
+    uint64 public operatorChangeAt;
+
+    /// @notice Pending voter role change
+    address public pendingVoter;
+    uint64 public voterChangeAt;
 
     // ========================================================================
     // MODIFIERS
@@ -163,11 +184,9 @@ contract StakePool is IStakePool, Ownable2Step, ReentrancyGuard {
 
     /// @inheritdoc IStakePool
     function getTotalPending() external view returns (uint256) {
-        if (_pendingBuckets.length == 0) {
-            return 0;
-        }
-        // Total pending = last bucket's cumulativeAmount - claimedAmount
-        return _pendingBuckets[_pendingBuckets.length - 1].cumulativeAmount - claimedAmount;
+        uint256 total = _totalPendingAmount();
+        if (total <= claimedAmount) return 0;
+        return total - claimedAmount;
     }
 
     /// @inheritdoc IStakePool
@@ -242,37 +261,114 @@ contract StakePool is IStakePool, Ownable2Step, ReentrancyGuard {
     // OWNER FUNCTIONS (via Ownable2Step)
     // ========================================================================
 
-    /// @inheritdoc IStakePool
-    function setOperator(
-        address newOperator
-    ) external onlyOwner {
-        if (newOperator == address(0)) revert Errors.ZeroAddress();
-        if (newOperator == operator) return; // Skip no-op
-        address oldOperator = operator;
-        operator = newOperator;
-        emit OperatorChanged(address(this), oldOperator, newOperator);
-    }
+    // ── Staker role change (2-step + timelock + pending withdrawal guard) ──
 
     /// @inheritdoc IStakePool
-    function setVoter(
-        address newVoter
-    ) external onlyOwner {
-        if (newVoter == address(0)) revert Errors.ZeroAddress();
-        if (newVoter == voter) return; // Skip no-op
-        address oldVoter = voter;
-        voter = newVoter;
-        emit VoterChanged(address(this), oldVoter, newVoter);
-    }
-
-    /// @inheritdoc IStakePool
-    function setStaker(
-        address newStaker
-    ) external onlyOwner {
+    function proposeStaker(address newStaker) external onlyOwner {
         if (newStaker == address(0)) revert Errors.ZeroAddress();
-        if (newStaker == staker) return; // Skip no-op
+        uint64 effectiveAt = uint64(block.timestamp) + roleChangeDelay;
+        pendingStaker = newStaker;
+        stakerChangeAt = effectiveAt;
+        emit RoleChangeProposed(address(this), "staker", newStaker, effectiveAt);
+    }
+
+    /// @inheritdoc IStakePool
+    function acceptStaker() external {
+        if (pendingStaker == address(0)) revert Errors.NoPendingRoleChange();
+        if (msg.sender != pendingStaker) revert Errors.NotPendingRole(msg.sender, pendingStaker);
+        if (block.timestamp < stakerChangeAt) revert Errors.RoleChangeTooEarly(stakerChangeAt, uint64(block.timestamp));
+
+        // Guard: no unclaimed pending withdrawals from the old staker
+        uint256 totalPending = _totalPendingAmount();
+        if (totalPending > claimedAmount) revert Errors.HasPendingWithdrawals(totalPending - claimedAmount);
+
         address oldStaker = staker;
-        staker = newStaker;
-        emit StakerChanged(address(this), oldStaker, newStaker);
+        staker = pendingStaker;
+        pendingStaker = address(0);
+        stakerChangeAt = 0;
+        emit StakerChanged(address(this), oldStaker, staker);
+    }
+
+    /// @inheritdoc IStakePool
+    function cancelStakerChange() external onlyOwner {
+        if (pendingStaker == address(0)) revert Errors.NoPendingRoleChange();
+        pendingStaker = address(0);
+        stakerChangeAt = 0;
+        emit RoleChangeCancelled(address(this), "staker");
+    }
+
+    // ── Operator role change (2-step + timelock) ────────────────────────
+
+    /// @inheritdoc IStakePool
+    function proposeOperator(address newOperator) external onlyOwner {
+        if (newOperator == address(0)) revert Errors.ZeroAddress();
+        uint64 effectiveAt = uint64(block.timestamp) + roleChangeDelay;
+        pendingOperator = newOperator;
+        operatorChangeAt = effectiveAt;
+        emit RoleChangeProposed(address(this), "operator", newOperator, effectiveAt);
+    }
+
+    /// @inheritdoc IStakePool
+    function acceptOperator() external {
+        if (pendingOperator == address(0)) revert Errors.NoPendingRoleChange();
+        if (msg.sender != pendingOperator) revert Errors.NotPendingRole(msg.sender, pendingOperator);
+        if (block.timestamp < operatorChangeAt) revert Errors.RoleChangeTooEarly(operatorChangeAt, uint64(block.timestamp));
+
+        address oldOperator = operator;
+        operator = pendingOperator;
+        pendingOperator = address(0);
+        operatorChangeAt = 0;
+        emit OperatorChanged(address(this), oldOperator, operator);
+    }
+
+    /// @inheritdoc IStakePool
+    function cancelOperatorChange() external onlyOwner {
+        if (pendingOperator == address(0)) revert Errors.NoPendingRoleChange();
+        pendingOperator = address(0);
+        operatorChangeAt = 0;
+        emit RoleChangeCancelled(address(this), "operator");
+    }
+
+    // ── Voter role change (2-step + timelock) ───────────────────────────
+
+    /// @inheritdoc IStakePool
+    function proposeVoter(address newVoter) external onlyOwner {
+        if (newVoter == address(0)) revert Errors.ZeroAddress();
+        uint64 effectiveAt = uint64(block.timestamp) + roleChangeDelay;
+        pendingVoter = newVoter;
+        voterChangeAt = effectiveAt;
+        emit RoleChangeProposed(address(this), "voter", newVoter, effectiveAt);
+    }
+
+    /// @inheritdoc IStakePool
+    function acceptVoter() external {
+        if (pendingVoter == address(0)) revert Errors.NoPendingRoleChange();
+        if (msg.sender != pendingVoter) revert Errors.NotPendingRole(msg.sender, pendingVoter);
+        if (block.timestamp < voterChangeAt) revert Errors.RoleChangeTooEarly(voterChangeAt, uint64(block.timestamp));
+
+        address oldVoter = voter;
+        voter = pendingVoter;
+        pendingVoter = address(0);
+        voterChangeAt = 0;
+        emit VoterChanged(address(this), oldVoter, voter);
+    }
+
+    /// @inheritdoc IStakePool
+    function cancelVoterChange() external onlyOwner {
+        if (pendingVoter == address(0)) revert Errors.NoPendingRoleChange();
+        pendingVoter = address(0);
+        voterChangeAt = 0;
+        emit RoleChangeCancelled(address(this), "voter");
+    }
+
+    // ── Role change delay configuration ─────────────────────────────────
+
+    /// @inheritdoc IStakePool
+    function setRoleChangeDelay(uint64 newDelay) external onlyOwner {
+        if (newDelay < MIN_ROLE_CHANGE_DELAY) revert Errors.RoleChangeDelayTooShort(newDelay, MIN_ROLE_CHANGE_DELAY);
+        uint64 oldDelay = roleChangeDelay;
+        roleChangeDelay = newDelay;
+        emit RoleChangeDelayUpdated(address(this), oldDelay, newDelay);
     }
 
     // ========================================================================
@@ -398,6 +494,13 @@ contract StakePool is IStakePool, Ownable2Step, ReentrancyGuard {
     // ========================================================================
     // INTERNAL FUNCTIONS
     // ========================================================================
+
+    /// @notice Get the total cumulative pending amount (before subtracting claimed)
+    /// @return Total cumulative pending amount
+    function _totalPendingAmount() internal view returns (uint256) {
+        if (_pendingBuckets.length == 0) return 0;
+        return _pendingBuckets[_pendingBuckets.length - 1].cumulativeAmount;
+    }
 
     /// @notice Internal unstake implementation
     /// @param amount Amount to unstake

--- a/test/unit/governance/Governance.t.sol
+++ b/test/unit/governance/Governance.t.sol
@@ -146,6 +146,14 @@ contract GovernanceTest is Test {
         return staking.createPool{ value: amount }(poolOwner, poolOwner, poolOwner, poolOwner, lockedUntil);
     }
 
+    function _delegateVoter(address poolOwner, address pool, address newVoter) internal {
+        vm.prank(poolOwner);
+        IStakePool(pool).proposeVoter(newVoter);
+        vm.warp(block.timestamp + 7 days);
+        vm.prank(newVoter);
+        IStakePool(pool).acceptVoter();
+    }
+
     function _computeExecutionHash(
         address target,
         bytes memory data
@@ -665,8 +673,7 @@ contract GovernanceTest is Test {
         // Alice creates pool and delegates voting to Bob
         address pool = _createStakePool(alice, 100 ether);
 
-        vm.prank(alice);
-        IStakePool(pool).setVoter(bob);
+        _delegateVoter(alice, pool, bob);
 
         (address[] memory targets, bytes[] memory datas) = _toArrays(address(mockTarget), "");
 
@@ -987,8 +994,7 @@ contract GovernanceTest is Test {
         address bobPool = _createStakePool(bob, 50 ether);
 
         // Bob delegates voting to alice so she can vote with both pools
-        vm.prank(bob);
-        IStakePool(bobPool).setVoter(alice);
+        _delegateVoter(bob, bobPool, alice);
 
         (address[] memory targets, bytes[] memory datas) = _toArrays(address(mockTarget), "");
 
@@ -1018,8 +1024,7 @@ contract GovernanceTest is Test {
         address bobPool = _createStakePool(bob, 50 ether);
 
         // Bob delegates voting to alice
-        vm.prank(bob);
-        IStakePool(bobPool).setVoter(alice);
+        _delegateVoter(bob, bobPool, alice);
 
         (address[] memory targets, bytes[] memory datas) = _toArrays(address(mockTarget), "");
 
@@ -1070,8 +1075,7 @@ contract GovernanceTest is Test {
         address bobPool = _createStakePool(bob, 50 ether);
 
         // Bob delegates voting to alice
-        vm.prank(bob);
-        IStakePool(bobPool).setVoter(alice);
+        _delegateVoter(bob, bobPool, alice);
 
         (address[] memory targets, bytes[] memory datas) = _toArrays(address(mockTarget), "");
 
@@ -1101,8 +1105,7 @@ contract GovernanceTest is Test {
         address bobPool = _createStakePool(bob, 20 ether);
 
         // Bob delegates voting to alice
-        vm.prank(bob);
-        IStakePool(bobPool).setVoter(alice);
+        _delegateVoter(bob, bobPool, alice);
 
         (address[] memory targets, bytes[] memory datas) = _toArrays(address(mockTarget), "");
 
@@ -1216,8 +1219,7 @@ contract GovernanceTest is Test {
         address bobPool = _createStakePool(bob, 50 ether);
 
         // Bob delegates voting to alice
-        vm.prank(bob);
-        IStakePool(bobPool).setVoter(alice);
+        _delegateVoter(bob, bobPool, alice);
 
         (address[] memory targets, bytes[] memory datas) = _toArrays(address(mockTarget), "");
 

--- a/test/unit/governance/Governance.t.sol
+++ b/test/unit/governance/Governance.t.sol
@@ -146,7 +146,11 @@ contract GovernanceTest is Test {
         return staking.createPool{ value: amount }(poolOwner, poolOwner, poolOwner, poolOwner, lockedUntil);
     }
 
-    function _delegateVoter(address poolOwner, address pool, address newVoter) internal {
+    function _delegateVoter(
+        address poolOwner,
+        address pool,
+        address newVoter
+    ) internal {
         vm.prank(poolOwner);
         IStakePool(pool).proposeVoter(newVoter);
         vm.warp(block.timestamp + 7 days);

--- a/test/unit/governance/Governance.t.sol
+++ b/test/unit/governance/Governance.t.sol
@@ -153,7 +153,7 @@ contract GovernanceTest is Test {
     ) internal {
         vm.prank(poolOwner);
         IStakePool(pool).proposeVoter(newVoter);
-        vm.warp(block.timestamp + 7 days);
+        vm.warp(block.timestamp + 1 days);
         vm.prank(newVoter);
         IStakePool(pool).acceptVoter();
     }

--- a/test/unit/staking/StakerSeparation.t.sol
+++ b/test/unit/staking/StakerSeparation.t.sol
@@ -115,40 +115,47 @@ contract StakerSeparationTest is Test {
         IStakePool(pool).addStake{ value: 1 ether }();
     }
 
-    function test_setStaker_OnlyOwnerSucceeds() public {
+    function test_proposeStaker_OnlyOwnerSucceeds() public {
         address pool = _createDistinctPool();
         address newStaker = makeAddr("newStaker");
 
-        // Staker cannot rotate itself
+        // Staker cannot propose
         vm.prank(stakerAddr);
         vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, stakerAddr));
-        IStakePool(pool).setStaker(newStaker);
+        IStakePool(pool).proposeStaker(newStaker);
 
-        // Operator cannot
+        // Operator cannot propose
         vm.prank(operatorAddr);
         vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, operatorAddr));
-        IStakePool(pool).setStaker(newStaker);
+        IStakePool(pool).proposeStaker(newStaker);
 
-        // Owner succeeds
+        // Owner proposes, new staker accepts after delay
         vm.prank(ownerAddr);
-        IStakePool(pool).setStaker(newStaker);
-        assertEq(IStakePool(pool).getStaker(), newStaker, "setStaker did not apply");
+        IStakePool(pool).proposeStaker(newStaker);
+        vm.warp(block.timestamp + 1 days);
+        vm.prank(newStaker);
+        IStakePool(pool).acceptStaker();
+        assertEq(IStakePool(pool).getStaker(), newStaker, "proposeStaker did not apply");
     }
 
-    function test_setOperator_OnlyOwnerSucceeds() public {
+    function test_proposeOperator_OnlyOwnerSucceeds() public {
         address pool = _createDistinctPool();
         address newOperator = makeAddr("newOperator");
 
         vm.prank(operatorAddr);
         vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, operatorAddr));
-        IStakePool(pool).setOperator(newOperator);
+        IStakePool(pool).proposeOperator(newOperator);
 
         vm.prank(stakerAddr);
         vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, stakerAddr));
-        IStakePool(pool).setOperator(newOperator);
+        IStakePool(pool).proposeOperator(newOperator);
 
+        // Owner proposes, new operator accepts after delay
         vm.prank(ownerAddr);
-        IStakePool(pool).setOperator(newOperator);
-        assertEq(IStakePool(pool).getOperator(), newOperator, "setOperator did not apply");
+        IStakePool(pool).proposeOperator(newOperator);
+        vm.warp(block.timestamp + 1 days);
+        vm.prank(newOperator);
+        IStakePool(pool).acceptOperator();
+        assertEq(IStakePool(pool).getOperator(), newOperator, "proposeOperator did not apply");
     }
 }

--- a/test/unit/staking/Staking.t.sol
+++ b/test/unit/staking/Staking.t.sol
@@ -912,8 +912,8 @@ contract StakingTest is Test {
         address pool = _createPool(alice, MIN_STAKE);
 
         vm.prank(alice);
-        vm.expectEmit(true, true, false, true);
-        emit IStakePool.RoleChangeProposed(pool, "operator", bob, uint64(block.timestamp + 1 days));
+        vm.expectEmit(true, true, true, true);
+        emit IStakePool.RoleChangeProposed(pool, IStakePool.Role.Operator, bob, uint64(block.timestamp + 1 days));
         IStakePool(pool).proposeOperator(bob);
     }
 
@@ -1089,6 +1089,117 @@ contract StakingTest is Test {
             abi.encodeWithSelector(Errors.RoleChangeDelayTooShort.selector, uint64(1 hours), uint64(1 days))
         );
         IStakePool(pool).setStakerChangeDelay(1 hours);
+    }
+
+    // ── Edge-case: propose current role holder reverts ──────────────────
+
+    function test_RevertWhen_proposeOperator_sameAsCurrent() public {
+        vm.prank(alice);
+        address pool = _createPool(alice, MIN_STAKE);
+
+        // alice is already the operator (set by _createPool)
+        vm.prank(alice);
+        vm.expectRevert(Errors.RoleAlreadySet.selector);
+        IStakePool(pool).proposeOperator(alice);
+    }
+
+    function test_RevertWhen_proposeStaker_sameAsCurrent() public {
+        vm.prank(alice);
+        address pool = _createPool(alice, MIN_STAKE);
+
+        vm.prank(alice);
+        vm.expectRevert(Errors.RoleAlreadySet.selector);
+        IStakePool(pool).proposeStaker(alice);
+    }
+
+    function test_RevertWhen_proposeVoter_sameAsCurrent() public {
+        vm.prank(alice);
+        address pool = _createPool(alice, MIN_STAKE);
+
+        vm.prank(alice);
+        vm.expectRevert(Errors.RoleAlreadySet.selector);
+        IStakePool(pool).proposeVoter(alice);
+    }
+
+    // ── Edge-case: re-propose emits cancellation then new proposal ──────
+
+    function test_repropose_emitsCancelThenPropose() public {
+        vm.prank(alice);
+        address pool = _createPool(alice, MIN_STAKE);
+
+        // First proposal
+        vm.prank(alice);
+        IStakePool(pool).proposeOperator(bob);
+
+        // Re-propose with charlie — should emit cancel for bob, then propose for charlie
+        vm.prank(alice);
+        vm.expectEmit(true, true, false, true);
+        emit IStakePool.RoleChangeCancelled(pool, IStakePool.Role.Operator);
+        vm.expectEmit(true, true, true, true);
+        emit IStakePool.RoleChangeProposed(
+            pool, IStakePool.Role.Operator, charlie, uint64(block.timestamp + 1 days)
+        );
+        IStakePool(pool).proposeOperator(charlie);
+
+        // bob can no longer accept
+        vm.warp(block.timestamp + 1 days);
+        vm.prank(bob);
+        vm.expectRevert(abi.encodeWithSelector(Errors.NotPendingRole.selector, bob, charlie));
+        IStakePool(pool).acceptOperator();
+
+        // charlie can accept
+        vm.prank(charlie);
+        IStakePool(pool).acceptOperator();
+        assertEq(IStakePool(pool).getOperator(), charlie);
+    }
+
+    // ── Edge-case: delay change does not affect in-flight proposal ──────
+
+    function test_delayChangeDoesNotAffectInflightProposal() public {
+        vm.prank(alice);
+        address pool = _createPool(alice, MIN_STAKE);
+
+        // Propose with default 1-day delay
+        uint256 proposeTime = block.timestamp;
+        vm.prank(alice);
+        IStakePool(pool).proposeOperator(bob);
+
+        // Owner increases delay to 14 days — should NOT affect the in-flight proposal
+        vm.prank(alice);
+        IStakePool(pool).setOperatorChangeDelay(14 days);
+
+        // Original 1-day delay should still work for the existing proposal
+        vm.warp(proposeTime + 1 days);
+        vm.prank(bob);
+        IStakePool(pool).acceptOperator();
+        assertEq(IStakePool(pool).getOperator(), bob);
+    }
+
+    // ── Edge-case: ownership transfer mid-proposal ──────────────────────
+
+    function test_ownershipTransferMidProposal_newOwnerCanCancel() public {
+        vm.prank(alice);
+        address pool = _createPool(alice, MIN_STAKE);
+
+        // alice proposes operator change
+        vm.prank(alice);
+        IStakePool(pool).proposeOperator(bob);
+
+        // alice transfers ownership to charlie (2-step)
+        vm.prank(alice);
+        Ownable2Step(pool).transferOwnership(charlie);
+        vm.prank(charlie);
+        Ownable2Step(pool).acceptOwnership();
+
+        // charlie (new owner) should be able to cancel the pending change
+        vm.prank(charlie);
+        IStakePool(pool).cancelOperatorChange();
+
+        // bob can no longer accept
+        vm.warp(block.timestamp + 1 days);
+        vm.prank(bob);
+        vm.expectRevert(Errors.NoPendingRoleChange.selector);
+        IStakePool(pool).acceptOperator();
     }
 
     // ========================================================================

--- a/test/unit/staking/Staking.t.sol
+++ b/test/unit/staking/Staking.t.sol
@@ -1055,12 +1055,12 @@ contract StakingTest is Test {
 
     // ── Role change delay configuration ─────────────────────────────
 
-    function test_setRoleChangeDelay() public {
+    function test_setOperatorChangeDelay() public {
         vm.prank(alice);
         address pool = _createPool(alice, MIN_STAKE);
 
         vm.prank(alice);
-        IStakePool(pool).setRoleChangeDelay(14 days);
+        IStakePool(pool).setOperatorChangeDelay(14 days);
 
         // Propose with new 14-day delay
         uint256 proposeTime = block.timestamp;
@@ -1080,7 +1080,7 @@ contract StakingTest is Test {
         assertEq(IStakePool(pool).getOperator(), bob);
     }
 
-    function test_RevertWhen_setRoleChangeDelay_belowMinimum() public {
+    function test_RevertWhen_setChangeDelay_belowMinimum() public {
         vm.prank(alice);
         address pool = _createPool(alice, MIN_STAKE);
 
@@ -1088,7 +1088,7 @@ contract StakingTest is Test {
         vm.expectRevert(
             abi.encodeWithSelector(Errors.RoleChangeDelayTooShort.selector, uint64(1 hours), uint64(1 days))
         );
-        IStakePool(pool).setRoleChangeDelay(1 hours);
+        IStakePool(pool).setStakerChangeDelay(1 hours);
     }
 
     // ========================================================================

--- a/test/unit/staking/Staking.t.sol
+++ b/test/unit/staking/Staking.t.sol
@@ -900,7 +900,7 @@ contract StakingTest is Test {
         vm.prank(alice);
         IStakePool(pool).proposeOperator(bob);
 
-        vm.warp(block.timestamp + 7 days);
+        vm.warp(block.timestamp + 1 days);
         vm.prank(bob);
         IStakePool(pool).acceptOperator();
 
@@ -913,7 +913,7 @@ contract StakingTest is Test {
 
         vm.prank(alice);
         vm.expectEmit(true, true, false, true);
-        emit IStakePool.RoleChangeProposed(pool, "operator", bob, uint64(block.timestamp + 7 days));
+        emit IStakePool.RoleChangeProposed(pool, "operator", bob, uint64(block.timestamp + 1 days));
         IStakePool(pool).proposeOperator(bob);
     }
 
@@ -924,7 +924,7 @@ contract StakingTest is Test {
         vm.prank(alice);
         IStakePool(pool).proposeOperator(bob);
 
-        vm.warp(block.timestamp + 7 days);
+        vm.warp(block.timestamp + 1 days);
         vm.prank(bob);
         vm.expectEmit(true, false, false, true);
         emit IStakePool.OperatorChanged(pool, alice, bob);
@@ -959,7 +959,7 @@ contract StakingTest is Test {
         vm.prank(alice);
         IStakePool(pool).proposeOperator(bob);
 
-        vm.warp(block.timestamp + 7 days);
+        vm.warp(block.timestamp + 1 days);
         vm.prank(charlie);
         vm.expectRevert(abi.encodeWithSelector(Errors.NotPendingRole.selector, charlie, bob));
         IStakePool(pool).acceptOperator();
@@ -976,7 +976,7 @@ contract StakingTest is Test {
         IStakePool(pool).cancelOperatorChange();
 
         // Should revert since pending was cleared
-        vm.warp(block.timestamp + 7 days);
+        vm.warp(block.timestamp + 1 days);
         vm.prank(bob);
         vm.expectRevert(Errors.NoPendingRoleChange.selector);
         IStakePool(pool).acceptOperator();
@@ -991,7 +991,7 @@ contract StakingTest is Test {
         vm.prank(alice);
         IStakePool(pool).proposeVoter(bob);
 
-        vm.warp(block.timestamp + 7 days);
+        vm.warp(block.timestamp + 1 days);
         vm.prank(bob);
         IStakePool(pool).acceptVoter();
 
@@ -1016,7 +1016,7 @@ contract StakingTest is Test {
         vm.prank(alice);
         IStakePool(pool).proposeStaker(bob);
 
-        vm.warp(block.timestamp + 7 days);
+        vm.warp(block.timestamp + 1 days);
         vm.prank(bob);
         IStakePool(pool).acceptStaker();
 
@@ -1045,7 +1045,7 @@ contract StakingTest is Test {
         IStakePool(pool).proposeStaker(bob);
 
         // Warp past delay
-        vm.warp(block.timestamp + 7 days);
+        vm.warp(block.timestamp + 1 days);
 
         // Should revert due to pending withdrawals
         vm.prank(bob);
@@ -1086,7 +1086,7 @@ contract StakingTest is Test {
 
         vm.prank(alice);
         vm.expectRevert(
-            abi.encodeWithSelector(Errors.RoleChangeDelayTooShort.selector, uint64(1 hours), uint64(2 days))
+            abi.encodeWithSelector(Errors.RoleChangeDelayTooShort.selector, uint64(1 hours), uint64(1 days))
         );
         IStakePool(pool).setRoleChangeDelay(1 hours);
     }

--- a/test/unit/staking/Staking.t.sol
+++ b/test/unit/staking/Staking.t.sol
@@ -891,91 +891,202 @@ contract StakingTest is Test {
     // STAKE POOL TESTS - Owner Functions (Role Management)
     // ========================================================================
 
-    function test_setOperator_changesOperator() public {
+    // ── Operator: propose → accept ────────────────────────────────────
+
+    function test_proposeOperator_and_acceptOperator() public {
         vm.prank(alice);
         address pool = _createPool(alice, MIN_STAKE);
 
         vm.prank(alice);
-        IStakePool(pool).setOperator(bob);
+        IStakePool(pool).proposeOperator(bob);
+
+        vm.warp(block.timestamp + 7 days);
+        vm.prank(bob);
+        IStakePool(pool).acceptOperator();
 
         assertEq(IStakePool(pool).getOperator(), bob);
     }
 
-    function test_setOperator_emitsOperatorChangedEvent() public {
+    function test_proposeOperator_emitsRoleChangeProposed() public {
         vm.prank(alice);
         address pool = _createPool(alice, MIN_STAKE);
 
         vm.prank(alice);
-        vm.expectEmit(true, false, false, true);
-        emit IStakePool.OperatorChanged(pool, alice, bob);
-        IStakePool(pool).setOperator(bob);
+        vm.expectEmit(true, true, false, true);
+        emit IStakePool.RoleChangeProposed(pool, "operator", bob, uint64(block.timestamp + 7 days));
+        IStakePool(pool).proposeOperator(bob);
     }
 
-    function test_RevertWhen_setOperator_notOwner() public {
+    function test_acceptOperator_emitsOperatorChanged() public {
+        vm.prank(alice);
+        address pool = _createPool(alice, MIN_STAKE);
+
+        vm.prank(alice);
+        IStakePool(pool).proposeOperator(bob);
+
+        vm.warp(block.timestamp + 7 days);
+        vm.prank(bob);
+        vm.expectEmit(true, false, false, true);
+        emit IStakePool.OperatorChanged(pool, alice, bob);
+        IStakePool(pool).acceptOperator();
+    }
+
+    function test_RevertWhen_proposeOperator_notOwner() public {
         vm.prank(alice);
         address pool = _createPool(alice, MIN_STAKE);
 
         vm.prank(bob);
         vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, bob));
-        IStakePool(pool).setOperator(charlie);
+        IStakePool(pool).proposeOperator(charlie);
     }
 
-    function test_setVoter_changesVoter() public {
+    function test_RevertWhen_acceptOperator_tooEarly() public {
         vm.prank(alice);
         address pool = _createPool(alice, MIN_STAKE);
 
         vm.prank(alice);
-        IStakePool(pool).setVoter(bob);
+        IStakePool(pool).proposeOperator(bob);
+
+        vm.prank(bob);
+        vm.expectRevert();
+        IStakePool(pool).acceptOperator();
+    }
+
+    function test_RevertWhen_acceptOperator_wrongCaller() public {
+        vm.prank(alice);
+        address pool = _createPool(alice, MIN_STAKE);
+
+        vm.prank(alice);
+        IStakePool(pool).proposeOperator(bob);
+
+        vm.warp(block.timestamp + 7 days);
+        vm.prank(charlie);
+        vm.expectRevert(abi.encodeWithSelector(Errors.NotPendingRole.selector, charlie, bob));
+        IStakePool(pool).acceptOperator();
+    }
+
+    function test_cancelOperatorChange() public {
+        vm.prank(alice);
+        address pool = _createPool(alice, MIN_STAKE);
+
+        vm.prank(alice);
+        IStakePool(pool).proposeOperator(bob);
+
+        vm.prank(alice);
+        IStakePool(pool).cancelOperatorChange();
+
+        // Should revert since pending was cleared
+        vm.warp(block.timestamp + 7 days);
+        vm.prank(bob);
+        vm.expectRevert(Errors.NoPendingRoleChange.selector);
+        IStakePool(pool).acceptOperator();
+    }
+
+    // ── Voter: propose → accept ─────────────────────────────────────
+
+    function test_proposeVoter_and_acceptVoter() public {
+        vm.prank(alice);
+        address pool = _createPool(alice, MIN_STAKE);
+
+        vm.prank(alice);
+        IStakePool(pool).proposeVoter(bob);
+
+        vm.warp(block.timestamp + 7 days);
+        vm.prank(bob);
+        IStakePool(pool).acceptVoter();
 
         assertEq(IStakePool(pool).getVoter(), bob);
     }
 
-    function test_setVoter_emitsVoterChangedEvent() public {
-        vm.prank(alice);
-        address pool = _createPool(alice, MIN_STAKE);
-
-        vm.prank(alice);
-        vm.expectEmit(true, false, false, true);
-        emit IStakePool.VoterChanged(pool, alice, bob);
-        IStakePool(pool).setVoter(bob);
-    }
-
-    function test_RevertWhen_setVoter_notOwner() public {
+    function test_RevertWhen_proposeVoter_notOwner() public {
         vm.prank(alice);
         address pool = _createPool(alice, MIN_STAKE);
 
         vm.prank(bob);
         vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, bob));
-        IStakePool(pool).setVoter(charlie);
+        IStakePool(pool).proposeVoter(charlie);
     }
 
-    function test_setStaker_changesStaker() public {
+    // ── Staker: propose → accept (with pending withdrawal guard) ────
+
+    function test_proposeStaker_and_acceptStaker() public {
         vm.prank(alice);
         address pool = _createPool(alice, MIN_STAKE);
 
         vm.prank(alice);
-        IStakePool(pool).setStaker(bob);
+        IStakePool(pool).proposeStaker(bob);
+
+        vm.warp(block.timestamp + 7 days);
+        vm.prank(bob);
+        IStakePool(pool).acceptStaker();
 
         assertEq(IStakePool(pool).getStaker(), bob);
     }
 
-    function test_setStaker_emitsStakerChangedEvent() public {
-        vm.prank(alice);
-        address pool = _createPool(alice, MIN_STAKE);
-
-        vm.prank(alice);
-        vm.expectEmit(true, false, false, true);
-        emit IStakePool.StakerChanged(pool, alice, bob);
-        IStakePool(pool).setStaker(bob);
-    }
-
-    function test_RevertWhen_setStaker_notOwner() public {
+    function test_RevertWhen_proposeStaker_notOwner() public {
         vm.prank(alice);
         address pool = _createPool(alice, MIN_STAKE);
 
         vm.prank(bob);
         vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, bob));
-        IStakePool(pool).setStaker(charlie);
+        IStakePool(pool).proposeStaker(charlie);
+    }
+
+    function test_RevertWhen_acceptStaker_hasPendingWithdrawals() public {
+        vm.prank(alice);
+        address pool = _createPool(alice, MIN_STAKE);
+
+        // Unstake some to create pending withdrawal
+        vm.prank(alice);
+        IStakePool(pool).unstake(1 ether);
+
+        // Propose new staker
+        vm.prank(alice);
+        IStakePool(pool).proposeStaker(bob);
+
+        // Warp past delay
+        vm.warp(block.timestamp + 7 days);
+
+        // Should revert due to pending withdrawals
+        vm.prank(bob);
+        vm.expectRevert();
+        IStakePool(pool).acceptStaker();
+    }
+
+    // ── Role change delay configuration ─────────────────────────────
+
+    function test_setRoleChangeDelay() public {
+        vm.prank(alice);
+        address pool = _createPool(alice, MIN_STAKE);
+
+        vm.prank(alice);
+        IStakePool(pool).setRoleChangeDelay(14 days);
+
+        // Propose with new 14-day delay
+        uint256 proposeTime = block.timestamp;
+        vm.prank(alice);
+        IStakePool(pool).proposeOperator(bob);
+
+        // 7 days is no longer enough
+        vm.warp(proposeTime + 7 days);
+        vm.prank(bob);
+        vm.expectRevert();
+        IStakePool(pool).acceptOperator();
+
+        // 14 days works
+        vm.warp(proposeTime + 14 days);
+        vm.prank(bob);
+        IStakePool(pool).acceptOperator();
+        assertEq(IStakePool(pool).getOperator(), bob);
+    }
+
+    function test_RevertWhen_setRoleChangeDelay_belowMinimum() public {
+        vm.prank(alice);
+        address pool = _createPool(alice, MIN_STAKE);
+
+        vm.prank(alice);
+        vm.expectRevert(abi.encodeWithSelector(Errors.RoleChangeDelayTooShort.selector, uint64(1 hours), uint64(2 days)));
+        IStakePool(pool).setRoleChangeDelay(1 hours);
     }
 
     // ========================================================================

--- a/test/unit/staking/Staking.t.sol
+++ b/test/unit/staking/Staking.t.sol
@@ -1136,9 +1136,7 @@ contract StakingTest is Test {
         vm.expectEmit(true, true, false, true);
         emit IStakePool.RoleChangeCancelled(pool, IStakePool.Role.Operator);
         vm.expectEmit(true, true, true, true);
-        emit IStakePool.RoleChangeProposed(
-            pool, IStakePool.Role.Operator, charlie, uint64(block.timestamp + 1 days)
-        );
+        emit IStakePool.RoleChangeProposed(pool, IStakePool.Role.Operator, charlie, uint64(block.timestamp + 1 days));
         IStakePool(pool).proposeOperator(charlie);
 
         // bob can no longer accept

--- a/test/unit/staking/Staking.t.sol
+++ b/test/unit/staking/Staking.t.sol
@@ -1085,7 +1085,9 @@ contract StakingTest is Test {
         address pool = _createPool(alice, MIN_STAKE);
 
         vm.prank(alice);
-        vm.expectRevert(abi.encodeWithSelector(Errors.RoleChangeDelayTooShort.selector, uint64(1 hours), uint64(2 days)));
+        vm.expectRevert(
+            abi.encodeWithSelector(Errors.RoleChangeDelayTooShort.selector, uint64(1 hours), uint64(2 days))
+        );
         IStakePool(pool).setRoleChangeDelay(1 hours);
     }
 


### PR DESCRIPTION
## Summary

Address StakePool audit findings from the V3.5 audit round:

### [#251](https://github.com/Galxe/gravity-audit/issues/251) [High] — New staker can claim predecessor's pending withdrawals
- Pending withdrawals are tracked at pool level, not per-staker. After `setStaker()`, the new staker could call `withdrawAvailable()` to claim the old staker's funds.
- **Fix**: `acceptStaker()` reverts if there are unclaimed pending withdrawals, ensuring the old staker must withdraw first.

### [#259](https://github.com/Galxe/gravity-audit/issues/259) [Medium] — Role changes have no timelock
- `setStaker`/`setOperator`/`setVoter` were immediate `onlyOwner` calls with no delay, enabling instant privilege transfer if owner key is compromised.
- **Fix**: Replaced with a 2-step propose → accept pattern (similar to `Ownable2Step`) with per-role configurable delays:
  - `proposeStaker()` / `acceptStaker()` / `cancelStakerChange()` / `setStakerChangeDelay()`
  - `proposeOperator()` / `acceptOperator()` / `cancelOperatorChange()` / `setOperatorChangeDelay()`
  - `proposeVoter()` / `acceptVoter()` / `cancelVoterChange()` / `setVoterChangeDelay()`
  - `MIN_ROLE_CHANGE_DELAY = 1 day` (constant floor), all delays default to 1 day

## Changed files

| File | Change |
|------|--------|
| `src/staking/StakePool.sol` | 2-step timelock role changes with per-role delays |
| `src/staking/IStakePool.sol` | Updated interface: propose/accept/cancel + delay setters |
| `src/foundation/Errors.sol` | New role change errors |
| `test/unit/staking/Staking.t.sol` | Updated role change tests |
| `test/unit/governance/Governance.t.sol` | Updated voter delegation tests |

## Test plan

- [x] `forge test` — 919 tests passed, 0 failed
- [x] New tests cover: propose/accept flow, timelock enforcement, wrong caller rejection, cancel, pending withdrawal guard, per-role delay configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)