### PR TITLE
fix(staking): enforce minBond on unstake for PENDING_ACTIVE validators

### DIFF
--- a/src/staking/StakePool.sol
+++ b/src/staking/StakePool.sol
@@ -419,7 +419,10 @@ contract StakePool is IStakePool, Ownable2Step, ReentrancyGuard {
         IValidatorManagement validatorMgmt = IValidatorManagement(SystemAddresses.VALIDATOR_MANAGER);
         if (validatorMgmt.isValidator(address(this))) {
             ValidatorStatus status = validatorMgmt.getValidatorStatus(address(this));
-            if (status == ValidatorStatus.ACTIVE || status == ValidatorStatus.PENDING_INACTIVE) {
+            if (
+                status == ValidatorStatus.ACTIVE || status == ValidatorStatus.PENDING_INACTIVE
+                    || status == ValidatorStatus.PENDING_ACTIVE
+            ) {
                 uint256 minBond = IValidatorConfig(SystemAddresses.VALIDATOR_CONFIG).minimumBond();
 
                 // Simple check: activeStake after unstake must be >= minBond

--- a/test/unit/staking/ValidatorManagement.t.sol
+++ b/test/unit/staking/ValidatorManagement.t.sol
@@ -965,6 +965,34 @@ contract ValidatorManagementTest is Test {
         assertEq(validatorManager.getPendingActiveValidators().length, 0, "Should have no pending active validators");
     }
 
+    /// @notice PENDING_ACTIVE validators must honor the minBond invariant on unstake.
+    /// @dev Regression test for Coacker finding #277: previously only ACTIVE/PENDING_INACTIVE
+    ///      were checked, so a staker could join the set then unstake all the way to zero,
+    ///      violating the "always >= minBond while in any validator lifecycle state" invariant.
+    function test_RevertWhen_unstake_pendingActiveBelowMinBond() public {
+        // Create pool with enough stake that unstaking would breach minBond.
+        address pool = _createRegisterAndJoin(alice, MIN_BOND + 5 ether, "alice");
+        assertEq(uint8(validatorManager.getValidatorStatus(pool)), uint8(ValidatorStatus.PENDING_ACTIVE));
+
+        // Unstaking 6 ether would leave 9 ether < MIN_BOND (10 ether) — must revert.
+        vm.prank(alice);
+        vm.expectRevert(
+            abi.encodeWithSelector(Errors.WithdrawalWouldBreachMinimumBond.selector, MIN_BOND - 1 ether, MIN_BOND)
+        );
+        IStakePool(pool).unstake(6 ether);
+    }
+
+    /// @notice PENDING_ACTIVE validators can still unstake above the minBond floor.
+    function test_unstake_pendingActiveAboveMinBond_succeeds() public {
+        address pool = _createRegisterAndJoin(alice, MIN_BOND + 5 ether, "alice");
+        assertEq(uint8(validatorManager.getValidatorStatus(pool)), uint8(ValidatorStatus.PENDING_ACTIVE));
+
+        // Unstaking exactly 5 ether keeps activeStake == MIN_BOND — allowed.
+        vm.prank(alice);
+        IStakePool(pool).unstake(5 ether);
+        assertEq(IStakePool(pool).getActiveStake(), MIN_BOND, "activeStake should equal minBond");
+    }
+
     /// @notice Test that operations are blocked during reconfiguration
     function test_RevertWhen_joinValidatorSet_duringReconfiguration() public {
         address pool = _createAndRegisterValidator(alice, MIN_BOND, "alice");


### PR DESCRIPTION
## Summary
- Adds \`PENDING_ACTIVE\` to the minBond guard in \`StakePool._unstake\` so a staker who has just called \`joinValidatorSet()\` cannot unstake below \`minimumBond\` before the epoch boundary.
- Adds two regression tests in \`ValidatorManagement.t.sol\`:
  - \`test_RevertWhen_unstake_pendingActiveBelowMinBond\` — verifies the revert path
  - \`test_unstake_pendingActiveAboveMinBond_succeeds\` — verifies unstake down to exactly \`minBond\` is still allowed

## Motivation
Coacker audit finding [#277](https://github.com/Galxe/gravity-audit/issues/277). Prior to this fix, \`_unstake\` only enforced \`minBond\` for \`ACTIVE\` and \`PENDING_INACTIVE\` states, leaving a small invariant gap for \`PENDING_ACTIVE\`. \`_computeNextEpochValidatorSet\` already catches the zero-stake case at the epoch boundary and reverts the validator to \`INACTIVE\`, so there is no fund loss or consensus risk — but the intermediate state violates the \"always ≥ minBond while in any validator lifecycle state\" invariant and wastes a pending slot. This is a defense-in-depth fix that keeps the lifecycle invariant clean.

## Test plan
- [x] \`forge test --match-path test/unit/staking/ValidatorManagement.t.sol --match-test pendingActive\` — both new tests pass
- [x] \`forge test --match-path \"test/unit/staking/*\"\` — all 199 staking unit tests pass, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)