### PR TITLE
feat(genesis): allow distinct operator/owner/staker at genesis

### DIFF
--- a/genesis-tool/config/genesis_config.json
+++ b/genesis-tool/config/genesis_config.json
@@ -76,6 +76,7 @@
     {
       "operator": "0x6e2021ee24e2430da0f5bb9c2ae6c586bf3e0a0f",
       "owner": "0x6e2021ee24e2430da0f5bb9c2ae6c586bf3e0a0f",
+      "staker": "0x6e2021ee24e2430da0f5bb9c2ae6c586bf3e0a0f",
       "stakeAmount": "20000000000000000000000",
       "moniker": "validator-1",
       "consensusPubkey": "0x851d41932d866f5fabed6673898e15473e6a0adcf5033d2c93816c6b115c85ad3451e0bac61d570d5ed9f23e1e7f77c4",
@@ -87,6 +88,7 @@
     {
       "operator": "0xedde7f05ae91961d0804ec634d7535969b7d171f",
       "owner": "0xedde7f05ae91961d0804ec634d7535969b7d171f",
+      "staker": "0xedde7f05ae91961d0804ec634d7535969b7d171f",
       "stakeAmount": "20000000000000000000000",
       "moniker": "validator-2",
       "consensusPubkey": "0x99ff89f453d9a9bf273e3ae8b61b99a2b336edc7b6eb9b8e308249fd59f3b76211771d7e0daaa97fad11518c4ad8eabd",
@@ -98,6 +100,7 @@
     {
       "operator": "0x02eb0186ea845ed75b01740726e581215de8625b",
       "owner": "0x02eb0186ea845ed75b01740726e581215de8625b",
+      "staker": "0x02eb0186ea845ed75b01740726e581215de8625b",
       "stakeAmount": "20000000000000000000000",
       "moniker": "validator-3",
       "consensusPubkey": "0xb7a931fa544c2d1d54dee27619edfb70cc801bc599dd7a3f56f641a588cee4600b63e35d0d35fe69f2e454462b0ce9b2",
@@ -109,6 +112,7 @@
     {
       "operator": "0x3872e99f21165874B20Cb9C8c877f8A0A0c5b779",
       "owner": "0x3872e99f21165874B20Cb9C8c877f8A0A0c5b779",
+      "staker": "0x3872e99f21165874B20Cb9C8c877f8A0A0c5b779",
       "stakeAmount": "20000000000000000000000",
       "moniker": "validator-4",
       "consensusPubkey": "0x958a9e1e0aef70cc5d99f22403c5cf9de35f8d818553f499b6f29a975aa3b70a95fcb45281f04070e516ad7acd9c7c99",

--- a/genesis-tool/config/genesis_config_single.json
+++ b/genesis-tool/config/genesis_config_single.json
@@ -89,6 +89,7 @@
     {
       "operator": "0x6e2021ee24e2430da0f5bb9c2ae6c586bf3e0a0f",
       "owner": "0x6e2021ee24e2430da0f5bb9c2ae6c586bf3e0a0f",
+      "staker": "0x6e2021ee24e2430da0f5bb9c2ae6c586bf3e0a0f",
       "stakeAmount": "20000000000000000000000",
       "moniker": "validator-1",
       "consensusPubkey": "0x851d41932d866f5fabed6673898e15473e6a0adcf5033d2c93816c6b115c85ad3451e0bac61d570d5ed9f23e1e7f77c4",

--- a/genesis-tool/src/genesis.rs
+++ b/genesis-tool/src/genesis.rs
@@ -217,6 +217,7 @@ pub struct RSA_JWK_Json {
 pub struct InitialValidator {
     pub operator: String,
     pub owner: String,
+    pub staker: String,
 
     #[serde(rename = "stakeAmount")]
     pub stake_amount: String,
@@ -314,6 +315,7 @@ sol! {
     struct SolInitialValidator {
         address operator;
         address owner;
+        address staker;
         uint256 stakeAmount;
         string moniker;
         bytes consensusPubkey;
@@ -506,6 +508,7 @@ pub fn convert_config_to_sol(config: &GenesisConfig) -> SolGenesisInitParams {
         .map(|v| SolInitialValidator {
             operator: parse_address(&v.operator),
             owner: parse_address(&v.owner),
+            staker: parse_address(&v.staker),
             stakeAmount: parse_u256(&v.stake_amount),
             moniker: v.moniker.clone(),
             consensusPubkey: parse_hex_bytes(&v.consensus_pubkey).into(),

--- a/src/Genesis.sol
+++ b/src/Genesis.sol
@@ -86,7 +86,8 @@ contract Genesis {
 
     struct InitialValidator {
         address operator;
-        address owner; // Used for owner, voter, and feeRecipient
+        address owner; // Also used as voter and feeRecipient
+        address staker;
         uint256 stakeAmount;
         string moniker;
         bytes consensusPubkey;
@@ -283,7 +284,7 @@ contract Genesis {
 
             address pool = Staking(SystemAddresses.STAKING).createPool{ value: v.stakeAmount }(
                 v.owner, // owner
-                v.owner, // staker (initially same as owner)
+                v.staker, // staker
                 v.operator, // operator
                 v.owner, // voter (initially same as owner)
                 initialLockedUntilMicros

--- a/test/unit/GenesisTest.t.sol
+++ b/test/unit/GenesisTest.t.sol
@@ -98,6 +98,7 @@ contract GenesisTest is Test {
         validators[0] = Genesis.InitialValidator({
             operator: makeAddr("operator1"),
             owner: makeAddr("owner1"),
+            staker: makeAddr("staker1"),
             stakeAmount: 200 ether,
             moniker: "Validator 1",
             consensusPubkey: hex"9112af1a4ef4038dfe24c5371e40b5bcfce16146bfc4ab819244ce57f5d002c4c3f06eca7273e733c0f78aada8c13deb",

--- a/test/unit/staking/StakerSeparation.t.sol
+++ b/test/unit/staking/StakerSeparation.t.sol
@@ -12,14 +12,23 @@ import { ValidatorStatus } from "../../../src/foundation/Types.sol";
 import { Ownable } from "@openzeppelin/access/Ownable.sol";
 
 contract MockValidatorManagement2 {
-    function isValidator(address) external pure returns (bool) { return false; }
-    function getValidatorStatus(address) external pure returns (ValidatorStatus) {
+    function isValidator(
+        address
+    ) external pure returns (bool) {
+        return false;
+    }
+
+    function getValidatorStatus(
+        address
+    ) external pure returns (ValidatorStatus) {
         return ValidatorStatus.INACTIVE;
     }
 }
 
 contract MockReconfiguration2 {
-    function isTransitionInProgress() external pure returns (bool) { return false; }
+    function isTransitionInProgress() external pure returns (bool) {
+        return false;
+    }
 }
 
 /// @title StakerSeparationTest
@@ -32,11 +41,11 @@ contract StakerSeparationTest is Test {
     StakingConfig public stakingConfig;
     Timestamp public timestamp;
 
-    address public ownerAddr   = makeAddr("distinctOwner");
-    address public stakerAddr  = makeAddr("distinctStaker");
+    address public ownerAddr = makeAddr("distinctOwner");
+    address public stakerAddr = makeAddr("distinctStaker");
     address public operatorAddr = makeAddr("distinctOperator");
-    address public voterAddr   = makeAddr("distinctVoter");
-    address public stranger    = makeAddr("stranger");
+    address public voterAddr = makeAddr("distinctVoter");
+    address public stranger = makeAddr("stranger");
 
     uint256 constant MIN_STAKE = 1 ether;
     uint64 constant LOCKUP_DURATION = 14 days * 1_000_000;
@@ -71,13 +80,7 @@ contract StakerSeparationTest is Test {
     function _createDistinctPool() internal returns (address pool) {
         uint64 lockedUntil = INITIAL_TIMESTAMP + LOCKUP_DURATION;
         vm.prank(ownerAddr);
-        pool = staking.createPool{ value: MIN_STAKE }(
-            ownerAddr,
-            stakerAddr,
-            operatorAddr,
-            voterAddr,
-            lockedUntil
-        );
+        pool = staking.createPool{ value: MIN_STAKE }(ownerAddr, stakerAddr, operatorAddr, voterAddr, lockedUntil);
     }
 
     function test_createPool_DistinctRolesStored() public {

--- a/test/unit/staking/StakerSeparation.t.sol
+++ b/test/unit/staking/StakerSeparation.t.sol
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import { Test } from "forge-std/Test.sol";
+import { Staking } from "../../../src/staking/Staking.sol";
+import { IStakePool } from "../../../src/staking/IStakePool.sol";
+import { StakingConfig } from "../../../src/runtime/StakingConfig.sol";
+import { Timestamp } from "../../../src/runtime/Timestamp.sol";
+import { SystemAddresses } from "../../../src/foundation/SystemAddresses.sol";
+import { Errors } from "../../../src/foundation/Errors.sol";
+import { ValidatorStatus } from "../../../src/foundation/Types.sol";
+import { Ownable } from "@openzeppelin/access/Ownable.sol";
+
+contract MockValidatorManagement2 {
+    function isValidator(address) external pure returns (bool) { return false; }
+    function getValidatorStatus(address) external pure returns (ValidatorStatus) {
+        return ValidatorStatus.INACTIVE;
+    }
+}
+
+contract MockReconfiguration2 {
+    function isTransitionInProgress() external pure returns (bool) { return false; }
+}
+
+/// @title StakerSeparationTest
+/// @notice Verifies Staking.createPool and StakePool role checks work when
+///         owner / staker / operator are three distinct EVM addresses.
+///         This guards the Genesis.sol change that stops collapsing all three
+///         roles into a single address.
+contract StakerSeparationTest is Test {
+    Staking public staking;
+    StakingConfig public stakingConfig;
+    Timestamp public timestamp;
+
+    address public ownerAddr   = makeAddr("distinctOwner");
+    address public stakerAddr  = makeAddr("distinctStaker");
+    address public operatorAddr = makeAddr("distinctOperator");
+    address public voterAddr   = makeAddr("distinctVoter");
+    address public stranger    = makeAddr("stranger");
+
+    uint256 constant MIN_STAKE = 1 ether;
+    uint64 constant LOCKUP_DURATION = 14 days * 1_000_000;
+    uint64 constant UNBONDING_DELAY = 7 days * 1_000_000;
+    uint64 constant INITIAL_TIMESTAMP = 1_000_000_000_000_000;
+
+    function setUp() public {
+        vm.etch(SystemAddresses.STAKE_CONFIG, address(new StakingConfig()).code);
+        stakingConfig = StakingConfig(SystemAddresses.STAKE_CONFIG);
+
+        vm.etch(SystemAddresses.TIMESTAMP, address(new Timestamp()).code);
+        timestamp = Timestamp(SystemAddresses.TIMESTAMP);
+
+        vm.etch(SystemAddresses.STAKING, address(new Staking()).code);
+        staking = Staking(SystemAddresses.STAKING);
+
+        vm.etch(SystemAddresses.VALIDATOR_MANAGER, address(new MockValidatorManagement2()).code);
+        vm.etch(SystemAddresses.RECONFIGURATION, address(new MockReconfiguration2()).code);
+
+        vm.prank(SystemAddresses.GENESIS);
+        stakingConfig.initialize(MIN_STAKE, LOCKUP_DURATION, UNBONDING_DELAY);
+
+        vm.prank(SystemAddresses.BLOCK);
+        timestamp.updateGlobalTime(ownerAddr, INITIAL_TIMESTAMP);
+
+        vm.deal(ownerAddr, 1000 ether);
+        vm.deal(stakerAddr, 1000 ether);
+        vm.deal(operatorAddr, 1000 ether);
+        vm.deal(stranger, 1000 ether);
+    }
+
+    function _createDistinctPool() internal returns (address pool) {
+        uint64 lockedUntil = INITIAL_TIMESTAMP + LOCKUP_DURATION;
+        vm.prank(ownerAddr);
+        pool = staking.createPool{ value: MIN_STAKE }(
+            ownerAddr,
+            stakerAddr,
+            operatorAddr,
+            voterAddr,
+            lockedUntil
+        );
+    }
+
+    function test_createPool_DistinctRolesStored() public {
+        address pool = _createDistinctPool();
+
+        assertEq(Ownable(pool).owner(), ownerAddr, "owner mismatch");
+        assertEq(IStakePool(pool).getStaker(), stakerAddr, "staker mismatch");
+        assertEq(IStakePool(pool).getOperator(), operatorAddr, "operator mismatch");
+        assertEq(staking.getPoolOperator(pool), operatorAddr, "factory operator view mismatch");
+    }
+
+    function test_addStake_OnlyStakerSucceeds() public {
+        address pool = _createDistinctPool();
+
+        // Owner cannot addStake
+        vm.prank(ownerAddr);
+        vm.expectRevert(abi.encodeWithSelector(Errors.NotStaker.selector, ownerAddr, stakerAddr));
+        IStakePool(pool).addStake{ value: 1 ether }();
+
+        // Operator cannot addStake
+        vm.prank(operatorAddr);
+        vm.expectRevert(abi.encodeWithSelector(Errors.NotStaker.selector, operatorAddr, stakerAddr));
+        IStakePool(pool).addStake{ value: 1 ether }();
+
+        // Stranger cannot addStake
+        vm.prank(stranger);
+        vm.expectRevert(abi.encodeWithSelector(Errors.NotStaker.selector, stranger, stakerAddr));
+        IStakePool(pool).addStake{ value: 1 ether }();
+
+        // Staker succeeds
+        vm.prank(stakerAddr);
+        IStakePool(pool).addStake{ value: 1 ether }();
+    }
+
+    function test_setStaker_OnlyOwnerSucceeds() public {
+        address pool = _createDistinctPool();
+        address newStaker = makeAddr("newStaker");
+
+        // Staker cannot rotate itself
+        vm.prank(stakerAddr);
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, stakerAddr));
+        IStakePool(pool).setStaker(newStaker);
+
+        // Operator cannot
+        vm.prank(operatorAddr);
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, operatorAddr));
+        IStakePool(pool).setStaker(newStaker);
+
+        // Owner succeeds
+        vm.prank(ownerAddr);
+        IStakePool(pool).setStaker(newStaker);
+        assertEq(IStakePool(pool).getStaker(), newStaker, "setStaker did not apply");
+    }
+
+    function test_setOperator_OnlyOwnerSucceeds() public {
+        address pool = _createDistinctPool();
+        address newOperator = makeAddr("newOperator");
+
+        vm.prank(operatorAddr);
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, operatorAddr));
+        IStakePool(pool).setOperator(newOperator);
+
+        vm.prank(stakerAddr);
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, stakerAddr));
+        IStakePool(pool).setOperator(newOperator);
+
+        vm.prank(ownerAddr);
+        IStakePool(pool).setOperator(newOperator);
+        assertEq(IStakePool(pool).getOperator(), newOperator, "setOperator did not apply");
+    }
+}


### PR DESCRIPTION
Previously Genesis.sol collapsed all three StakePool roles into v.owner when calling Staking.createPool, making it impossible to configure genesis validators with three different EVM addresses. Add a staker field to InitialValidator (Sol + Rust ABI + genesis-tool config) and pass it through to createPool so operator/owner/staker can differ.

Covered by new test/unit/staking/StakerSeparation.t.sol.

## Description

<!--
  Add a detailed description for the changes made in this pull request

  If your PR addresses an existing issue, add it here.
  Use the template string - `This pull request resolves #<issue-number>`
-->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->
- [ ] 📚 Documentation    (Non-breaking change; Changes in the documentation)
- [ ] 🔧 Bug fix          (Non-breaking change; Fixes an existing bug)
- [ ] 🥂 Improvement      (Non-breaking change; Improves existing feature)
- [ ] 🚀 New feature      (Non-breaking change; Adds functionality)
- [ ] 🔐 Security fix     (Non-breaking change; Patches a security issue)
- [ ] 💥 Breaking change  (Breaks existing functionality)

<!--
    Leave this section as-is, no changes are to be made below this point!
-->