### PR TITLE
fix(validator): V3.5 audit hardening (#83, #85, #154, #187)

### DIFF
--- a/src/staking/ValidatorManagement.sol
+++ b/src/staking/ValidatorManagement.sol
@@ -738,6 +738,11 @@ contract ValidatorManagement is IValidatorManagement {
             validator.status = ValidatorStatus.INACTIVE;
             validator.validatorIndex = type(uint64).max; // Clear index
 
+            // Audit #85: clear pending fee recipient on deactivation so a stale value
+            // set by a (potentially compromised) operator before deactivation cannot
+            // silently activate when the pool later rejoins the validator set.
+            validator.pendingFeeRecipient = address(0);
+
             emit ValidatorDeactivated(pool);
         }
         delete _pendingInactive;

--- a/src/staking/ValidatorManagement.sol
+++ b/src/staking/ValidatorManagement.sol
@@ -238,7 +238,7 @@ contract ValidatorManagement is IValidatorManagement {
         bytes calldata consensusPop,
         bytes calldata networkAddresses,
         bytes calldata fullnodeAddresses
-    ) external {
+    ) external whenNotReconfiguring {
         // Check that validator set changes are allowed
         if (!IValidatorConfig(SystemAddresses.VALIDATOR_CONFIG).allowValidatorSetChange()) {
             revert Errors.ValidatorSetChangesDisabled();

--- a/src/staking/ValidatorManagement.sol
+++ b/src/staking/ValidatorManagement.sol
@@ -610,6 +610,14 @@ contract ValidatorManagement is IValidatorManagement {
     function evictUnderperformingValidators() external {
         requireAllowed(SystemAddresses.RECONFIGURATION);
 
+        // Audit #154: honor allowValidatorSetChange freeze. The freeze switch is the
+        // operator's incident-response tool ("stop all validator set mutation"). Letting
+        // eviction still run while join/leave are blocked defeats the freeze, because the
+        // active set can only shrink (no replenishment) and may fall below the BFT quorum.
+        if (!IValidatorConfig(SystemAddresses.VALIDATOR_CONFIG).allowValidatorSetChange()) {
+            return;
+        }
+
         // Skip eviction for epoch 1 — the first epoch after genesis has insufficient
         // performance data (validators are still bootstrapping), so eviction starts from epoch 2.
         uint64 closingEpoch = IReconfiguration(SystemAddresses.RECONFIGURATION).currentEpoch();

--- a/src/staking/ValidatorManagement.sol
+++ b/src/staking/ValidatorManagement.sol
@@ -908,12 +908,21 @@ contract ValidatorManagement is IValidatorManagement {
         }
     }
 
-    /// @notice Calculate total voting power of active validators
-    function _calculateTotalVotingPower() internal view returns (uint256) {
+    /// @notice Calculate the voting power of validators that will STAY active next epoch
+    /// @dev Audit #83: when used as the base for votingPowerIncreaseLimitPct, the denominator
+    ///      must exclude PENDING_INACTIVE (they are leaving and will not be part of next epoch).
+    ///      Including them inflates the base by a factor of 1/stayingRatio, which weakens the
+    ///      BFT-level cap on voting power churn per epoch. Aptos's stake.move::on_new_epoch
+    ///      clears pending_inactive before computing total_voting_power for the same reason.
+    function _calculateStayingVotingPower() internal view returns (uint256) {
         uint256 total = 0;
         uint256 length = _activeValidators.length;
         for (uint256 i = 0; i < length; i++) {
-            total += _getValidatorVotingPower(_activeValidators[i]);
+            address pool = _activeValidators[i];
+            if (_validators[pool].status == ValidatorStatus.PENDING_INACTIVE) {
+                continue;
+            }
+            total += _getValidatorVotingPower(pool);
         }
         return total;
     }
@@ -966,8 +975,11 @@ contract ValidatorManagement is IValidatorManagement {
             stayingActiveCount++;
         }
 
-        // Step 3: Compute pending activation with voting power limits
-        uint256 currentTotal = _calculateTotalVotingPower();
+        // Step 3: Compute pending activation with voting power limits.
+        // Audit #83: base must be "staying" voting power (excludes PENDING_INACTIVE),
+        // so the increase-limit denominator reflects the set that will actually be
+        // active in the next epoch, not the inflated current-epoch total.
+        uint256 currentTotal = _calculateStayingVotingPower();
         uint64 limitPct = IValidatorConfig(SystemAddresses.VALIDATOR_CONFIG).votingPowerIncreaseLimitPct();
         uint256 maxIncrease = (currentTotal * limitPct * PRECISION_FACTOR) / (100 * PRECISION_FACTOR);
         uint256 addedPower = 0;

--- a/test/unit/staking/ValidatorManagement.t.sol
+++ b/test/unit/staking/ValidatorManagement.t.sol
@@ -252,6 +252,80 @@ contract ValidatorManagementTest is Test {
     }
 
     /// @notice Test revert when validator set changes are disabled
+    /// @notice Audit #154: evictUnderperformingValidators must honor allowValidatorSetChange.
+    ///         When the freeze switch is off, eviction must be a no-op — otherwise an
+    ///         incident-response freeze is meaningless because the active set can only
+    ///         shrink (no replenishment via join) and may fall below the BFT quorum.
+    function test_audit_evict_honorsAllowValidatorSetChange() public {
+        // Setup: 3 active validators, each with baseline bond
+        address pool1 = _createRegisterAndJoin(alice, MIN_BOND, "alice");
+        address pool2 = _createRegisterAndJoin(bob, MIN_BOND, "bob");
+        address pool3 = _createRegisterAndJoin(charlie, MIN_BOND, "charlie");
+        _processEpoch(); // activates all 3 (epoch 0 -> 1)
+        _processEpoch(); // no-op, but currentEpoch -> 2 so evict's closingEpoch>1 guard passes
+
+        // Raise minimumBond so all 3 become underbonded AND freeze the set
+        vm.prank(SystemAddresses.GOVERNANCE);
+        validatorConfig.setForNextEpoch(
+            MIN_BOND * 10, // huge minimumBond — everyone underbonded
+            MAX_BOND,
+            UNBONDING_DELAY,
+            false, // allowValidatorSetChange = false  (FREEZE)
+            VOTING_POWER_INCREASE_LIMIT,
+            MAX_VALIDATOR_SET_SIZE,
+            false,
+            0
+        );
+        vm.prank(SystemAddresses.RECONFIGURATION);
+        validatorConfig.applyPendingConfig();
+
+        // Call eviction under freeze — must be no-op
+        vm.prank(SystemAddresses.RECONFIGURATION);
+        validatorManager.evictUnderperformingValidators();
+
+        assertEq(validatorManager.getActiveValidatorCount(), 3, "Freeze must block eviction");
+        assertEq(
+            uint8(validatorManager.getValidator(pool1).status),
+            uint8(ValidatorStatus.ACTIVE),
+            "alice must remain ACTIVE under freeze"
+        );
+        assertEq(
+            uint8(validatorManager.getValidator(pool2).status),
+            uint8(ValidatorStatus.ACTIVE),
+            "bob must remain ACTIVE under freeze"
+        );
+        assertEq(
+            uint8(validatorManager.getValidator(pool3).status),
+            uint8(ValidatorStatus.ACTIVE),
+            "charlie must remain ACTIVE under freeze"
+        );
+
+        // Un-freeze and re-run — now underbonded eviction runs (liveness guard protects last one)
+        vm.prank(SystemAddresses.GOVERNANCE);
+        validatorConfig.setForNextEpoch(
+            MIN_BOND * 10,
+            MAX_BOND,
+            UNBONDING_DELAY,
+            true, // un-freeze
+            VOTING_POWER_INCREASE_LIMIT,
+            MAX_VALIDATOR_SET_SIZE,
+            false,
+            0
+        );
+        vm.prank(SystemAddresses.RECONFIGURATION);
+        validatorConfig.applyPendingConfig();
+
+        vm.prank(SystemAddresses.RECONFIGURATION);
+        validatorManager.evictUnderperformingValidators();
+
+        // Baseline: without freeze, 2 of 3 get evicted (liveness guard keeps the last one ACTIVE)
+        uint256 stillActive;
+        if (validatorManager.getValidator(pool1).status == ValidatorStatus.ACTIVE) stillActive++;
+        if (validatorManager.getValidator(pool2).status == ValidatorStatus.ACTIVE) stillActive++;
+        if (validatorManager.getValidator(pool3).status == ValidatorStatus.ACTIVE) stillActive++;
+        assertEq(stillActive, 1, "Without freeze, eviction must run and leave exactly 1 validator");
+    }
+
     /// @notice Audit #187: registerValidator must be blocked during reconfiguration
     ///         to prevent consensus pubkey writes from interleaving with a live DKG session,
     ///         which would produce nondeterministic DKG reads across validators.

--- a/test/unit/staking/ValidatorManagement.t.sol
+++ b/test/unit/staking/ValidatorManagement.t.sol
@@ -252,6 +252,64 @@ contract ValidatorManagementTest is Test {
     }
 
     /// @notice Test revert when validator set changes are disabled
+    /// @notice Audit #85: a pending fee recipient set before leave→deactivate must not
+    ///         silently activate when the pool later rejoins. Without the fix, an operator
+    ///         (who can call setFeeRecipient unilaterally) can plant a stale recipient,
+    ///         the owner kicks them out, and the stale recipient takes effect on rejoin.
+    function test_audit_pendingFeeRecipient_clearedOnDeactivation() public {
+        // Two pools so leaveValidatorSet doesn't hit the "last validator" guard
+        address alicePool = _createRegisterAndJoin(alice, MIN_BOND, "alice");
+        _createRegisterAndJoin(bob, MIN_BOND, "bob");
+        _processEpoch(); // both ACTIVE
+
+        address staleRecipient = makeAddr("staleRecipient");
+
+        // Operator plants a pending fee recipient
+        vm.prank(alice);
+        validatorManager.setFeeRecipient(alicePool, staleRecipient);
+        assertEq(
+            validatorManager.getValidator(alicePool).pendingFeeRecipient,
+            staleRecipient,
+            "pending should be set"
+        );
+        address originalRecipient = validatorManager.getValidator(alicePool).feeRecipient;
+
+        // Pool owner leaves the set, validator deactivates at epoch boundary
+        vm.prank(alice);
+        validatorManager.leaveValidatorSet(alicePool);
+        _processEpoch(); // apply deactivation
+
+        ValidatorRecord memory afterDeactivate = validatorManager.getValidator(alicePool);
+        assertEq(uint8(afterDeactivate.status), uint8(ValidatorStatus.INACTIVE), "must be INACTIVE");
+        assertEq(
+            afterDeactivate.pendingFeeRecipient,
+            address(0),
+            "pendingFeeRecipient must be cleared on deactivation"
+        );
+        assertEq(
+            afterDeactivate.feeRecipient,
+            originalRecipient,
+            "feeRecipient must remain unchanged through deactivation"
+        );
+
+        // Rejoin and process another epoch — stale recipient must NOT activate
+        vm.prank(alice);
+        validatorManager.joinValidatorSet(alicePool);
+        _processEpoch(); // PENDING_ACTIVE -> ACTIVE, _applyPendingFeeRecipients runs
+
+        ValidatorRecord memory afterRejoin = validatorManager.getValidator(alicePool);
+        assertEq(uint8(afterRejoin.status), uint8(ValidatorStatus.ACTIVE), "must be ACTIVE again");
+        assertEq(
+            afterRejoin.feeRecipient,
+            originalRecipient,
+            "stale recipient must not activate on rejoin"
+        );
+        assertTrue(
+            afterRejoin.feeRecipient != staleRecipient,
+            "stale recipient must not leak through deactivate/rejoin cycle"
+        );
+    }
+
     /// @notice Audit #154: evictUnderperformingValidators must honor allowValidatorSetChange.
     ///         When the freeze switch is off, eviction must be a no-op — otherwise an
     ///         incident-response freeze is meaningless because the active set can only

--- a/test/unit/staking/ValidatorManagement.t.sol
+++ b/test/unit/staking/ValidatorManagement.t.sol
@@ -252,6 +252,57 @@ contract ValidatorManagementTest is Test {
     }
 
     /// @notice Test revert when validator set changes are disabled
+    /// @notice Audit #83: votingPowerIncreaseLimitPct base must exclude PENDING_INACTIVE.
+    ///         Including them inflates the limit denominator by 1/stayingRatio, letting
+    ///         more new voting power activate in a single epoch than the BFT safety
+    ///         analysis allows. Aptos's stake.move::on_new_epoch clears pending_inactive
+    ///         before computing total_voting_power; this test asserts we match.
+    function test_audit_votingPowerLimit_excludesPendingInactive() public {
+        // Two 500-ether actives (total 1000 with bug, 500 staying without bug)
+        address alicePool = _createRegisterAndJoin(alice, 500 ether, "alice");
+        address bobPool = _createRegisterAndJoin(bob, 500 ether, "bob");
+        _processEpoch(); // both ACTIVE
+
+        // bob leaves → PENDING_INACTIVE (still in _activeValidators until next epoch)
+        vm.prank(bob);
+        validatorManager.leaveValidatorSet(bobPool);
+
+        // Two pending validators, 100 ether each.
+        //
+        // votingPowerIncreaseLimitPct = 20 (from setUp).
+        //
+        // With bug: base = 1000 (includes bob), maxIncrease = 200.
+        //   - charlie: 100 > 200? no, whale-bypass activates → addedPower = 100
+        //   - david:   100+100 = 200 > 200? false → activated    → addedPower = 200
+        //   => after epoch: alice, charlie, david ACTIVE (count = 3)
+        //
+        // With fix: base = 500 (excludes bob), maxIncrease = 100.
+        //   - charlie: 100, whale-bypass activates                → addedPower = 100
+        //   - david:   100+100 = 200 > 100? true → kept pending
+        //   => after epoch: alice, charlie ACTIVE (count = 2), david still PENDING_ACTIVE
+        _createRegisterAndJoin(charlie, 100 ether, "charlie");
+        address davidPool = _createRegisterAndJoin(david, 100 ether, "david");
+
+        _processEpoch(); // applies deactivations and activations based on staying total
+
+        assertEq(validatorManager.getActiveValidatorCount(), 2, "PENDING_INACTIVE must not inflate base");
+        assertEq(
+            uint8(validatorManager.getValidator(alicePool).status),
+            uint8(ValidatorStatus.ACTIVE),
+            "alice stays active"
+        );
+        assertEq(
+            uint8(validatorManager.getValidator(bobPool).status),
+            uint8(ValidatorStatus.INACTIVE),
+            "bob is deactivated"
+        );
+        assertEq(
+            uint8(validatorManager.getValidator(davidPool).status),
+            uint8(ValidatorStatus.PENDING_ACTIVE),
+            "david must be kept PENDING_ACTIVE (limit hit against staying-power base)"
+        );
+    }
+
     /// @notice Audit #85: a pending fee recipient set before leave→deactivate must not
     ///         silently activate when the pool later rejoins. Without the fix, an operator
     ///         (who can call setFeeRecipient unilaterally) can plant a stale recipient,

--- a/test/unit/staking/ValidatorManagement.t.sol
+++ b/test/unit/staking/ValidatorManagement.t.sol
@@ -287,14 +287,10 @@ contract ValidatorManagementTest is Test {
 
         assertEq(validatorManager.getActiveValidatorCount(), 2, "PENDING_INACTIVE must not inflate base");
         assertEq(
-            uint8(validatorManager.getValidator(alicePool).status),
-            uint8(ValidatorStatus.ACTIVE),
-            "alice stays active"
+            uint8(validatorManager.getValidator(alicePool).status), uint8(ValidatorStatus.ACTIVE), "alice stays active"
         );
         assertEq(
-            uint8(validatorManager.getValidator(bobPool).status),
-            uint8(ValidatorStatus.INACTIVE),
-            "bob is deactivated"
+            uint8(validatorManager.getValidator(bobPool).status), uint8(ValidatorStatus.INACTIVE), "bob is deactivated"
         );
         assertEq(
             uint8(validatorManager.getValidator(davidPool).status),
@@ -318,11 +314,7 @@ contract ValidatorManagementTest is Test {
         // Operator plants a pending fee recipient
         vm.prank(alice);
         validatorManager.setFeeRecipient(alicePool, staleRecipient);
-        assertEq(
-            validatorManager.getValidator(alicePool).pendingFeeRecipient,
-            staleRecipient,
-            "pending should be set"
-        );
+        assertEq(validatorManager.getValidator(alicePool).pendingFeeRecipient, staleRecipient, "pending should be set");
         address originalRecipient = validatorManager.getValidator(alicePool).feeRecipient;
 
         // Pool owner leaves the set, validator deactivates at epoch boundary
@@ -332,15 +324,9 @@ contract ValidatorManagementTest is Test {
 
         ValidatorRecord memory afterDeactivate = validatorManager.getValidator(alicePool);
         assertEq(uint8(afterDeactivate.status), uint8(ValidatorStatus.INACTIVE), "must be INACTIVE");
+        assertEq(afterDeactivate.pendingFeeRecipient, address(0), "pendingFeeRecipient must be cleared on deactivation");
         assertEq(
-            afterDeactivate.pendingFeeRecipient,
-            address(0),
-            "pendingFeeRecipient must be cleared on deactivation"
-        );
-        assertEq(
-            afterDeactivate.feeRecipient,
-            originalRecipient,
-            "feeRecipient must remain unchanged through deactivation"
+            afterDeactivate.feeRecipient, originalRecipient, "feeRecipient must remain unchanged through deactivation"
         );
 
         // Rejoin and process another epoch — stale recipient must NOT activate
@@ -350,14 +336,9 @@ contract ValidatorManagementTest is Test {
 
         ValidatorRecord memory afterRejoin = validatorManager.getValidator(alicePool);
         assertEq(uint8(afterRejoin.status), uint8(ValidatorStatus.ACTIVE), "must be ACTIVE again");
-        assertEq(
-            afterRejoin.feeRecipient,
-            originalRecipient,
-            "stale recipient must not activate on rejoin"
-        );
+        assertEq(afterRejoin.feeRecipient, originalRecipient, "stale recipient must not activate on rejoin");
         assertTrue(
-            afterRejoin.feeRecipient != staleRecipient,
-            "stale recipient must not leak through deactivate/rejoin cycle"
+            afterRejoin.feeRecipient != staleRecipient, "stale recipient must not leak through deactivate/rejoin cycle"
         );
     }
 
@@ -457,7 +438,9 @@ contract ValidatorManagementTest is Test {
             pool, "alice", CONSENSUS_PUBKEY, CONSENSUS_POP, NETWORK_ADDRESSES, FULLNODE_ADDRESSES
         );
         ValidatorRecord memory record = validatorManager.getValidator(pool);
-        assertEq(uint8(record.status), uint8(ValidatorStatus.INACTIVE), "Should register successfully after reconfig ends");
+        assertEq(
+            uint8(record.status), uint8(ValidatorStatus.INACTIVE), "Should register successfully after reconfig ends"
+        );
     }
 
     function test_RevertWhen_registerValidator_validatorSetChangesDisabled() public {

--- a/test/unit/staking/ValidatorManagement.t.sol
+++ b/test/unit/staking/ValidatorManagement.t.sol
@@ -252,6 +252,31 @@ contract ValidatorManagementTest is Test {
     }
 
     /// @notice Test revert when validator set changes are disabled
+    /// @notice Audit #187: registerValidator must be blocked during reconfiguration
+    ///         to prevent consensus pubkey writes from interleaving with a live DKG session,
+    ///         which would produce nondeterministic DKG reads across validators.
+    function test_RevertWhen_registerValidator_duringReconfiguration() public {
+        address pool = _createStakePool(alice, MIN_BOND);
+
+        // Simulate a reconfiguration (DKG) in progress
+        mockReconfiguration.setTransitionInProgress(true);
+
+        vm.prank(alice);
+        vm.expectRevert(Errors.ReconfigurationInProgress.selector);
+        validatorManager.registerValidator(
+            pool, "alice", CONSENSUS_PUBKEY, CONSENSUS_POP, NETWORK_ADDRESSES, FULLNODE_ADDRESSES
+        );
+
+        // Once reconfiguration completes, registration succeeds again
+        mockReconfiguration.setTransitionInProgress(false);
+        vm.prank(alice);
+        validatorManager.registerValidator(
+            pool, "alice", CONSENSUS_PUBKEY, CONSENSUS_POP, NETWORK_ADDRESSES, FULLNODE_ADDRESSES
+        );
+        ValidatorRecord memory record = validatorManager.getValidator(pool);
+        assertEq(uint8(record.status), uint8(ValidatorStatus.INACTIVE), "Should register successfully after reconfig ends");
+    }
+
     function test_RevertWhen_registerValidator_validatorSetChangesDisabled() public {
         // Disable validator set changes via pending pattern
         vm.prank(SystemAddresses.GOVERNANCE);


### PR DESCRIPTION
## Summary

Addresses 4 findings from the V3.5 audit round ([gravity-audit #261](https://github.com/Galxe/gravity-audit/issues/261) backlog), each with its own commit and dedicated unit test. All 118 tests in `ValidatorManagementTest` pass.

## Fixes

### #187 — `registerValidator` missing `whenNotReconfiguring`
Consensus pubkey writes during an active DKG session produce nondeterministic reads across validators and risk epoch-transition fork. Added the modifier to match `joinValidatorSet` / `leaveValidatorSet` / `setFeeRecipient`.

### #154 — `evictUnderperformingValidators` ignores freeze switch
When `allowValidatorSetChange = false` (incident-response freeze), eviction kept running, letting the active set shrink with no replenishment path. Return early under freeze.

### #85 — Stale `pendingFeeRecipient` survives deactivate→rejoin
Operator can unilaterally set `pendingFeeRecipient` (#188 is a separate concern). On deactivate, `_applyDeactivations` previously left the pending value in storage; on rejoin, `_applyPendingFeeRecipients` would silently activate it. Clear `pendingFeeRecipient` in `_applyDeactivations`.

### #83 — PENDING_INACTIVE inflates `votingPowerIncreaseLimitPct` base
`_calculateTotalVotingPower` included PENDING_INACTIVE in the denominator used to cap new-power activation per epoch, weakening the BFT cap by a factor of `1/stayingRatio`. Added `_calculateStayingVotingPower` which filters out PENDING_INACTIVE, matching Aptos's `stake.move::on_new_epoch` (clears `pending_inactive` before computing `total_voting_power`).

## Test plan
- [x] `forge test --match-contract ValidatorManagementTest` — 118/118 passed
- [x] Each fix paired with a dedicated `test_audit_*` unit test
- [x] Audit finding comments on each referenced issue (see `Closes #...` below)

Closes Galxe/gravity-audit#83
Closes Galxe/gravity-audit#85
Closes Galxe/gravity-audit#154
Closes Galxe/gravity-audit#187

🤖 Generated with [Claude Code](https://claude.com/claude-code)