### PR TITLE
[yumin-xia] docs(spec_v2): sync specs with current contract implementation

### DIFF
--- a/spec_v2/blocker.spec.md
+++ b/spec_v2/blocker.spec.md
@@ -99,8 +99,8 @@ flowchart TD
 
 | Constant | Address | Description |
 |----------|---------|-------------|
-| `BLOCK` | `0x0000000000000000000000000001625F2016` | Blocker contract |
-| `RECONFIGURATION` | `0x0000000000000000000000000001625F2010` | Reconfiguration contract |
+| `RECONFIGURATION` | `0x0000000000000000000000000001625F2003` | Reconfiguration contract |
+| `BLOCK` | `0x0000000000000000000000000001625F2004` | Blocker contract |
 | `PERFORMANCE_TRACKER` | `0x0000000000000000000000000001625F2005` | Validator performance tracker |
 
 ---
@@ -126,7 +126,7 @@ Central orchestrator for epoch transitions. Coordinates with DKG, RandomnessConf
 ### State Variables
 
 ```solidity
-/// @notice Current epoch number (starts at 0)
+/// @notice Current epoch number (starts at 1 after genesis initialization)
 uint64 public currentEpoch;
 
 /// @notice Timestamp of last reconfiguration (microseconds)
@@ -142,7 +142,7 @@ uint64 private _transitionStartedAtEpoch;
 bool private _initialized;
 ```
 
-> **Note**: `epochIntervalMicros` is now stored in `EpochConfig` (Runtime layer), not in Reconfiguration.
+> **Note**: `epochIntervalMicros` is stored in `EpochConfig` (Runtime layer), not in Reconfiguration. On genesis, `initialize()` sets `currentEpoch = 1` and emits `EpochTransitioned(0, timestamp)` for the genesis block.
 
 ### Interface
 
@@ -156,6 +156,12 @@ interface IReconfiguration {
     // Events
     event EpochTransitionStarted(uint64 indexed epoch);
     event EpochTransitioned(uint64 indexed newEpoch, uint64 transitionTime);
+    event NewEpochEvent(
+        uint64 indexed epoch,
+        ValidatorConsensusInfo[] validators,
+        uint256 totalVotingPower,
+        uint64 timestampMicros
+    );
 
     // Initialization
     function initialize() external;
@@ -163,6 +169,7 @@ interface IReconfiguration {
     // Transition Control
     function checkAndStartTransition() external returns (bool started);
     function finishTransition(bytes calldata dkgResult) external;
+    function governanceReconfigure() external;
 
     // View Functions
     function currentEpoch() external view returns (uint64);
@@ -187,12 +194,12 @@ Initialize the contract at genesis.
 **Access Control**: GENESIS only
 
 **Behavior**:
-1. Set `currentEpoch = 0`
+1. Set `currentEpoch = 1` (post-genesis active epoch)
 2. Set `lastReconfigurationTime` to current timestamp
 3. Set `transitionState = Idle`
-4. Emit `EpochTransitioned(0, timestamp)`
+4. Emit `EpochTransitioned(0, timestamp)` (epoch 0 = genesis marker)
 
-> **Note**: `epochIntervalMicros` is no longer set here; it is initialized separately in `EpochConfig`.
+> **Note**: `epochIntervalMicros` is not set here; it is initialized separately in `EpochConfig`.
 
 **Reverts**:
 - `AlreadyInitialized` - Contract already initialized
@@ -207,17 +214,15 @@ Check and start epoch transition if conditions are met.
 
 **Behavior**:
 1. If `transitionState == DkgInProgress`, return false (no-op)
-2. Check if time has elapsed: `currentTime >= lastReconfigurationTime + EpochConfig.epochIntervalMicros()`
-3. If not ready, return false
-4. Get current validator set from ValidatorManagement
-5. Get randomness config from RandomnessConfig
-6. Clear any stale DKG session
-7. Start DKG session with validators and config
-8. Set `transitionState = DkgInProgress`
-9. Emit `EpochTransitionStarted(currentEpoch)`
-10. Return true
+2. Check if time has elapsed: `currentTime >= lastReconfigurationTime + EpochConfig.epochIntervalMicros()`. If not, return false.
+3. **Evict underperforming validators** via `ValidatorManagement.evictUnderperformingValidators()` (uses the closing epoch's performance data, which is still available because the perf tracker has not yet been reset).
+4. Read randomness variant from `RandomnessConfig.getCurrentConfig()`.
+5. Branch:
+   - **If variant == Off (DKG disabled)**: call `_doImmediateReconfigure()` (clears any stale DKG session, then runs `_applyReconfiguration()` inline — no `EpochTransitionStarted` event, no state transition through `DkgInProgress`).
+   - **If variant != Off**: call `_startDkgSession(config)` — fetch dealer/target consensus infos, clear stale DKG session, `DKG.start(...)`, set `transitionState = DkgInProgress`, emit `EpochTransitionStarted(currentEpoch)`.
+6. Return true.
 
-**Returns**: `bool started` - True if DKG was started
+**Returns**: `bool started` - True if a transition was started (DKG path) or applied (immediate path).
 
 ---
 
@@ -225,34 +230,52 @@ Check and start epoch transition if conditions are met.
 
 Finish epoch transition after DKG completes.
 
-**Access Control**: SYSTEM_CALLER (consensus engine) or GOVERNANCE (governance)
+**Access Control**: SYSTEM_CALLER (consensus engine) or GOVERNANCE (force-end)
 
 **Parameters**:
-- `dkgResult` - DKG transcript (empty bytes for force-end or if DKG disabled)
+- `dkgResult` - DKG transcript (empty bytes = governance force-end without transcript)
 
 **Behavior**:
-1. Require `transitionState == DkgInProgress`
-2. If `dkgResult` is non-empty, finish DKG session
-3. Clear any incomplete DKG session
-4. Apply pending RandomnessConfig
-5. **Auto-evict underperforming validators** via `ValidatorManagement.evictUnderperformingValidators()`
-6. **Call `ValidatorManagement.onNewEpoch()` BEFORE incrementing epoch** (Aptos pattern)
-7. Reset `ValidatorPerformanceTracker.onNewEpoch(activeValidatorCount)`
-8. Increment epoch: `currentEpoch++`
-9. Update `lastReconfigurationTime`
-10. Set `transitionState = Idle`
-11. Emit `EpochTransitioned(newEpoch, timestamp)`
-
-> **Important**: The ordering matters:
-> - Config is applied first so that `autoEvictEnabled` reflects the latest governance decision
-> - Auto-eviction runs after config apply and before `onNewEpoch()` so evicted validators go ACTIVE → PENDING_INACTIVE here, then PENDING_INACTIVE → INACTIVE in `onNewEpoch()` — all within one epoch transition
-> - `ValidatorManagement.onNewEpoch()` is called before the epoch is incremented, matching Aptos's `reconfiguration.move`
-> - Performance tracker is reset after `onNewEpoch()` so perf data is available during epoch processing
+1. Require `transitionState == DkgInProgress`.
+2. If `dkgResult.length > 0`, call `DKG.finish(dkgResult)`.
+3. `DKG.tryClearIncompleteSession()`.
+4. Call `_applyReconfiguration()` (see below).
 
 **Reverts**:
 - `ReconfigurationNotInProgress` - No transition in progress
 
 ---
+
+### `governanceReconfigure()`
+
+Force an immediate reconfiguration from governance (bypasses the time check).
+
+**Access Control**: GOVERNANCE only
+
+**Behavior**:
+1. Require `transitionState != DkgInProgress` (if one is in progress, governance should call `finishTransition` instead). Revert with `ReconfigurationInProgress` otherwise.
+2. Evict underperforming validators.
+3. Read randomness variant.
+4. If `Off`, run `_doImmediateReconfigure()`; otherwise `_startDkgSession(config)` — governance must follow up with `finishTransition(...)`.
+
+---
+
+### `_applyReconfiguration()` (internal)
+
+Core reconfiguration body shared by `finishTransition()` and `_doImmediateReconfigure()`:
+
+1. **Apply pending configs** (order: RandomnessConfig → ConsensusConfig → ExecutionConfig → ValidatorConfig → VersionConfig → GovernanceConfig → StakingConfig → EpochConfig).
+2. **`ValidatorManagement.onNewEpoch()`** (before epoch increment, matching Aptos).
+3. **Reset performance tracker**: read `getActiveValidatorCount()` and call `PerformanceTracker.onNewEpoch(newCount)`. MUST happen after `onNewEpoch()` — it destructively erases the closing epoch's perf data.
+4. Increment epoch: `currentEpoch++`.
+5. `lastReconfigurationTime = now`.
+6. `transitionState = Idle`.
+7. Emit `EpochTransitioned(newEpoch, timestamp)` and `NewEpochEvent(newEpoch, validators, totalVotingPower, timestamp)`.
+
+> **Important ordering notes**:
+> - Eviction is performed in `checkAndStartTransition()` / `governanceReconfigure()` (before DKG starts), NOT inside `_applyReconfiguration()`. This ensures the closing epoch's performance data is consulted before the perf tracker is reset.
+> - `onNewEpoch()` is called before the epoch number is incremented, matching Aptos's `reconfiguration.move`.
+> - `NewEpochEvent` carries the finalized validator set for the consensus engine.
 
 ---
 
@@ -304,15 +327,15 @@ Called by VM runtime at the start of each block.
 - `failedProposerIndices` - Indices of validators who failed to propose (for future performance tracking)
 - `timestampMicros` - Block timestamp in microseconds
 
-**Behavior**:
-1. Resolve proposer address:
-   - If `proposerIndex == type(uint64).max` (NIL block): use `SYSTEM_CALLER`
-   - Otherwise: query `ValidatorManagement.getActiveValidatorByIndex(proposerIndex).validator`
-2. Update global timestamp via `Timestamp.updateGlobalTime(validatorAddr, timestampMicros)`
-3. Update `ValidatorPerformanceTracker.updateStatistics(proposerIndex, failedProposerIndices)`
-4. Call `Reconfiguration.checkAndStartTransition()`
-5. Get current epoch from Reconfiguration
-6. Emit `BlockStarted(block.number, epoch, validatorAddr, timestampMicros)`
+**Behavior** (in this exact order — perf tracker update MUST precede the reconfig check because the block that triggers the transition is the last block of the closing epoch):
+1. `ValidatorPerformanceTracker.updateStatistics(proposerIndex, failedProposerIndices)` — record the closing epoch's proposal outcomes first.
+2. Resolve proposer address:
+   - If `proposerIndex == NIL_PROPOSER_INDEX (type(uint64).max)` (NIL block): use `SYSTEM_CALLER`.
+   - Otherwise: `ValidatorManagement.getActiveValidatorByIndex(proposerIndex).validator` (returns the stake-pool address).
+3. `Timestamp.updateGlobalTime(validatorAddr, timestampMicros)` — normal blocks must advance time; NIL blocks keep the same timestamp.
+4. `Reconfiguration.checkAndStartTransition()` — may trigger auto-eviction + DKG/immediate reconfigure.
+5. Read `Reconfiguration.currentEpoch()`.
+6. Emit `BlockStarted(block.number, epoch, validatorAddr, timestampMicros)`.
 
 > **Note**: Using validator indices (instead of consensus public keys) aligns with Aptos's `block_prologue` approach where the consensus layer passes proposer indices.
 
@@ -325,6 +348,7 @@ Called by VM runtime at the start of each block.
 | `Reconfiguration.initialize()` | GENESIS only |
 | `Reconfiguration.checkAndStartTransition()` | BLOCK only |
 | `Reconfiguration.finishTransition()` | SYSTEM_CALLER or GOVERNANCE |
+| `Reconfiguration.governanceReconfigure()` | GOVERNANCE only |
 | `Reconfiguration` view functions | Anyone |
 | `Blocker.initialize()` | GENESIS only |
 | `Blocker.onBlockStart()` | SYSTEM_CALLER only |
@@ -345,29 +369,39 @@ Called by VM runtime at the start of each block.
 │                        EPOCH TRANSITION LIFECYCLE                            │
 ├─────────────────────────────────────────────────────────────────────────────┤
 │                                                                              │
-│  PHASE 1: DETECTION & DKG START                                              │
-│  ─────────────────────────────                                               │
+│  PHASE 1: DETECTION, EVICTION, DKG START                                     │
+│  ────────────────────────────────────                                        │
 │                                                                              │
 │    VM Runtime                                                                │
 │       │                                                                      │
-│       │ onBlockStart(proposer, failed, timestamp)                            │
+│       │ onBlockStart(proposerIndex, failed, timestamp)                       │
 │       ▼                                                                      │
 │    Blocker                                                                   │
 │       │                                                                      │
-│       ├─► Timestamp.updateGlobalTime()                                       │
+│       ├─► PerformanceTracker.updateStatistics(proposer, failed)  (FIRST)    │
+│       ├─► resolveProposer(proposerIndex) (NIL → SYSTEM_CALLER)               │
+│       ├─► Timestamp.updateGlobalTime(validatorAddr, ts)                      │
 │       │                                                                      │
 │       └─► Reconfiguration.checkAndStartTransition()                          │
 │               │                                                              │
 │               ├── Check: time elapsed && state == Idle?                      │
 │               │     └── If NO → return false                                 │
 │               │                                                              │
-│               ├── ValidatorManagement.getActiveValidators()                  │
+│               ├── ValidatorManagement.evictUnderperformingValidators()       │
 │               ├── RandomnessConfig.getCurrentConfig()                        │
-│               ├── DKG.tryClearIncompleteSession()                            │
-│               ├── DKG.start(epoch, config, validators, validators)           │
-│               │     └── Emits DKGStartEvent                                  │
-│               ├── transitionState = DkgInProgress                            │
-│               └── Emit EpochTransitionStarted                                │
+│               │                                                              │
+│               ├── IF variant == Off (DKG disabled):                          │
+│               │     ├── DKG.tryClearIncompleteSession()                      │
+│               │     └── _applyReconfiguration() ──► jump to Phase 2 body    │
+│               │                                                              │
+│               └── ELSE (DKG enabled):                                        │
+│                     ├── ValidatorManagement.getCurValidatorConsensusInfos()  │
+│                     ├── ValidatorManagement.getNextValidatorConsensusInfos() │
+│                     ├── DKG.tryClearIncompleteSession()                      │
+│                     ├── DKG.start(currentEpoch, config, dealers, targets)    │
+│                     │     └── Emits DKGStartEvent                            │
+│                     ├── transitionState = DkgInProgress                      │
+│                     └── Emit EpochTransitionStarted                          │
 │                                                                              │
 ├─────────────────────────────────────────────────────────────────────────────┤
 │                                                                              │
@@ -375,8 +409,8 @@ Called by VM runtime at the start of each block.
 │                                                                              │
 ├─────────────────────────────────────────────────────────────────────────────┤
 │                                                                              │
-│  PHASE 2: FINISH TRANSITION                                                  │
-│  ─────────────────────────                                                   │
+│  PHASE 2: FINISH TRANSITION (_applyReconfiguration body)                     │
+│  ───────────────────────────────────────────────────                         │
 │                                                                              │
 │    Consensus Engine / Governance                                             │
 │       │                                                                      │
@@ -387,16 +421,22 @@ Called by VM runtime at the start of each block.
 │       ├── Validate: state == DkgInProgress                                   │
 │       ├── DKG.finish(dkgResult) (if result provided)                         │
 │       ├── DKG.tryClearIncompleteSession()                                    │
+│       │                                                                      │
+│       │  [ _applyReconfiguration() shared body ]                             │
 │       ├── RandomnessConfig.applyPendingConfig()                              │
+│       ├── ConsensusConfig.applyPendingConfig()                               │
+│       ├── ExecutionConfig.applyPendingConfig()                               │
+│       ├── ValidatorConfig.applyPendingConfig()                               │
+│       ├── VersionConfig.applyPendingConfig()                                 │
 │       ├── GovernanceConfig.applyPendingConfig()                              │
+│       ├── StakingConfig.applyPendingConfig()                                 │
 │       ├── EpochConfig.applyPendingConfig()                                   │
-│       ├── ValidatorManagement.evictUnderperformingValidators()  ◄── NEW      │
 │       ├── ValidatorManagement.onNewEpoch() (BEFORE incrementing epoch)       │
-│       ├── ValidatorPerformanceTracker.onNewEpoch(activeCount)                │
+│       ├── PerformanceTracker.onNewEpoch(getActiveValidatorCount())           │
 │       ├── currentEpoch++                                                     │
 │       ├── lastReconfigurationTime = now                                      │
 │       ├── transitionState = Idle                                             │
-│       └── Emit EpochTransitioned + NewEpochEvent                             │
+│       └── Emit EpochTransitioned + NewEpochEvent(validators, totalPower)     │
 │                                                                              │
 └─────────────────────────────────────────────────────────────────────────────┘
 ```

--- a/spec_v2/foundation.spec.md
+++ b/spec_v2/foundation.spec.md
@@ -59,103 +59,54 @@ graph TD
 
 ## Contract: `SystemAddresses.sol`
 
-A library containing compile-time constants for all Gravity system addresses. These addresses follow the `0x1625F2xxx`
-pattern and are reserved at genesis.
+A library containing compile-time constants for all Gravity system addresses. Addresses are segmented into ranges
+by layer (consensus engine, runtime, staking/validator, governance, oracle, precompiles) and are reserved at genesis.
+
+### Address Ranges
+
+| Range        | Purpose                                   |
+| ------------ | ----------------------------------------- |
+| `0x1625F0xxx` | Consensus engine contracts / caller       |
+| `0x1625F1xxx` | Runtime configurations                    |
+| `0x1625F2xxx` | Staking & validator                       |
+| `0x1625F3xxx` | Governance                                |
+| `0x1625F4xxx` | Oracle                                    |
+| `0x1625F5xxx` | Precompiles                               |
 
 ### Address Table
 
-| Constant            | Address                                        | Description                       |
-| ------------------- | ---------------------------------------------- | --------------------------------- |
-| `SYSTEM_CALLER`     | `0x0000000000000000000000000001625F2000`       | VM/runtime system calls           |
-| `GENESIS`           | `0x0000000000000000000000000001625F2008`       | Genesis initialization contract   |
-| `RECONFIGURATION`   | `0x0000000000000000000000000001625F2010`       | Epoch lifecycle management        |
-| `STAKE_CONFIG`      | `0x0000000000000000000000000001625F2011`       | Staking configuration parameters  |
-| `STAKING`           | `0x0000000000000000000000000001625F2012`       | Governance staking factory        |
-| `VALIDATOR_MANAGER` | `0x0000000000000000000000000001625F2013`       | Validator set management          |
-| `GOVERNANCE`        | `0x0000000000000000000000000001625F2014`       | Governance contract               |
-| `VALIDATOR_CONFIG`  | `0x0000000000000000000000000001625F2015`       | Validator config parameters       |
-| `BLOCK`             | `0x0000000000000000000000000001625F2016`       | Block prologue/epilogue handler   |
-| `TIMESTAMP`         | `0x0000000000000000000000000001625F2017`       | On-chain time oracle              |
-| `JWK_MANAGER`       | `0x0000000000000000000000000001625F2018`       | JWK management for keyless auth   |
-| `NATIVE_ORACLE`     | `0x0000000000000000000000000001625F2023`       | Native oracle                     |
-| `RANDOMNESS_CONFIG` | `0x0000000000000000000000000001625F2024`       | DKG threshold configuration       |
-| `DKG`               | `0x0000000000000000000000000001625F2025`       | Distributed Key Generation        |
-| `GOVERNANCE_CONFIG` | `0x0000000000000000000000000001625F2026`       | Governance voting parameters      |
+| Constant                       | Address                                        | Description                                     |
+| ------------------------------ | ---------------------------------------------- | ----------------------------------------------- |
+| `SYSTEM_CALLER`                | `0x0000000000000000000000000001625F0000`       | VM/runtime system caller                        |
+| `GENESIS`                      | `0x0000000000000000000000000001625F0001`       | Genesis initialization contract                 |
+| `TIMESTAMP`                    | `0x0000000000000000000000000001625F1000`       | On-chain time oracle                            |
+| `STAKE_CONFIG`                 | `0x0000000000000000000000000001625F1001`       | Staking configuration parameters                |
+| `VALIDATOR_CONFIG`             | `0x0000000000000000000000000001625F1002`       | Validator config parameters                     |
+| `RANDOMNESS_CONFIG`            | `0x0000000000000000000000000001625F1003`       | DKG threshold configuration                     |
+| `GOVERNANCE_CONFIG`            | `0x0000000000000000000000000001625F1004`       | Governance voting parameters                    |
+| `EPOCH_CONFIG`                 | `0x0000000000000000000000000001625F1005`       | Epoch interval configuration                    |
+| `VERSION_CONFIG`               | `0x0000000000000000000000000001625F1006`       | Protocol major-version marker                   |
+| `CONSENSUS_CONFIG`             | `0x0000000000000000000000000001625F1007`       | Consensus parameters (BCS-serialized bytes)     |
+| `EXECUTION_CONFIG`             | `0x0000000000000000000000000001625F1008`       | VM execution parameters (BCS-serialized bytes)  |
+| `ORACLE_TASK_CONFIG`           | `0x0000000000000000000000000001625F1009`       | Continuous oracle task registry                 |
+| `ON_DEMAND_ORACLE_TASK_CONFIG` | `0x0000000000000000000000000001625F100A`       | On-demand oracle request-type registry          |
+| `STAKING`                      | `0x0000000000000000000000000001625F2000`       | Staking factory (StakePool deployer)            |
+| `VALIDATOR_MANAGER`            | `0x0000000000000000000000000001625F2001`       | Validator set management                        |
+| `DKG`                          | `0x0000000000000000000000000001625F2002`       | Distributed Key Generation                      |
+| `RECONFIGURATION`              | `0x0000000000000000000000000001625F2003`       | Epoch lifecycle management                      |
+| `BLOCK`                        | `0x0000000000000000000000000001625F2004`       | Block prologue/epilogue handler                 |
+| `PERFORMANCE_TRACKER`          | `0x0000000000000000000000000001625F2005`       | Validator performance tracker                   |
+| `GOVERNANCE`                   | `0x0000000000000000000000000001625F3000`       | Governance contract                             |
+| `NATIVE_ORACLE`                | `0x0000000000000000000000000001625F4000`       | Native oracle                                   |
+| `JWK_MANAGER`                  | `0x0000000000000000000000000001625F4001`       | JWK management for keyless auth                 |
+| `ORACLE_REQUEST_QUEUE`         | `0x0000000000000000000000000001625F4002`       | On-demand oracle request queue                  |
+| `NATIVE_MINT_PRECOMPILE`       | `0x0000000000000000000000000001625F5000`       | Native G token mint precompile                  |
+| `BLS_POP_VERIFY_PRECOMPILE`    | `0x0000000000000000000000000001625F5001`       | BLS12-381 PoP verification precompile           |
 
 ### Implementation
 
-```solidity
-// SPDX-License-Identifier: MIT
-pragma solidity ^0.8.30;
-
-/// @title SystemAddresses
-/// @notice Compile-time constants for Gravity system addresses
-/// @dev Import this library to get zero-cost address access (inlined by compiler)
-///      All addresses use the 0x1625F2xxx pattern reserved at genesis
-library SystemAddresses {
-    /// @notice VM/runtime system caller address
-    /// @dev Used for block prologue, NIL blocks, and other system-initiated calls
-    address internal constant SYSTEM_CALLER = 0x0000000000000000000000000001625F2000;
-
-    /// @notice Genesis initialization contract
-    /// @dev Only active during chain initialization
-    address internal constant GENESIS = 0x0000000000000000000000000001625F2008;
-
-    /// @notice Epoch lifecycle manager
-    /// @dev Handles epoch transitions and reconfiguration
-    address internal constant RECONFIGURATION = 0x0000000000000000000000000001625F2010;
-
-    /// @notice Staking configuration contract
-    /// @dev Stores staking parameters (lockup duration, minimum stake, etc.)
-    address internal constant STAKE_CONFIG = 0x0000000000000000000000000001625F2011;
-
-    /// @notice Governance staking contract
-    /// @dev Anyone can stake tokens to participate in governance voting
-    address internal constant STAKING = 0x0000000000000000000000000001625F2012;
-
-    /// @notice Validator set management contract
-    /// @dev Manages validator registration, bonding, and set transitions
-    address internal constant VALIDATOR_MANAGER = 0x0000000000000000000000000001625F2013;
-
-    /// @notice Governance contract
-    /// @dev Handles proposals, voting, and execution of governance decisions
-    address internal constant GOVERNANCE = 0x0000000000000000000000000001625F2014;
-
-    /// @notice Validator configuration contract
-    /// @dev Stores validator parameters (minimum/maximum bond, unbonding delay, etc.)
-    address internal constant VALIDATOR_CONFIG = 0x0000000000000000000000000001625F2015;
-
-    /// @notice Block prologue/epilogue handler
-    /// @dev Called by VM at start/end of each block
-    address internal constant BLOCK = 0x0000000000000000000000000001625F2016;
-
-    /// @notice On-chain timestamp oracle
-    /// @dev Provides microsecond-precision time, updated in block prologue
-    address internal constant TIMESTAMP = 0x0000000000000000000000000001625F2017;
-
-    /// @notice JWK (JSON Web Key) manager
-    /// @dev Manages JWKs for keyless account authentication
-    address internal constant JWK_MANAGER = 0x0000000000000000000000000001625F2018;
-
-    /// @notice Native oracle contract
-    /// @dev Stores verified data from external sources (blockchains, JWK providers, DNS).
-    ///      Supports hash-only mode (storage-efficient) and data mode (direct access).
-    ///      Data is recorded by consensus engine via SYSTEM_CALLER.
-    address internal constant NATIVE_ORACLE = 0x0000000000000000000000000001625F2023;
-
-    /// @notice Randomness configuration contract
-    /// @dev Stores DKG threshold parameters for on-chain randomness
-    address internal constant RANDOMNESS_CONFIG = 0x0000000000000000000000000001625F2024;
-
-    /// @notice DKG (Distributed Key Generation) contract
-    /// @dev Manages DKG session lifecycle for epoch transitions
-    address internal constant DKG = 0x0000000000000000000000000001625F2025;
-
-    /// @notice Governance configuration contract
-    /// @dev Stores governance parameters (voting threshold, proposal stake, etc.)
-    address internal constant GOVERNANCE_CONFIG = 0x0000000000000000000000000001625F2026;
-}
-```
+See `src/foundation/SystemAddresses.sol` for the authoritative list. Each constant is `address internal constant`
+and inlined at compile time.
 
 ### Gas Comparison
 
@@ -306,30 +257,29 @@ struct ValidatorConsensusInfo {
     bytes consensusPop;
     /// @notice Voting power derived from bond
     uint256 votingPower;
+    /// @notice Index in active validator array of an epoch
+    uint64 validatorIndex;
+    /// @notice Network addresses for P2P communication
+    bytes networkAddresses;
+    /// @notice Fullnode addresses for sync
+    bytes fullnodeAddresses;
 }
 
 /// @notice Full validator record
-/// @dev All timestamps are in microseconds (from Timestamp contract).
+/// @dev Owner / operator / voter roles are sourced from the StakePool (the validator's
+///      bond-holding pool), not stored on the record. All timestamps are microseconds.
 struct ValidatorRecord {
-    /// @notice Immutable validator identity address
+    /// @notice Immutable validator identity address (the StakePool address)
     address validator;
     /// @notice Display name (max 31 bytes)
     string moniker;
-    /// @notice Owner address (controls bond, can set operator)
-    address owner;
-    /// @notice Operator address (can rotate keys, request join/leave)
-    address operator;
     /// @notice Current lifecycle status
     ValidatorStatus status;
-    
-    // === Bond Management (simplified - no 4-bucket model) ===
-    /// @notice Current validator bond amount
+
+    // === Bond Management ===
+    /// @notice Current validator bond amount (voting power snapshot at epoch boundary)
     uint256 bond;
-    /// @notice Pending unbond amount (effective next epoch)
-    uint256 pendingUnbond;
-    /// @notice When unbond becomes withdrawable (microseconds)
-    uint64 unbondAvailableAt;
-    
+
     // === Consensus Key Material ===
     /// @notice BLS consensus public key
     bytes consensusPubkey;
@@ -339,30 +289,33 @@ struct ValidatorRecord {
     bytes networkAddresses;
     /// @notice Fullnode addresses
     bytes fullnodeAddresses;
-    
+
     // === Fee Distribution ===
     /// @notice Current fee recipient address
     address feeRecipient;
     /// @notice Pending fee recipient (applied next epoch)
     address pendingFeeRecipient;
-    
+
     // === Optional External Staking Pool ===
-    /// @notice Address of IValidatorStakingPool (0x0 if none)
+    /// @notice Address of IValidatorStakingPool (address(0) if none)
     address stakingPool;
-    
+
     // === Indexing ===
     /// @notice Index in active validator array (only valid when ACTIVE/PENDING_INACTIVE)
     uint64 validatorIndex;
-}
 
-/// @notice Compact validator info for queries
-struct ValidatorInfo {
-    address validator;
-    uint64 votingPower;
-    uint64 validatorIndex;
-    bytes consensusPubkey;
+    // === Pending Consensus Key Rotation (V3.5 audit fix D2-3) ===
+    /// @notice Pending BLS consensus public key (applied at next epoch boundary).
+    ///         Empty bytes mean no pending rotation.
+    bytes pendingConsensusPubkey;
+    /// @notice Pending proof of possession for the pending BLS key
+    bytes pendingConsensusPop;
 }
 ```
+
+> Note: unbond accounting (`pendingUnbond`, `unbondAvailableAt`) and the `owner` / `operator`
+> fields were removed in favor of the StakePool-centric model — roles and bond state live on
+> the `StakePool` that represents the validator. See [staking.spec.md](./staking.spec.md).
 
 ### Governance Types
 
@@ -404,231 +357,33 @@ struct Proposal {
 }
 ```
 
-### Full Implementation
-
-```solidity
-// SPDX-License-Identifier: MIT
-pragma solidity ^0.8.30;
-
-/// @title Types
-/// @notice Core data types for Gravity system contracts
-
-// ============================================================================
-// STAKING TYPES (for governance participation — anyone can stake)
-// ============================================================================
-
-/// @notice Stake position for governance voting
-struct StakePosition {
-    uint256 amount;
-    uint64 lockedUntil;
-    uint64 stakedAt;
-}
-
-// ============================================================================
-// VALIDATOR TYPES (for consensus participation)
-// ============================================================================
-
-/// @notice Validator lifecycle status
-enum ValidatorStatus {
-    INACTIVE,
-    PENDING_ACTIVE,
-    ACTIVE,
-    PENDING_INACTIVE
-}
-
-/// @notice Validator consensus info (packed for consensus engine)
-struct ValidatorConsensusInfo {
-    address validator;
-    bytes consensusPubkey;
-    bytes consensusPop;
-    uint256 votingPower;
-}
-
-/// @notice Full validator record
-struct ValidatorRecord {
-    address validator;
-    string moniker;
-    address owner;
-    address operator;
-    ValidatorStatus status;
-    uint256 bond;
-    uint256 pendingUnbond;
-    uint64 unbondAvailableAt;
-    bytes consensusPubkey;
-    bytes consensusPop;
-    bytes networkAddresses;
-    bytes fullnodeAddresses;
-    address feeRecipient;
-    address pendingFeeRecipient;
-    address stakingPool;
-    uint64 validatorIndex;
-}
-
-/// @notice Compact validator info for queries
-struct ValidatorInfo {
-    address validator;
-    uint64 votingPower;
-    uint64 validatorIndex;
-    bytes consensusPubkey;
-}
-
-// ============================================================================
-// GOVERNANCE TYPES
-// ============================================================================
-
-/// @notice Governance proposal lifecycle state
-enum ProposalState {
-    PENDING,
-    SUCCEEDED,
-    FAILED,
-    EXECUTED,
-    CANCELLED
-}
-
-/// @notice Governance proposal
-struct Proposal {
-    uint64 id;
-    address proposer;
-    bytes32 executionHash;
-    string metadataUri;
-    uint64 creationTime;
-    uint64 expirationTime;
-    uint128 minVoteThreshold;
-    uint128 yesVotes;
-    uint128 noVotes;
-    bool isResolved;
-    uint64 resolutionTime;
-}
-```
+See `src/foundation/Types.sol` for the authoritative definitions.
 
 ---
 
 ## Contract: `Errors.sol`
 
 Custom errors organized by domain. Using custom errors instead of require strings saves gas and provides structured
-error data.
+error data. See `src/foundation/Errors.sol` for the authoritative definitions — the library groups errors into
+Staking-factory, StakePool, Validator, Reconfiguration, Governance, Timestamp, Config, RandomnessConfig, DKG,
+NativeOracle, VersionConfig, ValidatorManagement, ValidatorConfig, GovernanceConfig, EpochConfig,
+Consensus/ExecutionConfig, JWK-manager, Role-change, and General sections.
 
-### Implementation
+Notable errors that pinned-down behavior of the system:
 
-```solidity
-// SPDX-License-Identifier: MIT
-pragma solidity ^0.8.30;
-
-/// @title Errors
-/// @notice Custom errors for Gravity system contracts
-
-library Errors {
-    // ========================================================================
-    // STAKING ERRORS
-    // ========================================================================
-
-    /// @notice Staker has no stake position
-    error NoStakePosition(address staker);
-
-    /// @notice Stake amount is insufficient
-    error InsufficientStake(uint256 required, uint256 actual);
-
-    /// @notice Lockup period has not expired
-    error LockupNotExpired(uint64 lockedUntil, uint64 currentTime);
-
-    /// @notice Amount cannot be zero
-    error ZeroAmount();
-
-    // ========================================================================
-    // VALIDATOR ERRORS
-    // ========================================================================
-
-    /// @notice Validator does not exist
-    error ValidatorNotFound(address validator);
-
-    /// @notice Validator already registered
-    error ValidatorAlreadyExists(address validator);
-
-    /// @notice Invalid validator status for operation
-    error InvalidStatus(uint8 expected, uint8 actual);
-
-    /// @notice Bond amount is insufficient
-    error InsufficientBond(uint256 required, uint256 actual);
-
-    /// @notice Bond exceeds maximum allowed
-    error ExceedsMaximumBond(uint256 maximum, uint256 actual);
-
-    /// @notice Caller is not the validator owner
-    error NotOwner(address expected, address actual);
-
-    /// @notice Caller is not the validator operator
-    error NotOperator(address expected, address actual);
-
-    /// @notice Caller is not the pool staker
-    error NotStaker(address caller, address staker);
-
-    /// @notice Validator set changes are disabled
-    error ValidatorSetChangesDisabled();
-
-    /// @notice Maximum validator set size reached
-    error MaxValidatorSetSizeReached(uint256 maxSize);
-
-    /// @notice Voting power increase exceeds limit
-    error VotingPowerIncreaseLimitExceeded(uint256 limit, uint256 actual);
-
-    /// @notice Moniker exceeds maximum length
-    error MonikerTooLong(uint256 maxLength, uint256 actualLength);
-
-    /// @notice Unbond period has not elapsed
-    error UnbondNotReady(uint64 availableAt, uint64 currentTime);
-
-    // ========================================================================
-    // RECONFIGURATION ERRORS
-    // ========================================================================
-
-    /// @notice Reconfiguration is already in progress
-    error ReconfigurationInProgress();
-
-    /// @notice No reconfiguration in progress
-    error ReconfigurationNotInProgress();
-
-    /// @notice Epoch has not yet ended
-    error EpochNotYetEnded(uint64 nextEpochTime, uint64 currentTime);
-
-    // ========================================================================
-    // GOVERNANCE ERRORS
-    // ========================================================================
-
-    /// @notice Proposal not found
-    error ProposalNotFound(uint64 proposalId);
-
-    /// @notice Voting period has ended
-    error VotingPeriodEnded(uint64 expirationTime);
-
-    /// @notice Voting period has not ended
-    error VotingPeriodNotEnded(uint64 expirationTime);
-
-    /// @notice Proposal has already been resolved
-    error ProposalAlreadyResolved(uint64 proposalId);
-
-    /// @notice Execution hash does not match
-    error ExecutionHashMismatch(bytes32 expected, bytes32 actual);
-
-    /// @notice Lockup duration is insufficient for operation
-    error InsufficientLockup(uint64 required, uint64 actual);
-
-    /// @notice Atomic resolution is not allowed
-    error AtomicResolutionNotAllowed();
-
-    /// @notice Voting power is insufficient
-    error InsufficientVotingPower(uint256 required, uint256 actual);
-
-    // ========================================================================
-    // TIMESTAMP ERRORS
-    // ========================================================================
-
-    /// @notice Timestamp must advance for normal blocks
-    error TimestampMustAdvance(uint64 proposed, uint64 current);
-
-    /// @notice Timestamp must equal current for NIL blocks
-    error TimestampMustEqual(uint64 proposed, uint64 current);
-}
-```
+| Error                                  | Meaning                                                               |
+| -------------------------------------- | --------------------------------------------------------------------- |
+| `NonceNotSequential`                   | Oracle nonces must be `currentNonce + 1` (no gaps)                    |
+| `ExecutionFailed(uint64, bytes)`       | Governance execute() includes revert reason in the error              |
+| `ProposalNotResolved`                  | execute() must be preceded by explicit resolve()                      |
+| `TooManyProposalTargets`               | Governance proposals are capped at `MAX_PROPOSAL_TARGETS = 100`       |
+| `InvalidProposalId`                    | Sentinel 0 is reserved — IDs start at 1                               |
+| `HasPendingWithdrawals`                | StakePool staker role cannot change while withdrawals are unclaimed   |
+| `RoleChangeDelayTooShort`              | StakePool per-role timelock delays have a minimum                     |
+| `RoleChangeTooEarly` / `NoPendingRoleChange` / `NotPendingRole` / `RoleAlreadySet` | 2-step propose/accept timelock guards |
+| `InvalidAutoEvictThresholdPct`         | `autoEvictThresholdPct` must be in 0–100                              |
+| `TooManyPendingBuckets`                | StakePool withdrawal buckets are capped at 1,000                      |
+| `WithdrawalWouldBreachMinimumBond`     | Unstake rejected if it drops an active validator's bond below minimum |
 
 ---
 

--- a/spec_v2/governance.spec.md
+++ b/spec_v2/governance.spec.md
@@ -118,10 +118,10 @@ graph TD
 
 ## System Addresses
 
-| Constant            | Address                                    | Description                  |
-| ------------------- | ------------------------------------------ | ---------------------------- |
-| `GOVERNANCE_CONFIG` | `0x0000000000000000000000000001625F2026`   | Governance config contract   |
-| `GOVERNANCE`        | `0x0000000000000000000000000001625F2014`   | Governance contract          |
+| Constant            | Address                                    | Description                                        |
+| ------------------- | ------------------------------------------ | -------------------------------------------------- |
+| `GOVERNANCE_CONFIG` | `0x0000000000000000000000000001625F1004`   | Governance config contract (lives in Runtime layer) |
+| `GOVERNANCE`        | `0x0000000000000000000000000001625F3000`   | Governance contract                                |
 
 ---
 
@@ -182,71 +182,12 @@ graph TD
 
 ## Contract: `GovernanceConfig.sol`
 
-### Purpose
+**This contract lives in the Runtime layer** (address `0x0000000000000000000000000001625F1004`). See **[runtime.spec.md → Contract: GovernanceConfig.sol](./runtime.spec.md#contract-governanceconfigsol)** for the full specification, including state variables, interface, events, validation rules, and the pending-config pattern (`setForNextEpoch` / `applyPendingConfig`).
 
-Configuration parameters for governance. Initialized at genesis, updatable via governance (GOVERNANCE).
-
-### System Address
-
-| Constant            | Address                                    | Description              |
-| ------------------- | ------------------------------------------ | ------------------------ |
-| `GOVERNANCE_CONFIG` | `0x0000000000000000000000000001625F2026`   | Governance configuration |
-
-### State Variables
-
-```solidity
-/// @notice Minimum total votes (yes + no) required for quorum
-uint128 public minVotingThreshold;
-
-/// @notice Minimum voting power required to create a proposal
-uint256 public requiredProposerStake;
-
-/// @notice Duration of voting period in microseconds
-uint64 public votingDurationMicros;
-
-/// @notice Whether contract has been initialized
-bool private _initialized;
-```
-
-### Interface
-
-```solidity
-interface IGovernanceConfig {
-    // === Events ===
-    event ConfigUpdated(bytes32 indexed param, uint256 oldValue, uint256 newValue);
-
-    // === View Functions ===
-    function minVotingThreshold() external view returns (uint128);
-    function requiredProposerStake() external view returns (uint256);
-    function votingDurationMicros() external view returns (uint64);
-
-    // === Initialization ===
-    function initialize(
-        uint128 _minVotingThreshold,
-        uint256 _requiredProposerStake,
-        uint64 _votingDurationMicros
-    ) external;
-
-    // === Setters (GOVERNANCE only) ===
-    function setMinVotingThreshold(uint128 _minVotingThreshold) external;
-    function setRequiredProposerStake(uint256 _requiredProposerStake) external;
-    function setVotingDurationMicros(uint64 _votingDurationMicros) external;
-}
-```
-
-### Access Control
-
-| Function                         | Allowed Callers    |
-| -------------------------------- | ------------------ |
-| All view functions               | Anyone             |
-| `initialize()`                   | GENESIS only       |
-| All setters                      | GOVERNANCE only    |
-
-### Validation Rules
-
-| Parameter                    | Validation                                   |
-| ---------------------------- | -------------------------------------------- |
-| `votingDurationMicros`       | Must be > 0                                  |
+Summary of parameters consumed by `Governance.sol`:
+- `minVotingThreshold()` — minimum total yes-voting-power for a proposal to pass
+- `requiredProposerStake()` — minimum stake a proposer must have
+- `votingDurationMicros()` — voting window length
 
 ---
 
@@ -257,10 +198,20 @@ interface IGovernanceConfig {
 Main governance contract handling proposal creation, voting, resolution, and execution.
 Uses `Ownable2Step` pattern for owner management and executor authorization.
 
+### Constants
+
+```solidity
+/// @notice Maximum number of targets/datas per proposal to prevent block-gas-limit DoS
+uint256 public constant MAX_PROPOSAL_TARGETS = 100;
+```
+
 ### State Variables
 
 ```solidity
 /// @notice Next proposal ID to be assigned
+/// @dev SENTINEL CONVENTION: proposal ID 0 is reserved as "not found".
+///      nextProposalId starts at 1 and only increments, so ID 0 is never assigned.
+///      All lookups check `p.id == 0` to detect non-existent proposals.
 uint64 public nextProposalId = 1;
 
 /// @notice Mapping of proposal ID to Proposal struct
@@ -385,21 +336,23 @@ Create a new governance proposal with batch execution support.
 
 1. Verify `targets.length == datas.length` (revert with `ProposalArrayLengthMismatch` if not)
 2. Verify `targets.length > 0` (revert with `EmptyProposalBatch` if empty)
-3. Verify `stakePool` is a valid pool via `Staking.isPool()`
-4. Verify `msg.sender == StakePool.voter`
-5. Calculate `expirationTime = now + votingDurationMicros`
-6. Get voting power at expiration time via `Staking.getPoolVotingPower(stakePool, expirationTime)`
-7. Revert if voting power < `requiredProposerStake`
-8. Compute execution hash: `keccak256(abi.encode(targets, datas))`
-9. Create proposal with:
-   - `id = nextProposalId++`
-   - `proposer = msg.sender`
-   - `executionHash = executionHash`
-   - `creationTime = now`
-   - `expirationTime = now + votingDurationMicros`
-   - `minVoteThreshold = config.minVotingThreshold()`
-10. Emit `ProposalCreated` event
-11. Return `proposalId`
+3. Verify `targets.length <= MAX_PROPOSAL_TARGETS` (100) — revert with `TooManyProposalTargets(targetsLength, maxTargets)` if exceeded
+4. Verify `stakePool` is a valid pool via `Staking.isPool()`
+5. Verify `msg.sender == StakePool.voter`
+6. Calculate `expirationTime = now + votingDurationMicros`
+7. Get voting power at expiration time via `Staking.getPoolVotingPower(stakePool, expirationTime)`
+8. Revert if voting power < `requiredProposerStake`
+9. Compute execution hash: `keccak256(abi.encode(targets, datas))`
+10. Defence-in-depth: if `nextProposalId == 0`, revert with `InvalidProposalId()` (preserves the "id 0 = not found" invariant across upgrades)
+11. Create proposal with:
+    - `id = nextProposalId++`
+    - `proposer = msg.sender`
+    - `executionHash = executionHash`
+    - `creationTime = now`
+    - `expirationTime = now + votingDurationMicros`
+    - `minVoteThreshold = config.minVotingThreshold()`
+12. Emit `ProposalCreated` event
+13. Return `proposalId`
 
 **Notes:**
 
@@ -412,9 +365,11 @@ Create a new governance proposal with batch execution support.
 
 - `ProposalArrayLengthMismatch(targetsLen, datasLen)` — Array lengths don't match
 - `EmptyProposalBatch()` — No targets provided
+- `TooManyProposalTargets(targetsLength, maxTargets)` — More than `MAX_PROPOSAL_TARGETS` (100) targets supplied
 - `InvalidPool(stakePool)` — Pool not created by Staking factory
 - `NotDelegatedVoter(expected, actual)` — Caller is not pool's voter
 - `InsufficientVotingPower(required, actual)` — Not enough stake (includes lockup too short case)
+- `InvalidProposalId()` — Internal sentinel (reserved; indicates id counter corruption)
 
 ---
 
@@ -539,16 +494,17 @@ Execute an approved proposal.
 
 1. Verify `targets.length == datas.length` (revert with `ProposalArrayLengthMismatch` if not)
 2. Verify `targets.length > 0` (revert with `EmptyProposalBatch` if empty)
-3. Verify proposal exists
-4. Revert if already executed
-5. Get proposal state; revert if not SUCCEEDED
-6. Compute hash: `keccak256(abi.encode(targets, datas))`
-7. Revert if hash != `proposal.executionHash`
-8. Mark as executed: `executed[proposalId] = true` (CEI pattern)
-9. For each (target, data) pair:
-   - Call `target` with `data`
-   - Revert if call fails
-10. Emit `ProposalExecuted` event
+3. Verify proposal exists (revert `ProposalNotFound`)
+4. Revert with `ProposalAlreadyExecuted` if already executed
+5. Require `isResolved == true` (revert with `ProposalNotResolved(proposalId)` if caller attempts to execute a proposal that has not been explicitly resolved yet — even if voting has ended and it would pass)
+6. Get proposal state; revert if not SUCCEEDED
+7. Compute hash: `keccak256(abi.encode(targets, datas))`
+8. Revert if hash != `proposal.executionHash`
+9. Mark as executed: `executed[proposalId] = true` (CEI pattern)
+10. For each (target, data) pair:
+    - `(success, returnData) = target.call(data)`
+    - If `!success`, revert with `ExecutionFailed(proposalId, returnData)` — the raw revert bytes are bubbled up so the executor can diagnose why
+11. Emit `ProposalExecuted` event
 
 **Notes:**
 
@@ -562,9 +518,10 @@ Execute an approved proposal.
 - `EmptyProposalBatch()` — No targets provided
 - `ProposalNotFound(proposalId)` — Proposal doesn't exist
 - `ProposalAlreadyExecuted(proposalId)` — Already executed
+- `ProposalNotResolved(proposalId)` — Voting period may be over but `resolve()` has not been called
 - `ProposalNotSucceeded(proposalId)` — Proposal didn't pass
 - `ExecutionHashMismatch(expected, actual)` — Hash doesn't match
-- `ExecutionFailed(proposalId)` — External call failed
+- `ExecutionFailed(uint64 proposalId, bytes reason)` — External call failed; `reason` is the raw revert bytes bubbled up from the target
 
 ---
 
@@ -683,12 +640,13 @@ Get the number of authorized executors.
 
 ## Access Control Summary
 
-| Contract          | Function                | Allowed Callers               |
-| ----------------- | ----------------------- | ----------------------------- |
-| GovernanceConfig  | `initialize()`          | GENESIS only (once)           |
-| GovernanceConfig  | All setters             | GOVERNANCE only               |
-| GovernanceConfig  | All view functions      | Anyone                        |
-| Governance        | `createProposal()`      | Pool's voter address          |
+| Contract          | Function                      | Allowed Callers                |
+| ----------------- | ----------------------------- | ------------------------------ |
+| GovernanceConfig  | `initialize()`                | GENESIS only (once)            |
+| GovernanceConfig  | `setForNextEpoch(...)`        | GOVERNANCE only                |
+| GovernanceConfig  | `applyPendingConfig()`        | RECONFIGURATION only           |
+| GovernanceConfig  | All view functions            | Anyone                         |
+| Governance        | `createProposal()`            | Pool's voter address           |
 | Governance        | `vote()`                | Pool's voter address          |
 | Governance        | `batchVote()`           | Pool's voter address (all)    |
 | Governance        | `batchPartialVote()`    | Pool's voter address (all)    |
@@ -722,12 +680,15 @@ The following errors are used by governance contracts:
 | --------------------------------------------------- | --------------------------------------------------- |
 | `NotDelegatedVoter(address expected, address actual)` | Caller is not pool's voter                        |
 | `NotExecutor(address caller)`                       | Caller is not an authorized executor                |
+| `ProposalNotResolved(uint64 proposalId)`            | Execute called before `resolve()`                   |
 | `ProposalNotSucceeded(uint64 proposalId)`           | Proposal didn't pass                                |
 | `ProposalAlreadyExecuted(uint64 proposalId)`        | Proposal already executed                           |
-| `ExecutionFailed(uint64 proposalId)`                | External call failed                                |
+| `ExecutionFailed(uint64 proposalId, bytes reason)`  | External call failed; `reason` is the bubbled revert data |
 | `EmptyProposalBatch()`                              | No targets in proposal batch                        |
+| `TooManyProposalTargets(uint256 targetsLength, uint256 maxTargets)` | More than `MAX_PROPOSAL_TARGETS` (100) targets  |
 | `ProposalArrayLengthMismatch(uint256, uint256)`     | targets.length != datas.length                      |
 | `ResolutionCannotBeAtomic(uint64 lastVoteTime)`     | Resolution in same timestamp as last vote           |
+| `InvalidProposalId()`                               | Sentinel guard — id counter must never be 0         |
 | `InvalidVotingDuration()`                           | Voting duration is zero                             |
 
 ---

--- a/spec_v2/oracle.spec.md
+++ b/spec_v2/oracle.spec.md
@@ -73,9 +73,12 @@ contract deployed on Gravity that provides:
 
 ### Contract Deployment
 
-| Chain   | Contract     | System Address                           |
-| ------- | ------------ | ---------------------------------------- |
-| Gravity | NativeOracle | `0x0000000000000000000000000001625F2023` |
+| Chain   | Contract                   | System Address                           |
+| ------- | -------------------------- | ---------------------------------------- |
+| Gravity | NativeOracle               | `0x0000000000000000000000000001625F4000` |
+| Gravity | OracleTaskConfig           | `0x0000000000000000000000000001625F1009` |
+| Gravity | OnDemandOracleTaskConfig   | `0x0000000000000000000000000001625F100A` |
+| Gravity | OracleRequestQueue         | see [oracle_evm_bridge.spec.md](./oracle_evm_bridge.spec.md) |
 
 ---
 
@@ -137,42 +140,38 @@ The `nonce` is a `uint128` value that uniquely identifies a record within a (sou
 
 **Requirements:**
 
-- **Must start from 1**: The first nonce for any source must be >= 1 (cannot be 0)
-- **Strictly increasing**: Each subsequent nonce must be greater than the previous
+- **Must start from 1**: The first nonce for any source must be 1 (cannot be 0)
+- **Sequential (no gaps)**: Each subsequent nonce must be exactly `previousNonce + 1` — strictly increasing is *not* sufficient. The contract reverts with `NonceNotSequential(sourceType, sourceId, expected, provided)` on any gap or duplicate.
 
 ```solidity
 /// @notice Nonce (uint128)
-/// @dev Must start from 1 and strictly increase for each source
-///      Interpretation depends on source type:
-///      - BLOCKCHAIN: Block number or event index
-///      - JWK: Unix timestamp or sequence
-///      - DNS: Unix timestamp or sequence
-///      - PRICE_FEED: Sequence number or timestamp
+/// @dev Must start from 1 and increment by exactly 1 per record per source
 uint128 nonce;
 ```
 
 | Source Type | Nonce Meaning   | Example                     |
 | ----------- | --------------- | --------------------------- |
-| Blockchain  | Block number    | `19000000` (Ethereum block) |
-| JWK         | Unix timestamp  | `1704067200`                |
-| DNS         | Unix timestamp  | `1704067200`                |
-| Custom      | Sequence number | `1`, `2`, `3`, ...          |
+| Blockchain  | Monotonic seq   | `1`, `2`, `3`, ...          |
+| JWK         | Monotonic seq   | `1`, `2`, `3`, ...          |
+| DNS         | Monotonic seq   | `1`, `2`, `3`, ...          |
+| Custom      | Monotonic seq   | `1`, `2`, `3`, ...          |
 
 **Invariants:**
 
-- `nonce >= 1` for the first record
-- `nonce` must be strictly increasing for each (sourceType, sourceId) pair
+- `nonce == 1` for the first record per source
+- For each (sourceType, sourceId) pair, consecutive records MUST satisfy `newNonce == latestNonce + 1`
 
 ### DataRecord
 
 ```solidity
 struct DataRecord {
-    uint64 recordedAt;  // Timestamp when recorded (0 = not exists)
-    bytes data;         // Stored payload data
+    uint64  recordedAt;   // EVM block.timestamp seconds when recorded (0 = not exists). NOTE: seconds, not Gravity microseconds.
+    uint256 blockNumber;  // Source block number the record refers to (meaning depends on sourceType — e.g. the Ethereum block that emitted the event)
+    bytes   data;         // Stored payload data
 }
 ```
 
-Record existence is determined by `recordedAt > 0`.
+Record existence is determined by `recordedAt > 0`. `blockNumber` is carried independently of `nonce` so that a single source can mix sequence-based ordering with source-block provenance.
 
 ---
 
@@ -207,30 +206,35 @@ interface INativeOracle {
     /// @notice Record a single data entry
     /// @param sourceType The source type (uint32, e.g., 0 = BLOCKCHAIN, 1 = JWK)
     /// @param sourceId The source identifier (e.g., chain ID for blockchains)
-    /// @param nonce The nonce - must start from 1 and strictly increase
+    /// @param nonce The nonce - must equal `currentNonce + 1` for this (sourceType, sourceId)
+    /// @param blockNumber The source block number (provenance, NOT used for ordering)
     /// @param payload The data payload to store
-    /// @param callbackGasLimit Gas limit for callback execution (0 = no callback)
+    /// @param callbackGasLimit Gas limit for callback execution (0 = invoke no callback, emit CallbackSkipped and store)
     function record(
         uint32 sourceType,
         uint256 sourceId,
         uint128 nonce,
+        uint256 blockNumber,
         bytes calldata payload,
         uint256 callbackGasLimit
     ) external;
 
     /// @notice Batch record multiple data entries from the same source
-    /// @dev Each payload is recorded at sequential nonces starting from the provided nonce.
+    /// @dev Each record is validated individually with its own nonce/blockNumber/callbackGasLimit.
+    ///      Callers typically pass strictly sequential nonces; the contract validates each as currentNonce+1.
     /// @param sourceType The source type
     /// @param sourceId The source identifier
-    /// @param nonce The starting nonce for the batch
-    /// @param payloads Array of payloads to store
-    /// @param callbackGasLimit Gas limit for callback execution per record (0 = no callback)
+    /// @param nonces Array of nonces (length N)
+    /// @param blockNumbers Array of source block numbers (length N)
+    /// @param payloads Array of payloads (length N)
+    /// @param callbackGasLimits Array of per-record gas limits (length N)
     function recordBatch(
         uint32 sourceType,
         uint256 sourceId,
-        uint128 nonce,
+        uint128[] calldata nonces,
+        uint256[] calldata blockNumbers,
         bytes[] calldata payloads,
-        uint256 callbackGasLimit
+        uint256[] calldata callbackGasLimits
     ) external;
 
     // ========== Callback Management (GOVERNANCE Only) ==========
@@ -286,19 +290,31 @@ interface INativeOracle {
 ```solidity
 interface IOracleCallback {
     /// @notice Called when an oracle event is recorded
-    /// @dev Callback failures are caught - do NOT revert oracle recording
+    /// @dev Callback failures are caught — do NOT revert oracle recording.
+    ///      The returned `shouldStore` flag tells NativeOracle whether to persist the payload
+    ///      into the `_records` mapping. Returning `false` lets callbacks that fully consume the
+    ///      payload (e.g., apply it to their own state) avoid paying for redundant storage.
     /// @param sourceType The source type
     /// @param sourceId The source identifier
     /// @param nonce The nonce of the record
     /// @param payload The event payload (encoding depends on event type)
+    /// @return shouldStore If true, NativeOracle writes the DataRecord; if false, storage is skipped
+    ///                    (a `StorageSkipped` event is emitted instead).
     function onOracleEvent(
         uint32 sourceType,
         uint256 sourceId,
         uint128 nonce,
         bytes calldata payload
-    ) external;
+    ) external returns (bool shouldStore);
 }
 ```
+
+**Storage semantics**:
+- No callback registered → payload is always stored.
+- Callback registered but `callbackGasLimit == 0` → `CallbackSkipped` event, payload is still stored.
+- Callback succeeds and returns `true` → `CallbackSuccess` event, payload stored.
+- Callback succeeds and returns `false` → `CallbackSuccess` + `StorageSkipped` events, payload NOT stored (the callback "consumed" the data).
+- Callback reverts or runs out of gas → `CallbackFailed` event with revert bytes, payload stored anyway (fail-safe).
 
 ### Callback Resolution (2-Layer System)
 
@@ -329,16 +345,25 @@ function _invokeCallback(
     uint128 nonce,
     bytes calldata payload,
     uint256 gasLimit
-) internal {
+) internal returns (bool shouldStore) {
     address callback = _resolveCallback(sourceType, sourceId);
-    if (callback == address(0)) return;
+    if (callback == address(0)) return true;           // no callback → store
+    if (gasLimit == 0) {
+        emit CallbackSkipped(sourceType, sourceId, nonce, callback);
+        return true;                                    // skip invocation, still store
+    }
 
     try IOracleCallback(callback).onOracleEvent{gas: gasLimit}(
         sourceType, sourceId, nonce, payload
-    ) {
+    ) returns (bool callbackShouldStore) {
         emit CallbackSuccess(sourceType, sourceId, nonce, callback);
+        if (!callbackShouldStore) {
+            emit StorageSkipped(sourceType, sourceId, nonce, callback);
+        }
+        return callbackShouldStore;
     } catch (bytes memory reason) {
         emit CallbackFailed(sourceType, sourceId, nonce, callback, reason);
+        return true;                                    // on failure, store by default to preserve data
     }
 }
 ```
@@ -399,27 +424,138 @@ event CallbackFailed(
     address callback,
     bytes reason
 );
+
+/// @notice Emitted when a callback is registered but gasLimit == 0 was passed (callback not invoked; record still stored)
+event CallbackSkipped(
+    uint32 indexed sourceType,
+    uint256 indexed sourceId,
+    uint128 nonce,
+    address callback
+);
+
+/// @notice Emitted when the callback returned shouldStore == false — the payload is NOT persisted
+event StorageSkipped(
+    uint32 indexed sourceType,
+    uint256 indexed sourceId,
+    uint128 nonce,
+    address callback
+);
 ```
 
 ### Errors
 
 ```solidity
-/// @dev For first record, latestNonce is 0, so nonce must be >= 1
-error NonceNotIncreasing(uint32 sourceType, uint256 sourceId, uint128 currentNonce, uint128 providedNonce);
+/// @notice The provided nonce was not exactly currentNonce + 1
+/// @param expectedNonce currentNonce + 1 (= 1 on first record)
+/// @param providedNonce The nonce supplied in the call
+error NonceNotSequential(
+    uint32 sourceType,
+    uint256 sourceId,
+    uint128 expectedNonce,
+    uint128 providedNonce
+);
+
+/// @notice recordBatch array-length mismatch
+error OracleBatchArrayLengthMismatch(
+    uint256 noncesLen,
+    uint256 blockNumbersLen,
+    uint256 payloadsLen,
+    uint256 callbackGasLimitsLen
+);
 ```
 
 ---
 
 ## Access Control Matrix
 
-| Contract         | Function             | Allowed Callers |
-| ---------------- | -------------------- | --------------- |
-| **NativeOracle** |                      |                 |
-|                  | record()             | SYSTEM_CALLER   |
-|                  | recordBatch()        | SYSTEM_CALLER   |
-|                  | setDefaultCallback() | GOVERNANCE      |
-|                  | setCallback()        | GOVERNANCE      |
-|                  | View functions       | Anyone          |
+| Contract                 | Function                               | Allowed Callers        |
+| ------------------------ | -------------------------------------- | ---------------------- |
+| **NativeOracle**         |                                        |                        |
+|                          | initialize()                           | GENESIS (once)         |
+|                          | record()                               | SYSTEM_CALLER          |
+|                          | recordBatch()                          | SYSTEM_CALLER          |
+|                          | setDefaultCallback()                   | GOVERNANCE             |
+|                          | setCallback()                          | GOVERNANCE             |
+|                          | View functions                         | Anyone                 |
+| **OracleTaskConfig**     |                                        |                        |
+|                          | setTask()                              | GENESIS or GOVERNANCE  |
+|                          | removeTask()                           | GOVERNANCE             |
+|                          | View / enumeration functions           | Anyone                 |
+| **OnDemandOracleTaskConfig** |                                    |                        |
+|                          | setTask() / removeTask()               | GOVERNANCE             |
+|                          | View / enumeration functions           | Anyone                 |
+
+---
+
+## Contract: OracleTaskConfig
+
+Stores configuration for **continuous** oracle tasks that validators actively monitor off-chain. Tasks are keyed by `(sourceType, sourceId, taskName)`, allowing multiple tasks per source (e.g., an Ethereum chain can have a JWK-sync task, a block-header task, and a price-feed task simultaneously).
+
+### System Address
+
+| Constant | Address |
+|----------|---------|
+| `ORACLE_TASK_CONFIG` | `0x0000000000000000000000000001625F1009` |
+
+### Types
+
+```solidity
+struct OracleTask {
+    bytes config;       // Opaque task configuration (schema depends on sourceType)
+    uint64 updatedAt;   // Block timestamp (seconds) of last update
+}
+
+struct FullTaskInfo {
+    uint32 sourceType;
+    uint256 sourceId;
+    bytes32 taskName;
+    bytes config;
+    uint64 updatedAt;
+}
+```
+
+### Interface
+
+```solidity
+interface IOracleTaskConfig {
+    event TaskSet(uint32 indexed sourceType, uint256 indexed sourceId, bytes32 indexed taskName, bytes config);
+    event TaskRemoved(uint32 indexed sourceType, uint256 indexed sourceId, bytes32 indexed taskName);
+
+    // GOVERNANCE (+ GENESIS for setTask only)
+    function setTask(uint32 sourceType, uint256 sourceId, bytes32 taskName, bytes calldata config) external;
+    function removeTask(uint32 sourceType, uint256 sourceId, bytes32 taskName) external;
+
+    // Queries
+    function getTask(uint32 sourceType, uint256 sourceId, bytes32 taskName) external view returns (OracleTask memory);
+    function hasTask(uint32 sourceType, uint256 sourceId, bytes32 taskName) external view returns (bool);
+    function getTaskNames(uint32 sourceType, uint256 sourceId) external view returns (bytes32[] memory);
+    function getTaskCount(uint32 sourceType, uint256 sourceId) external view returns (uint256);
+    function getTaskNameAt(uint32 sourceType, uint256 sourceId, uint256 index) external view returns (bytes32);
+    function getSourceTypes() external view returns (uint32[] memory);
+    function getSourceIds(uint32 sourceType) external view returns (uint256[] memory);
+    function getAllTasks() external view returns (FullTaskInfo[] memory);
+}
+```
+
+### Behavior Notes
+
+- `setTask()` reverts with `EmptyConfig` if `config.length == 0`.
+- Setting `taskName` that already exists overwrites in place (same `updatedAt` refresh).
+- `removeTask()` cleans up empty source-id and source-type registrations to keep the enumeration helpers bounded.
+
+---
+
+## Contract: OnDemandOracleTaskConfig
+
+Parallel configuration contract for **on-demand** oracle tasks (pull-based requests fulfilled by the queue in `OracleRequestQueue`). Same `(sourceType, sourceId, taskName)` keying and the same interface shape as `OracleTaskConfig`; the two are kept separate so validators can distinguish continuous-monitoring tasks from request/response workflows.
+
+### System Address
+
+| Constant | Address |
+|----------|---------|
+| `ON_DEMAND_ORACLE_TASK_CONFIG` | `0x0000000000000000000000000001625F100A` |
+
+See `src/oracle/ondemand/` for the full on-demand-specific flow (request queue, fulfillment, timeouts).
 
 ---
 

--- a/spec_v2/oracle_evm_bridge.spec.md
+++ b/spec_v2/oracle_evm_bridge.spec.md
@@ -85,7 +85,7 @@ consists of contracts deployed on both chains, providing:
 | Ethereum | GravityPortal          | Regular deployment                          |
 | Ethereum | GBridgeSender          | Regular deployment                          |
 | Gravity  | GBridgeReceiver        | Regular deployment (registered as callback) |
-| Gravity  | NATIVE_MINT_PRECOMPILE | `0x0000000000000000000000000001625F2100`    |
+| Gravity  | NATIVE_MINT_PRECOMPILE | `0x0000000000000000000000000001625F5000`    |
 
 ---
 
@@ -252,8 +252,9 @@ interface IGravityPortal {
 ```solidity
 /// @notice Emitted when a message is sent to Gravity
 /// @param nonce The unique nonce for this message
+/// @param block_number The Ethereum block number this message was emitted at (carried into the oracle DataRecord as provenance)
 /// @param payload The encoded payload: sender (20B) || nonce (16B) || message
-event MessageSent(uint128 indexed nonce, bytes payload);
+event MessageSent(uint128 indexed nonce, uint256 indexed block_number, bytes payload);
 
 /// @notice Emitted when fee configuration is updated
 event FeeConfigUpdated(uint256 baseFee, uint256 feePerByte);
@@ -270,6 +271,9 @@ event FeesWithdrawn(address indexed recipient, uint256 amount);
 ```solidity
 /// @notice Insufficient fee provided
 error InsufficientFee(uint256 required, uint256 provided);
+
+/// @notice Fee overpayment — we reject msg.value > requiredFee so callers do not silently overpay
+error ExcessiveFee(uint256 required, uint256 provided);
 
 /// @notice Zero address not allowed
 error ZeroAddress();
@@ -290,21 +294,18 @@ PortalMessage payloads.
 ```solidity
 abstract contract BlockchainEventHandler is IOracleCallback {
     /// @notice Called by NativeOracle when a blockchain event is recorded
-    /// @dev Parses the portal message payload and delegates to _handlePortalMessage()
+    /// @dev Parses the portal message payload and delegates to _handlePortalMessage().
+    ///      Returns `shouldStore` up to NativeOracle so the derived handler can decide whether
+    ///      the raw payload is worth persisting.
     function onOracleEvent(
         uint32 sourceType,
         uint256 sourceId,
         uint128 oracleNonce,
         bytes calldata payload
-    ) external override;
+    ) external override returns (bool shouldStore);
 
     /// @notice Handle a parsed portal message (override in derived contracts)
-    /// @param sourceType The source type from NativeOracle
-    /// @param sourceId The source identifier (chain ID)
-    /// @param oracleNonce The oracle nonce for this record
-    /// @param sender The sender address on the source chain
-    /// @param messageNonce The message nonce from the source chain
-    /// @param message The message body (application-specific encoding)
+    /// @return shouldStore Whether NativeOracle should persist the raw payload
     function _handlePortalMessage(
         uint32 sourceType,
         uint256 sourceId,
@@ -312,7 +313,7 @@ abstract contract BlockchainEventHandler is IOracleCallback {
         address sender,
         uint128 messageNonce,
         bytes memory message
-    ) internal virtual;
+    ) internal virtual returns (bool shouldStore);
 }
 ```
 
@@ -438,21 +439,39 @@ Mints native G tokens when bridge messages are received from GBridgeSender.
 /// @notice Trusted GBridgeSender address on Ethereum
 address public immutable trustedBridge;
 
-/// @notice Processed nonces for replay protection
-mapping(uint128 => bool) private _processedNonces;
+/// @notice Trusted source chain ID (e.g. 1 for Ethereum mainnet).
+///         Incoming callbacks with a different sourceId are rejected.
+uint256 public immutable trustedSourceId;
+
+// @deprecated — a previous revision tracked processedNonces here. Replay protection is now provided
+// by NativeOracle's sequential-nonce enforcement (`nonce == currentNonce + 1`), so local tracking is
+// redundant. The storage slot is retained as __deprecated_processedNonces only to preserve layout
+// across the hardfork.
+uint256 private __deprecated_processedNonces;
 ```
 
 ### Interface
 
 ```solidity
 interface IGBridgeReceiver {
-    /// @notice Check if a nonce has been processed
-    function isProcessed(uint128 nonce) external view returns (bool);
-
     /// @notice Get trusted bridge address
     function trustedBridge() external view returns (address);
+
+    /// @notice Get trusted source chain ID
+    function trustedSourceId() external view returns (uint256);
 }
 ```
+
+### Validation
+
+`_handlePortalMessage` validates, in order:
+
+1. `sourceId == trustedSourceId` — else revert with `InvalidSourceChain(provided, expected)`.
+2. `sender == trustedBridge` — defence-in-depth, even though the Ethereum side is already gated.
+3. `amount != 0` — reject no-op mints (`Errors.ZeroAmount`).
+4. `recipient != address(0)` — reject burns to the zero address (`Errors.ZeroAddress`).
+
+Replay protection is **not** implemented locally; `NativeOracle` already enforces `nonce == currentNonce + 1` for this (sourceType, sourceId), so a message cannot be delivered twice.
 
 ### Native Mint Precompile Interface
 
@@ -486,8 +505,11 @@ event NativeMinted(address indexed recipient, uint256 amount, uint128 indexed no
 /// @notice Message sender is not the trusted bridge
 error InvalidSender(address sender, address expected);
 
-/// @notice Nonce has already been processed
-error AlreadyProcessed(uint128 nonce);
+/// @notice Source chain ID does not match the receiver's trusted source
+error InvalidSourceChain(uint256 provided, uint256 expected);
+
+/// @notice Native mint precompile call failed
+error MintFailed(address recipient, uint256 amount);
 ```
 
 ---
@@ -500,36 +522,37 @@ error AlreadyProcessed(uint128 nonce);
    └─> Calls gBridgeSender.bridgeToGravity(amount, recipient) + ETH fee
        └─> G tokens transferred to GBridgeSender (locked)
        └─> Calls gravityPortal.send(abi.encode(amount, recipient))
-           └─> Fee validated (baseFee + bytes * feePerByte)
+           └─> Fee validated: reverts with InsufficientFee if msg.value < required
+               and with ExcessiveFee if msg.value > required
            └─> Payload = sender (20B) || nonce (16B) || abi.encode(amount, recipient)
-           └─> Emit MessageSent(nonce, payload)
+           └─> Emit MessageSent(nonce, block.number, payload)
 
 2. Gravity Validators:
-   └─> Monitor MessageSent events on Ethereum
+   └─> Monitor MessageSent events on Ethereum (including block.number for provenance)
    └─> Reach consensus on event validity
    └─> SYSTEM_CALLER calls nativeOracle.record(
            sourceType=0,        // BLOCKCHAIN
-           sourceId=1,          // Ethereum chain ID
-           nonce=messageNonce,  // Portal nonce
+           sourceId=1,          // Ethereum chain ID (matches GBridgeReceiver.trustedSourceId)
+           nonce=currentNonce+1,// Sequential; NativeOracle enforces expectedNonce == currentNonce+1
+           blockNumber,         // From MessageSent.block_number; stored as provenance in DataRecord
            payload,             // Full portal message
            callbackGasLimit     // Caller-specified
        )
 
 3. NativeOracle on Gravity:
-   └─> Validates nonce >= 1 and increasing
-   └─> Stores record
+   └─> Validates nonce == currentNonce + 1 (reverts NonceNotSequential otherwise — replay-safe)
    └─> Resolves callback using 2-layer lookup → GBridgeReceiver
-   └─> Calls receiver.onOracleEvent{gas: callbackGasLimit}(...)
+   └─> Calls receiver.onOracleEvent{gas: callbackGasLimit}(...) — expects bool return
+   └─> Stores DataRecord (with blockNumber) iff callback returned true (or no callback / gas=0 / revert)
 
 4. GBridgeReceiver (extends BlockchainEventHandler):
-   └─> Verifies caller is NativeOracle
-   └─> Decodes PortalMessage: (sender=GBridgeSender, messageNonce, message)
-   └─> Verifies sender == trustedBridge (defense in depth)
-   └─> Verifies nonce not already processed
-   └─> Decodes message: (amount, recipient)
-   └─> Marks nonce as processed (CEI pattern)
-   └─> Calls NATIVE_MINT_PRECOMPILE.mint(recipient, amount)
-   └─> Emit NativeMinted(recipient, amount, nonce)
+   └─> Verifies sourceId == trustedSourceId
+   └─> Verifies sender == trustedBridge (defence in depth)
+   └─> Decodes message: (amount, recipient); reverts on amount==0 or recipient==0
+   └─> Calls NATIVE_MINT_PRECOMPILE (0x...1625F5000) via low-level call
+       with callData = 0x01 || recipient || amount
+   └─> Emits NativeMinted(recipient, amount, messageNonce)
+   └─> Returns shouldStore = true so the oracle keeps the payload for audit
 ```
 
 ---
@@ -555,13 +578,12 @@ error AlreadyProcessed(uint128 nonce);
 
 ## Security Considerations
 
-1. **Fee Validation**: GravityPortal requires sufficient ETH before accepting messages
+1. **Fee Validation**: GravityPortal rejects both underpayment (`InsufficientFee`) and overpayment (`ExcessiveFee`) so a caller sees a deterministic cost.
 2. **Consensus Required**: All oracle data requires validator consensus via SYSTEM_CALLER
-3. **Sender Verification**: GBridgeReceiver verifies sender from payload is the trusted bridge
-4. **Callback Failure Tolerance**: Failures do NOT revert oracle recording
-5. **Replay Protection**: GBridgeReceiver tracks processed nonces
-6. **CEI Pattern**: Nonce marked as processed BEFORE minting (prevents reentrancy)
-7. **Compact Encoding**: PortalMessage uses 36-byte overhead (vs 128+ with abi.encode)
+3. **Source and Sender Verification**: GBridgeReceiver checks both `sourceId == trustedSourceId` and the in-payload `sender == trustedBridge`.
+4. **Callback Failure Tolerance**: Failures do NOT revert oracle recording; NativeOracle falls back to storing the payload for later inspection.
+5. **Replay Protection**: Enforced by NativeOracle's sequential-nonce rule (`nonce == currentNonce + 1`). GBridgeReceiver does NOT keep its own processed-nonce map; the legacy slot exists only as `__deprecated_processedNonces` for storage-layout compatibility.
+6. **Compact Encoding**: PortalMessage uses 36-byte overhead (vs 128+ with abi.encode)
 
 ---
 
@@ -570,7 +592,7 @@ error AlreadyProcessed(uint128 nonce);
 1. **Nonce Uniqueness**: Each nonce from GravityPortal is unique (monotonic uint128)
 2. **Callback Safety**: Callback failures never affect oracle state
 3. **Token Conservation**: G tokens locked on Ethereum = native G minted on Gravity (minus failed mints)
-4. **Replay Prevention**: Each message nonce can only be processed once on GBridgeReceiver
+4. **Replay Prevention**: NativeOracle enforces `nonce == currentNonce + 1` per (sourceType, sourceId), so each portal nonce can be delivered to the receiver at most once.
 
 ---
 

--- a/spec_v2/overview.spec.md
+++ b/spec_v2/overview.spec.md
@@ -214,17 +214,20 @@ Gravity Core Contracts form the on-chain infrastructure for the Gravity blockcha
 
 ## Quick Reference
 
-| Layer | Contracts | System Address(es) |
-|-------|-----------|-------------------|
-| Foundation | SystemAddresses, Types, Errors | — |
-| Runtime | Timestamp, StakingConfig, ValidatorConfig, etc. | `0x...2017`, `0x...2011`, `0x...2015` |
-| Staking | Staking, StakePool | `0x...2012` |
-| Validator | ValidatorManagement | `0x...2013` |
-| Blocker | Blocker, Reconfiguration | `0x...2016`, `0x...2010` |
-| Governance | Governance, GovernanceConfig | `0x...2014`, `0x...2026` |
-| Oracle | NativeOracle | `0x...2023` |
+| Layer       | Contracts                                                                                         | System Address Range   |
+|-------------|---------------------------------------------------------------------------------------------------|------------------------|
+| Foundation  | SystemAddresses, Types, Errors, SystemAccessControl                                               | — (libraries)          |
+| Runtime     | Timestamp, StakingConfig, ValidatorConfig, RandomnessConfig, GovernanceConfig, EpochConfig, VersionConfig, ConsensusConfig, ExecutionConfig, OracleTaskConfig, OnDemandOracleTaskConfig | `0x...1625F1xxx`       |
+| Staking     | Staking (factory), StakePool                                                                      | `0x...1625F2000`       |
+| Validator   | ValidatorManagement, DKG                                                                          | `0x...1625F2001`, `...2002` |
+| Blocker     | Reconfiguration, Blocker, ValidatorPerformanceTracker                                             | `0x...1625F2003-2005`  |
+| Governance  | Governance (GovernanceConfig lives in Runtime)                                                    | `0x...1625F3000`       |
+| Oracle      | NativeOracle, JWKManager, OracleRequestQueue, EVM bridge components                               | `0x...1625F4xxx`       |
+| Precompiles | NativeMint, BLS12-381 PoP verify                                                                  | `0x...1625F5xxx`       |
 
-*All addresses follow the `0x...1625F2xxx` pattern reserved at genesis.*
+*System addresses are grouped by layer: `0x1625F0xxx` consensus/caller, `0x1625F1xxx` runtime configs,
+`0x1625F2xxx` staking & validator, `0x1625F3xxx` governance, `0x1625F4xxx` oracle, `0x1625F5xxx` precompiles.
+See [foundation.spec.md](./foundation.spec.md) for the full table.*
 
 ---
 

--- a/spec_v2/randomness.spec.md
+++ b/spec_v2/randomness.spec.md
@@ -79,7 +79,7 @@ src/runtime/
 
 | Constant | Address | Description |
 |----------|---------|-------------|
-| `RANDOMNESS_CONFIG` | `0x0000000000000000000000000001625F2024` | Randomness configuration |
+| `RANDOMNESS_CONFIG` | `0x0000000000000000000000000001625F1003` | Randomness configuration |
 
 ### Types
 
@@ -132,43 +132,45 @@ bool private _initialized;
 ### Interface
 
 ```solidity
-interface IRandomnessConfig {
+/// @dev RandomnessConfig is deployed as a standalone contract (no separate interface).
+///      Cross-contract callers read/write via the concrete contract API shown below.
+contract RandomnessConfig {
     // ========== Initialization ==========
-    
+
     /// @notice Initialize with config (genesis only)
     function initialize(RandomnessConfigData calldata config) external;
-    
+
     // ========== View Functions ==========
-    
+
     /// @notice Check if randomness is enabled
     function enabled() external view returns (bool);
-    
+
     /// @notice Get current config
     function getCurrentConfig() external view returns (RandomnessConfigData memory);
-    
+
     /// @notice Get pending config if any
     function getPendingConfig() external view returns (bool hasPending, RandomnessConfigData memory config);
-    
+
     /// @notice Check if initialized
     function isInitialized() external view returns (bool);
-    
-    // ========== Governance (TIMELOCK only) ==========
-    
+
+    // ========== Governance (GOVERNANCE only) ==========
+
     /// @notice Set config for next epoch
     function setForNextEpoch(RandomnessConfigData calldata newConfig) external;
-    
+
     // ========== Epoch Transition (RECONFIGURATION only) ==========
-    
+
     /// @notice Apply pending config at epoch boundary
     function applyPendingConfig() external;
-    
-    // ========== Config Builders (Pure) ==========
-    
+
+    // ========== Config Builders (Pure Helpers) ==========
+
     /// @notice Create Off config
     function newOff() external pure returns (RandomnessConfigData memory);
-    
+
     /// @notice Create V2 config
-    function newV2(uint128 secrecy, uint128 reconstruction, uint128 fastPath) 
+    function newV2(uint128 secrecy, uint128 reconstruction, uint128 fastPath)
         external pure returns (RandomnessConfigData memory);
 }
 ```
@@ -212,7 +214,7 @@ event PendingRandomnessConfigCleared();
 
 | Constant | Address | Description |
 |----------|---------|-------------|
-| `DKG` | `0x0000000000000000000000000001625F2025` | DKG session management |
+| `DKG` | `0x0000000000000000000000000001625F2002` | DKG session management |
 
 ### Types
 

--- a/spec_v2/runtime.spec.md
+++ b/spec_v2/runtime.spec.md
@@ -138,7 +138,7 @@ in microseconds and updated by the Block contract during block prologue.
 
 | Constant | Address | Description |
 |----------|---------|-------------|
-| `TIMESTAMP` | `0x0000000000000000000000000001625F2017` | On-chain time oracle |
+| `TIMESTAMP` | `0x0000000000000000000000000001625F1000` | On-chain time oracle |
 
 ### State Variables
 
@@ -218,7 +218,7 @@ Configuration parameters for governance staking. Anyone can stake tokens to part
 
 | Constant | Address | Description |
 |----------|---------|-------------|
-| `STAKE_CONFIG` | `0x0000000000000000000000000001625F2011` | Staking configuration |
+| `STAKE_CONFIG` | `0x0000000000000000000000000001625F1001` | Staking configuration |
 
 ### Interface
 
@@ -229,9 +229,13 @@ Configuration parameters for governance staking. Anyone can stake tokens to part
 interface IStakingConfig {
     function minimumStake() external view returns (uint256);
     function lockupDurationMicros() external view returns (uint64);
-    function minimumProposalStake() external view returns (uint256);
+    function unbondingDelayMicros() external view returns (uint64);
 }
 ```
+
+> Historical: `minimumProposalStake` was moved to `GovernanceConfig` in v1.2.0. The slot is
+> retained as `__deprecated_minimumProposalStake` on the pending-config struct purely to preserve
+> storage layout. New callers must use `GovernanceConfig.requiredProposerStake()`.
 
 ### Parameters
 
@@ -239,7 +243,7 @@ interface IStakingConfig {
 |-----------|------|-------------|-------------|
 | `minimumStake` | `uint256` | Minimum stake for governance participation | >= 0 |
 | `lockupDurationMicros` | `uint64` | Lockup duration in microseconds | > 0 |
-| `minimumProposalStake` | `uint256` | Minimum stake to create governance proposals | >= 0 |
+| `unbondingDelayMicros` | `uint64` | Additional wait after lockup expires before withdrawal is claimable | > 0 |
 
 ### Access Control
 
@@ -247,7 +251,7 @@ interface IStakingConfig {
 |----------|-----------------|
 | All view functions | Anyone |
 | `initialize()` | GENESIS only (once) |
-| All setters | GOVERNANCE only |
+| `setForNextEpoch(...)` / `applyPendingConfig()` | GOVERNANCE / RECONFIGURATION respectively |
 
 ---
 
@@ -259,7 +263,7 @@ Configuration parameters for the validator registry. Controls validator bonding,
 
 | Constant | Address | Description |
 |----------|---------|-------------|
-| `VALIDATOR_CONFIG` | `0x0000000000000000000000000001625F2015` | Validator configuration |
+| `VALIDATOR_CONFIG` | `0x0000000000000000000000000001625F1002` | Validator configuration |
 
 ### Interface
 
@@ -275,7 +279,7 @@ interface IValidatorConfig {
     function votingPowerIncreaseLimitPct() external view returns (uint64);
     function maxValidatorSetSize() external view returns (uint256);
     function autoEvictEnabled() external view returns (bool);
-    function autoEvictThreshold() external view returns (uint256);
+    function autoEvictThresholdPct() external view returns (uint64);
     function MAX_VOTING_POWER_INCREASE_LIMIT() external view returns (uint64);
     function MAX_VALIDATOR_SET_SIZE() external view returns (uint256);
 }
@@ -291,8 +295,8 @@ interface IValidatorConfig {
 | `allowValidatorSetChange` | `bool` | Whether validators can join/leave post-genesis | - |
 | `votingPowerIncreaseLimitPct` | `uint64` | Max % of voting power that can join per epoch | 1-50 |
 | `maxValidatorSetSize` | `uint256` | Maximum number of validators in the set | 1-65536 |
-| `autoEvictEnabled` | `bool` | Whether automatic eviction of underperforming validators is active | - |
-| `autoEvictThreshold` | `uint256` | Minimum successful proposals required to avoid eviction | >= 0 |
+| `autoEvictEnabled` | `bool` | Whether performance-based eviction of underperforming validators is active (underbonded-sweep is always on) | - |
+| `autoEvictThresholdPct` | `uint64` | Minimum success percentage (successful proposals / total proposals * 100) required to avoid eviction | 0-100 |
 
 ### Constants
 
@@ -305,13 +309,13 @@ uint256 public constant MAX_VALIDATOR_SET_SIZE = 65536;
 
 ## Contract: `EpochConfig.sol`
 
-Configuration for epoch timing. Determines how long each epoch lasts. The `Reconfiguration` contract reads `epochIntervalMicros` from this contract to determine when epoch transitions should occur.
+Configuration for epoch timing. Determines how long each epoch lasts. The `Reconfiguration` contract reads `epochIntervalMicros` from this contract to determine when epoch transitions should occur. Updates follow the pending-config pattern (propose via `setForNextEpoch`, apply at epoch boundary via `applyPendingConfig`).
 
 ### System Address
 
 | Constant | Address | Description |
 |----------|---------|-------------|
-| `EPOCH_CONFIG` | `0x0000000000000000000000000001625F2027` | Epoch configuration |
+| `EPOCH_CONFIG` | `0x0000000000000000000000000001625F1005` | Epoch configuration |
 
 ### Parameters
 
@@ -329,16 +333,20 @@ Configuration for epoch timing. Determines how long each epoch lasts. The `Recon
 /// @title EpochConfig
 /// @notice Configuration parameters for epoch timing
 contract EpochConfig {
-    /// @notice Epoch duration in microseconds
+    /// @notice Epoch duration in microseconds (currently applied)
     uint64 public epochIntervalMicros;
 
     /// @notice Initialize the epoch configuration
     /// @dev Can only be called once by GENESIS
     function initialize(uint64 _epochIntervalMicros) external;
 
-    /// @notice Update epoch interval
+    /// @notice Stage an epoch-interval change to apply at the next epoch boundary
     /// @dev Only callable by GOVERNANCE
-    function setEpochIntervalMicros(uint64 _epochIntervalMicros) external;
+    function setForNextEpoch(uint64 _epochIntervalMicros) external;
+
+    /// @notice Apply the staged interval at epoch transition
+    /// @dev Only callable by RECONFIGURATION
+    function applyPendingConfig() external;
 
     /// @notice Check if initialized
     function isInitialized() external view returns (bool);
@@ -352,7 +360,8 @@ contract EpochConfig {
 | `epochIntervalMicros()` | Anyone |
 | `isInitialized()` | Anyone |
 | `initialize()` | GENESIS only (once) |
-| `setEpochIntervalMicros()` | GOVERNANCE only |
+| `setForNextEpoch()` | GOVERNANCE only |
+| `applyPendingConfig()` | RECONFIGURATION only |
 
 ---
 
@@ -364,7 +373,7 @@ Protocol version tracking. Used to coordinate upgrades and gate new features.
 
 | Constant | Address | Description |
 |----------|---------|-------------|
-| `VERSION_CONFIG` | `0x0000000000000000000000000001625F2028` | Version configuration |
+| `VERSION_CONFIG` | `0x0000000000000000000000000001625F1006` | Version configuration |
 
 ### Parameters
 
@@ -377,20 +386,31 @@ Protocol version tracking. Used to coordinate upgrades and gate new features.
 ```solidity
 /// @title VersionConfig
 /// @notice Configuration for protocol versioning
+/// @dev Uses pending-config pattern: changes queued via setForNextEpoch and applied at epoch boundary.
 contract VersionConfig {
     /// @notice Major protocol version number
     uint64 public majorVersion;
+
+    /// @notice Whether a pending configuration exists
+    bool public hasPendingConfig;
 
     /// @notice Initialize the version configuration
     /// @dev Can only be called once by GENESIS
     function initialize(uint64 _majorVersion) external;
 
-    /// @notice Update major version
-    /// @dev Only callable by GOVERNANCE. Version must be strictly greater.
-    function setMajorVersion(uint64 _majorVersion) external;
-
     /// @notice Check if initialized
     function isInitialized() external view returns (bool);
+
+    /// @notice Get pending version if any
+    function getPendingConfig() external view returns (bool hasPending, uint64 pendingVersion);
+
+    /// @notice Queue a new major version for the next epoch
+    /// @dev Only callable by GOVERNANCE. New version must be strictly greater than current.
+    function setForNextEpoch(uint64 _majorVersion) external;
+
+    /// @notice Apply pending configuration at epoch boundary
+    /// @dev Only callable by RECONFIGURATION. No-op if no pending config.
+    function applyPendingConfig() external;
 }
 ```
 
@@ -400,12 +420,102 @@ contract VersionConfig {
 |----------|-----------------|
 | `majorVersion()` | Anyone |
 | `isInitialized()` | Anyone |
+| `getPendingConfig()` | Anyone |
 | `initialize()` | GENESIS only (once) |
-| `setMajorVersion()` | GOVERNANCE only |
+| `setForNextEpoch()` | GOVERNANCE only |
+| `applyPendingConfig()` | RECONFIGURATION only |
 
 ### Validation Rules
 
-- `setMajorVersion()`: New version must be strictly greater than current (`newVersion > majorVersion`)
+- `setForNextEpoch()`: New version must be strictly greater than current (`newVersion > majorVersion`)
+
+---
+
+## Contract: `GovernanceConfig.sol`
+
+Configuration for on-chain governance. Holds parameters that the `Governance` contract reads when creating and resolving proposals. Updates follow the pending-config pattern and apply at the next epoch boundary.
+
+### System Address
+
+| Constant | Address | Description |
+|----------|---------|-------------|
+| `GOVERNANCE_CONFIG` | `0x0000000000000000000000000001625F1004` | Governance configuration |
+
+### Parameters
+
+| Parameter | Type | Description | Constraints |
+|-----------|------|-------------|-------------|
+| `minVotingThreshold` | `uint128` | Minimum total yes-voting-power (in wei) for a proposal to pass | `> 0` and `< type(uint128).max` |
+| `requiredProposerStake` | `uint256` | Minimum stake (in wei) a proposer must have to submit a proposal | `> 0` and `< type(uint256).max` |
+| `votingDurationMicros` | `uint64` | Proposal voting window in microseconds | `MIN_VOTING_DURATION (1 hour) ≤ value ≤ MAX_VOTING_DURATION (365 days)` |
+
+### Interface
+
+```solidity
+/// @title GovernanceConfig
+/// @notice Configuration parameters for the Governance contract
+contract GovernanceConfig {
+    /// @notice Pending configuration data structure
+    struct PendingConfig {
+        uint128 minVotingThreshold;
+        uint256 requiredProposerStake;
+        uint64  votingDurationMicros;
+    }
+
+    /// @notice Duration bounds enforced during validation
+    function MIN_VOTING_DURATION() external view returns (uint64); // 1 hour in microseconds
+    function MAX_VOTING_DURATION() external view returns (uint64); // 365 days in microseconds
+
+    /// @notice Current applied parameters
+    function minVotingThreshold() external view returns (uint128);
+    function requiredProposerStake() external view returns (uint256);
+    function votingDurationMicros() external view returns (uint64);
+
+    /// @notice Pending (staged) parameters, if any
+    function getPendingConfig() external view returns (bool hasPending, PendingConfig memory config);
+
+    /// @notice Whether a pending configuration exists
+    function hasPendingConfig() external view returns (bool);
+
+    /// @notice Genesis initialization
+    function initialize(
+        uint128 _minVotingThreshold,
+        uint256 _requiredProposerStake,
+        uint64  _votingDurationMicros
+    ) external;
+
+    /// @notice Stage a governance-parameter update for the next epoch
+    /// @dev Only callable by GOVERNANCE
+    function setForNextEpoch(
+        uint128 _minVotingThreshold,
+        uint256 _requiredProposerStake,
+        uint64  _votingDurationMicros
+    ) external;
+
+    /// @notice Apply the staged update at epoch transition
+    /// @dev Only callable by RECONFIGURATION
+    function applyPendingConfig() external;
+
+    function isInitialized() external view returns (bool);
+}
+```
+
+### Events
+
+- `PendingGovernanceConfigSet()` (parameterless)
+- `PendingGovernanceConfigCleared()`
+- `GovernanceConfigUpdated()` (parameterless)
+
+### Access Control
+
+| Function | Allowed Callers |
+|----------|-----------------|
+| All view functions | Anyone |
+| `initialize()` | GENESIS only (once) |
+| `setForNextEpoch(...)` | GOVERNANCE only |
+| `applyPendingConfig()` | RECONFIGURATION only |
+
+> Note: Before v1.2.0 these parameters lived inside `StakingConfig` as `minimumProposalStake`. That slot is retained on `StakingConfig` only as `__deprecated_minimumProposalStake` for storage-layout compatibility; all new callers must read from `GovernanceConfig`.
 
 ---
 
@@ -417,7 +527,7 @@ Configuration for on-chain randomness (DKG thresholds). Uses the pending config 
 
 | Constant | Address | Description |
 |----------|---------|-------------|
-| `RANDOMNESS_CONFIG` | `0x0000000000000000000000000001625F2024` | Randomness configuration |
+| `RANDOMNESS_CONFIG` | `0x0000000000000000000000000001625F1003` | Randomness configuration |
 
 ### Configuration Variants
 
@@ -425,9 +535,9 @@ Configuration for on-chain randomness (DKG thresholds). Uses the pending config 
 enum ConfigVariant { Off, V2 }
 
 struct ConfigV2Data {
-    uint64 secrecyThreshold;       // Min stake ratio to keep secret
-    uint64 reconstructionThreshold; // Min stake ratio to reveal
-    uint64 fastPathSecrecyThreshold; // Fast path threshold
+    uint128 secrecyThreshold;        // Min stake ratio to keep secret (fixed-point: value / 2^64)
+    uint128 reconstructionThreshold; // Min stake ratio to reveal (fixed-point: value / 2^64)
+    uint128 fastPathSecrecyThreshold; // Fast path threshold (fixed-point: value / 2^64)
 }
 
 struct RandomnessConfigData {
@@ -481,7 +591,7 @@ Consensus parameters stored as opaque bytes. Uses the pending config pattern for
 
 | Constant | Address | Description |
 |----------|---------|-------------|
-| `CONSENSUS_CONFIG` | `0x0000000000000000000000000001625F2029` | Consensus configuration |
+| `CONSENSUS_CONFIG` | `0x0000000000000000000000000001625F1007` | Consensus configuration |
 
 ### Interface
 
@@ -532,7 +642,7 @@ VM execution parameters stored as opaque bytes. Uses the pending config pattern 
 
 | Constant | Address | Description |
 |----------|---------|-------------|
-| `EXECUTION_CONFIG` | `0x0000000000000000000000000001625F202A` | Execution configuration |
+| `EXECUTION_CONFIG` | `0x0000000000000000000000000001625F1008` | Execution configuration |
 
 ### Interface
 
@@ -584,7 +694,7 @@ Manages Distributed Key Generation session lifecycle for epoch transitions. The 
 
 | Constant | Address | Description |
 |----------|---------|-------------|
-| `DKG` | `0x0000000000000000000000000001625F2025` | DKG session management |
+| `DKG` | `0x0000000000000000000000000001625F2002` | DKG session management |
 
 ### Session Info
 
@@ -736,15 +846,16 @@ uint64 microseconds = seconds * MICRO_CONVERSION_FACTOR;
 
 | Contract | Address |
 |----------|---------|
-| `STAKE_CONFIG` | `0x...1625F2011` |
-| `VALIDATOR_CONFIG` | `0x...1625F2015` |
-| `TIMESTAMP` | `0x...1625F2017` |
-| `RANDOMNESS_CONFIG` | `0x...1625F2024` |
-| `DKG` | `0x...1625F2025` |
-| `EPOCH_CONFIG` | `0x...1625F2027` |
-| `VERSION_CONFIG` | `0x...1625F2028` |
-| `CONSENSUS_CONFIG` | `0x...1625F2029` |
-| `EXECUTION_CONFIG` | `0x...1625F202A` |
+| `TIMESTAMP` | `0x...1625F1000` |
+| `STAKE_CONFIG` | `0x...1625F1001` |
+| `VALIDATOR_CONFIG` | `0x...1625F1002` |
+| `RANDOMNESS_CONFIG` | `0x...1625F1003` |
+| `GOVERNANCE_CONFIG` | `0x...1625F1004` |
+| `EPOCH_CONFIG` | `0x...1625F1005` |
+| `VERSION_CONFIG` | `0x...1625F1006` |
+| `CONSENSUS_CONFIG` | `0x...1625F1007` |
+| `EXECUTION_CONFIG` | `0x...1625F1008` |
+| `DKG` | `0x...1625F2002` |
 
 ---
 

--- a/spec_v2/staking.spec.md
+++ b/spec_v2/staking.spec.md
@@ -147,7 +147,7 @@ graph TD
 
 | Constant  | Address                                  | Description                |
 | --------- | ---------------------------------------- | -------------------------- |
-| `STAKING` | `0x0000000000000000000000000001625F2012` | StakePool factory contract |
+| `STAKING` | `0x0000000000000000000000000001625F2000` | StakePool factory contract |
 
 ---
 
@@ -164,21 +164,21 @@ graph TD
         Voter[Voter]
     end
     
-    Owner -->|setVoter, setOperator, setStaker| StakePool
+    Owner -->|propose/accept/cancel{Staker,Operator,Voter}, set*ChangeDelay| StakePool
     Owner -->|transferOwnership, acceptOwnership| StakePool
-    Staker -->|addStake, unstake, withdrawAvailable, renewLockUntil| StakePool
+    Staker -->|addStake, unstake, withdrawAvailable, renewLockUntil, withdrawRewards| StakePool
     Operator -.->|reserved for validator ops| StakePool
     Voter -.->|used for governance voting| StakePool
 ```
 
 ### Role Definitions
 
-| Role       | Controlled By      | Can Do                                                          |
-| ---------- | ------------------ | --------------------------------------------------------------- |
-| **Owner**  | `Ownable2Step`     | Set voter/operator/staker, transfer ownership (2-step process)  |
-| **Staker** | `staker` address   | Add stake, unstake, withdraw, renew lockup (can be a contract)  |
-| **Operator** | `operator` address | Reserved for validator operations (used by ValidatorManager)   |
-| **Voter**  | `voter` address    | Cast governance votes using pool's voting power                 |
+| Role         | Controlled By       | Can Do                                                                        |
+| ------------ | ------------------- | ----------------------------------------------------------------------------- |
+| **Owner**    | `Ownable2Step`      | Propose/cancel voter/operator/staker changes, tune per-role delays, transfer ownership |
+| **Staker**   | `staker` address    | Add stake, unstake, withdraw, renew lockup, withdraw rewards (can be a contract) |
+| **Operator** | `operator` address  | Reserved for validator operations (used by ValidatorManager)                  |
+| **Voter**    | `voter` address     | Cast governance votes using pool's voting power                               |
 
 ### Ownership Transfer (Ownable2Step)
 
@@ -188,6 +188,28 @@ StakePool inherits from OpenZeppelin's `Ownable2Step` for secure ownership trans
 2. New owner calls `acceptOwnership()` — completes transfer
 
 This prevents accidental transfers to wrong addresses.
+
+### 2-Step Role Change (Timelock)
+
+Staker, operator, and voter changes go through a per-role timelock (V3.5 audit hardening, PRs #251/#259):
+
+1. **Propose** — owner calls `proposeStaker(addr)` / `proposeOperator(addr)` / `proposeVoter(addr)` which records
+   `pendingX` and `xChangeAt = now + xChangeDelay`. Emits `RoleChangeProposed(pool, role, newAddress, effectiveAt)`.
+2. **Accept** — after the delay, the *pending address itself* calls `acceptStaker()` / `acceptOperator()` /
+   `acceptVoter()`. Reverts with `RoleChangeTooEarly` if too early, `NotPendingRole` if the wrong caller.
+3. **Cancel** — owner may call `cancelStakerChange()` / `cancelOperatorChange()` / `cancelVoterChange()` at any point.
+   Emits `RoleChangeCancelled`.
+
+Additional guards:
+
+- `acceptStaker()` reverts with `HasPendingWithdrawals(pendingAmount)` if there are any unclaimed pending withdrawals
+  — this prevents the outgoing staker's funds from being trapped.
+- Delays default to `MIN_ROLE_CHANGE_DELAY` (1 day) at construction and can be raised per-role via
+  `setStakerChangeDelay(uint64)` / `setOperatorChangeDelay(uint64)` / `setVoterChangeDelay(uint64)`; setting below
+  the minimum reverts with `RoleChangeDelayTooShort`.
+- `proposeX(sameAddress)` reverts with `RoleAlreadySet`.
+- Events `OperatorChanged` / `VoterChanged` / `StakerChanged` still fire on successful acceptance to preserve
+  indexer compatibility.
 
 ### Staker as Smart Contract
 
@@ -349,7 +371,11 @@ function _getClaimableAmount() internal view returns (uint256) {
 
 - Reduces `activeStake` by `amount`
 - Creates or merges into pending bucket with current `lockedUntil`
-- For validators (ACTIVE or PENDING_INACTIVE): verifies `activeStake - amount >= minimumBond`
+- Rejected while a reconfiguration is in progress (`whenNotReconfiguring` modifier)
+- For validators in **PENDING_ACTIVE, ACTIVE, or PENDING_INACTIVE** state: verifies the effective stake
+  at `now + minLockupDuration` stays `>= minimumBond`, else reverts `WithdrawalWouldBreachMinimumBond`.
+  The PENDING_ACTIVE check was added in PR #75 — without it, a validator could join the set under-bonded.
+- Caps the pending bucket count at `MAX_PENDING_BUCKETS = 1000`; overflow reverts `TooManyPendingBuckets`.
 - Pending stake remains "effective" for voting while its `lockedUntil >= now`
 
 **On `withdrawAvailable(recipient)` (staker only):**
@@ -369,6 +395,20 @@ function _getClaimableAmount() internal view returns (uint256) {
 - Extends `lockedUntil` by `duration`
 - Validates result: `newLockedUntil >= now + minLockupDuration`
 - Does NOT affect existing pending buckets (they keep original lockedUntil)
+
+**On `withdrawRewards(recipient)` (staker only, `nonReentrant`):**
+
+- Withdraws `address(this).balance - activeStake - unclaimedPending` — i.e. any balance above the tracked stake/pending.
+- Not subject to lockup or unbonding delay (rewards are not stake).
+- Emits `RewardsWithdrawn(pool, amount, recipient)`.
+- `getRewardBalance()` exposes the same quantity as a view.
+
+### Reconfiguration Guard
+
+`addStake`, `unstake`, `unstakeAndWithdraw`, `withdrawAvailable`, and `renewLockUntil` use a
+`whenNotReconfiguring` modifier that reverts with `ReconfigurationInProgress` whenever
+`IReconfiguration.isTransitionInProgress()` returns true. This prevents stake-state mutations from racing with
+epoch/DKG handoffs.
 
 ---
 
@@ -554,6 +594,9 @@ uint256 public claimedAmount;
 
 ```solidity
 interface IStakePool {
+    // === Enums ===
+    enum Role { Staker, Operator, Voter }
+
     // === Structs ===
     struct PendingBucket {
         uint64 lockedUntil;        // When this stake stops being effective
@@ -568,6 +611,10 @@ interface IStakePool {
     event OperatorChanged(address indexed pool, address oldOperator, address newOperator);
     event VoterChanged(address indexed pool, address oldVoter, address newVoter);
     event StakerChanged(address indexed pool, address oldStaker, address newStaker);
+    event RoleChangeProposed(address indexed pool, Role indexed role, address indexed newAddress, uint64 effectiveAt);
+    event RoleChangeCancelled(address indexed pool, Role indexed role);
+    event RoleChangeDelayUpdated(address indexed pool, Role indexed role, uint64 oldDelay, uint64 newDelay);
+    event RewardsWithdrawn(address indexed pool, uint256 amount, address indexed recipient);
 
     // === View Functions ===
     function getStaker() external view returns (address);
@@ -585,11 +632,23 @@ interface IStakePool {
     function getPendingBucket(uint256 index) external view returns (PendingBucket memory);
     function getClaimedAmount() external view returns (uint256);
     function getClaimableAmount() external view returns (uint256);
+    function getRewardBalance() external view returns (uint256);
 
     // === Owner Functions (via Ownable2Step) ===
-    function setOperator(address newOperator) external;
-    function setVoter(address newVoter) external;
-    function setStaker(address newStaker) external;
+    // 2-step role change timelock (propose → wait → accept, or cancel)
+    function proposeStaker(address newStaker) external;
+    function acceptStaker() external;                 // called by the new staker itself
+    function cancelStakerChange() external;
+    function proposeOperator(address newOperator) external;
+    function acceptOperator() external;               // called by the new operator itself
+    function cancelOperatorChange() external;
+    function proposeVoter(address newVoter) external;
+    function acceptVoter() external;                  // called by the new voter itself
+    function cancelVoterChange() external;
+    // Tunable per-role delays (must be >= MIN_ROLE_CHANGE_DELAY)
+    function setStakerChangeDelay(uint64 newDelay) external;
+    function setOperatorChangeDelay(uint64 newDelay) external;
+    function setVoterChangeDelay(uint64 newDelay) external;
 
     // === Staker Functions ===
     function addStake() external payable;
@@ -597,11 +656,17 @@ interface IStakePool {
     function withdrawAvailable(address recipient) external returns (uint256 amount);
     function unstakeAndWithdraw(uint256 amount, address recipient) external returns (uint256 withdrawn);
     function renewLockUntil(uint64 durationMicros) external;
+    function withdrawRewards(address recipient) external returns (uint256 amount);
 
     // === System Functions ===
     function systemRenewLockup() external;
 }
 ```
+
+Constants exposed on the pool:
+
+- `MAX_PENDING_BUCKETS = 1000` — hard cap on per-pool pending buckets to bound withdrawal-state growth.
+- `MIN_ROLE_CHANGE_DELAY = 1 days` — minimum acceptable per-role timelock delay.
 
 ### Constructor
 
@@ -659,15 +724,20 @@ Unstake tokens (move from active stake to pending bucket).
 
 1. Revert if `amount == 0`
 2. Revert if `amount > activeStake` (insufficient available)
-3. **For validators (ACTIVE or PENDING_INACTIVE)**: Check `activeStake - amount >= minimumBond`
-4. Reduce `activeStake` by `amount`
-5. Add to pending bucket with current `lockedUntil`:
+3. Revert with `ReconfigurationInProgress` while a transition is running (`whenNotReconfiguring`).
+4. **For validators in PENDING_ACTIVE, ACTIVE, or PENDING_INACTIVE**: check that effective stake at
+   `now + minLockupDuration` stays `>= minimumBond`; otherwise revert `WithdrawalWouldBreachMinimumBond`.
+5. Revert with `TooManyPendingBuckets` if the pool already holds `MAX_PENDING_BUCKETS = 1000` buckets
+   and the new unstake would append another.
+6. Reduce `activeStake` by `amount`
+7. Add to pending bucket with current `lockedUntil`:
    - If last bucket has same `lockedUntil`: merge (add to cumulativeAmount)
    - Otherwise: append new bucket with cumulative prefix sum
-6. Emit `Unstaked` event
+8. Emit `Unstaked` event
 
 **Notes:**
-- Active validators cannot reduce `activeStake` below `minimumBond`
+- Validators in PENDING_ACTIVE cannot drop below `minimumBond` either (PR #75) — this prevents joining
+  the set under-bonded.
 - Combined with lockup auto-renewal at epoch boundaries, voting power is always >= minBond
 - The pending amount is still "effective" for voting while its `lockedUntil >= now`
 - Tokens remain in contract until `withdrawAvailable()` is called after unbonding
@@ -748,41 +818,47 @@ Renew lockup for active validators (called by Staking factory during epoch trans
 - Ensures voting power never drops to zero due to lockup expiration while validating
 - Does NOT affect existing pending buckets (they keep original lockedUntil)
 
-#### `setOperator(address newOperator)` — Owner Only
+#### Role Change Functions (2-step timelock)
 
-Change the operator address.
+Staker, operator, and voter role changes go through a propose → wait → accept flow
+(`cancel*Change` clears a pending proposal). Each role has an independent, owner-tunable delay that
+starts at `MIN_ROLE_CHANGE_DELAY` (1 day) and cannot go below it (`RoleChangeDelayTooShort`).
 
-**Access Control:** Only `owner` (via Ownable2Step)
+**Common behavior for `propose{Staker,Operator,Voter}(addr)` — Owner Only:**
+
+1. Revert `RoleAlreadySet` if `addr` equals the current role holder.
+2. Record `pendingX = addr` and `xChangeAt = uint64(block.timestamp) + xChangeDelay`.
+3. Emit `RoleChangeProposed(pool, role, addr, xChangeAt)`.
+
+**Common behavior for `accept{Staker,Operator,Voter}()` — Pending Role Holder Only:**
+
+1. Revert `NoPendingRoleChange` if no proposal is pending.
+2. Revert `NotPendingRole(caller, expected)` if `msg.sender != pendingX`.
+3. Revert `RoleChangeTooEarly(xChangeAt, block.timestamp)` if the delay has not elapsed.
+4. For `acceptStaker()` only: revert `HasPendingWithdrawals(pendingAmount)` if any pending-bucket amount is unclaimed.
+5. Promote `pendingX` to `x`, clear the pending slot, and emit the original `OperatorChanged` / `VoterChanged` /
+   `StakerChanged` event.
+
+**Common behavior for `cancel{Staker,Operator,Voter}Change()` — Owner Only:**
+
+1. Revert `NoPendingRoleChange` if nothing is pending.
+2. Clear `pendingX` and `xChangeAt`. Emit `RoleChangeCancelled(pool, role)`.
+
+**`set{Staker,Operator,Voter}ChangeDelay(uint64 newDelay)` — Owner Only:**
+
+1. Revert `RoleChangeDelayTooShort` if `newDelay < MIN_ROLE_CHANGE_DELAY`.
+2. Emit `RoleChangeDelayUpdated(pool, role, old, new)`.
+
+#### `withdrawRewards(address recipient)` — Staker Only (nonReentrant)
+
+Withdraw any balance above the tracked stake (i.e. rewards/airdrops credited to the pool).
 
 **Behavior:**
 
-1. Store old operator
-2. Set `operator = newOperator`
-3. Emit `OperatorChanged` event
-
-#### `setVoter(address newVoter)` — Owner Only
-
-Change the delegated voter address.
-
-**Access Control:** Only `owner` (via Ownable2Step)
-
-**Behavior:**
-
-1. Store old voter
-2. Set `voter = newVoter`
-3. Emit `VoterChanged` event
-
-#### `setStaker(address newStaker)` — Owner Only
-
-Change the staker address.
-
-**Access Control:** Only `owner` (via Ownable2Step)
-
-**Behavior:**
-
-1. Store old staker
-2. Set `staker = newStaker`
-3. Emit `StakerChanged` event
+1. Compute `amount = address(this).balance - activeStake - (totalPending - claimedAmount)`.
+2. Revert `ZeroAmount` if `amount == 0`.
+3. Transfer `amount` to `recipient` (`TransferFailed` on failure).
+4. Emit `RewardsWithdrawn(pool, amount, recipient)`.
 
 #### `getVotingPower(uint64 atTime)`
 
@@ -872,9 +948,10 @@ Lockup parameters are configured in `StakingConfig`:
 | Staking   | createPool                                      | Anyone (with min stake) |
 | Staking   | renewPoolLockup                                 | VALIDATOR_MANAGER only  |
 | Staking   | view functions                                  | Anyone                  |
-| StakePool | addStake/unstake/withdrawAvailable/unstakeAndWithdraw/renewLockUntil | Staker only   |
+| StakePool | addStake/unstake/withdrawAvailable/unstakeAndWithdraw/renewLockUntil/withdrawRewards | Staker only (blocked during reconfiguration for mutating funcs) |
 | StakePool | systemRenewLockup                               | Staking factory only    |
-| StakePool | setOperator/setVoter/setStaker                  | Owner only              |
+| StakePool | propose{Staker,Operator,Voter} / cancel*Change / set*ChangeDelay | Owner only |
+| StakePool | accept{Staker,Operator,Voter}                   | Pending role holder only |
 | StakePool | transferOwnership                               | Owner only              |
 | StakePool | acceptOwnership                                 | Pending owner only      |
 | StakePool | view functions                                  | Anyone                  |
@@ -944,8 +1021,10 @@ uint256 power = IStakePool(pool).getVotingPowerNow();
 uint64 futureTime = uint64(block.timestamp * 1_000_000) + 15 days * 1_000_000;
 uint256 futurePower = IStakePool(pool).getVotingPower(futureTime);
 
-// 5. Delegate voting to another address (as owner)
-IStakePool(pool).setVoter(delegatee);
+// 5. Delegate voting to another address (as owner) — 2-step timelock
+IStakePool(pool).proposeVoter(delegatee);
+// ...wait voterChangeDelay seconds (>= MIN_ROLE_CHANGE_DELAY = 1 day)...
+vm.prank(delegatee); IStakePool(pool).acceptVoter();
 
 // 6. Extend lockup by 30 days (as staker)
 IStakePool(pool).renewLockUntil(30 days * 1_000_000); // microseconds

--- a/spec_v2/validator_management.spec.md
+++ b/spec_v2/validator_management.spec.md
@@ -196,8 +196,10 @@ graph TD
 
 | Constant | Address | Description |
 | --- | --- | --- |
-| `VALIDATOR_MANAGER` | `0x0000000000000000000000000001625F2013` | Validator set management |
-| `VALIDATOR_CONFIG` | `0x0000000000000000000000000001625F2015` | Validator configuration |
+| `VALIDATOR_MANAGER` | `0x0000000000000000000000000001625F2001` | Validator set management |
+| `VALIDATOR_CONFIG` | `0x0000000000000000000000000001625F1002` | Validator configuration |
+| `RECONFIGURATION`   | `0x0000000000000000000000000001625F2003` | Epoch lifecycle (caller of `onNewEpoch`) |
+| `PERFORMANCE_TRACKER` | `0x0000000000000000000000000001625F2005` | Per-epoch proposal stats source |
 
 ---
 
@@ -316,17 +318,38 @@ bool private _initialized;
 ### Interface
 
 ```solidity
+struct GenesisValidator {
+    address stakePool;
+    string moniker;
+    bytes consensusPubkey;
+    bytes consensusPop;
+    bytes networkAddresses;
+    bytes fullnodeAddresses;
+    address feeRecipient;
+    uint256 votingPower;
+}
+
 interface IValidatorManagement {
     // === Events ===
     event ValidatorRegistered(address indexed stakePool, string moniker);
     event ValidatorJoinRequested(address indexed stakePool);
     event ValidatorActivated(address indexed stakePool, uint64 validatorIndex, uint256 votingPower);
     event ValidatorLeaveRequested(address indexed stakePool);
+    event ValidatorForceLeaveRequested(address indexed stakePool);
     event ValidatorDeactivated(address indexed stakePool);
-    event ValidatorAutoEvicted(address indexed stakePool, uint64 successfulProposals);
+    event ValidatorAutoEvicted(address indexed stakePool, uint256 successfulProposals);
+    event ValidatorUnderbondedEvicted(address indexed stakePool, uint256 votingPower, uint256 minimumBond);
+    event ValidatorRevertedInactive(address indexed stakePool);
+    event PerformanceLengthMismatch(uint256 activeCount, uint256 perfCount);
     event ConsensusKeyRotated(address indexed stakePool, bytes newPubkey);
     event FeeRecipientUpdated(address indexed stakePool, address newRecipient);
+    event FeeRecipientApplied(address indexed stakePool, address oldRecipient, address newRecipient);
     event EpochProcessed(uint64 epoch, uint256 activeCount, uint256 totalVotingPower);
+    event ValidatorManagementInitialized(uint256 validatorCount, uint256 totalVotingPower);
+
+    // === Initialization (genesis only) ===
+    function initialize(GenesisValidator[] calldata validators) external;
+    function isInitialized() external view returns (bool);
 
     // === Registration ===
     function registerValidator(
@@ -341,15 +364,16 @@ interface IValidatorManagement {
     // === Lifecycle ===
     function joinValidatorSet(address stakePool) external;
     function leaveValidatorSet(address stakePool) external;
-    
+    function forceLeaveValidatorSet(address stakePool) external;         // GOVERNANCE only
+
     // === Operator Functions ===
     function rotateConsensusKey(address stakePool, bytes calldata newPubkey, bytes calldata newPop) external;
     function setFeeRecipient(address stakePool, address newRecipient) external;
-    
+
     // === Epoch Processing ===
     function onNewEpoch() external;
     function evictUnderperformingValidators() external;
-    
+
     // === View Functions ===
     function getValidator(address stakePool) external view returns (ValidatorRecord memory);
     function getActiveValidators() external view returns (ValidatorConsensusInfo[] memory);
@@ -359,8 +383,12 @@ interface IValidatorManagement {
     function isValidator(address stakePool) external view returns (bool);
     function getValidatorStatus(address stakePool) external view returns (ValidatorStatus);
     function getCurrentEpoch() external view returns (uint64);
-    function getPendingActiveValidators() external view returns (address[] memory);
-    function getPendingInactiveValidators() external view returns (address[] memory);
+    function getPendingActiveValidators() external view returns (ValidatorConsensusInfo[] memory);
+    function getPendingInactiveValidators() external view returns (ValidatorConsensusInfo[] memory);
+
+    // === DKG support ===
+    function getCurValidatorConsensusInfos() external view returns (ValidatorConsensusInfo[] memory);
+    function getNextValidatorConsensusInfos() external view returns (ValidatorConsensusInfo[] memory);
 }
 ```
 
@@ -460,6 +488,32 @@ Request to leave the active validator set. Can also cancel a pending join reques
 
 ---
 
+### `forceLeaveValidatorSet(address stakePool)`
+
+Governance emergency hook to remove a validator without operator cooperation.
+
+**Access Control**: GOVERNANCE only
+
+**Behavior**:
+- Verify validator exists.
+- **If status is PENDING_ACTIVE** — immediately revert to INACTIVE (removes from the pending queue).
+- **If status is ACTIVE** — mark PENDING_INACTIVE for deactivation at the next epoch boundary.
+- Emits `ValidatorForceLeaveRequested(pool)`.
+- Unlike voluntary `leaveValidatorSet`, this CAN remove the last active validator — intentional so
+  governance can respond to a compromised single-node set. Use with extreme care.
+
+### `initialize(GenesisValidator[] calldata validators)`
+
+One-shot genesis initializer, callable only by `SystemAddresses.GENESIS`. Seeds the validator set
+directly into ACTIVE state with the provided consensus keys, monikers, network / fullnode addresses,
+fee recipient, and voting power. Reverts with `AlreadyInitialized` on re-call, and runs BLS PoP /
+length checks on each entry. Emits `ValidatorManagementInitialized(count, totalVotingPower)` and a
+`ValidatorActivated` event per genesis validator. Mirrors `GenesisValidator` in
+`src/staking/IValidatorManagement.sol`. Post-genesis, `isInitialized() == true`; new validators
+must join via the normal `registerValidator` → `joinValidatorSet` flow.
+
+---
+
 ### `onNewEpoch()`
 
 Process epoch transition.
@@ -476,45 +530,65 @@ Process epoch transition.
 2. Process PENDING_ACTIVE → ACTIVE:
    - Check voting power increase limit
    - Validators exceeding limit remain pending
-   - Validators below minimum revert to INACTIVE
+   - Validators below minimum revert to INACTIVE (emits `ValidatorRevertedInactive`)
    - Emit `ValidatorActivated` event
-3. **Auto-renew lockups for active validators** (Aptos-style):
+3. Apply revert-inactive sweep for validators whose bond dropped under `minimumBond`
+   between join request and activation.
+4. **Auto-renew lockups for active validators** (Aptos-style):
    - Call `Staking.renewPoolLockup(pool)` for each active validator
    - Ensures voting power never drops to zero due to lockup expiration
-   - Matches Aptos `stake.move` lines 1435-1449
-4. Apply pending fee recipient changes
-5. Sync owner/operator from stake pools
-6. Reassign indices (0 to n-1) for all active validators
-7. Read and store current epoch from `IReconfiguration.currentEpoch()`
-8. Update total voting power
-9. Emit `EpochProcessed` event
+5. Apply pending fee recipient changes (emits `FeeRecipientApplied` per update).
+6. Apply pending consensus key rotations queued by `rotateConsensusKey()` — old key is
+   unmapped and the pending key becomes the active `consensusPubkey` / `consensusPop`.
+7. Reassign indices (0 to n-1) for all active validators.
+8. Read and store current epoch from `IReconfiguration.currentEpoch()`.
+9. Update total voting power.
+10. Emit `EpochProcessed` event.
 
-> **Note**: The epoch is not passed as a parameter; instead, `ValidatorManagement` reads it from `Reconfiguration.currentEpoch()`. This aligns with Aptos's pattern where `stake::on_new_epoch()` is called before the epoch is incremented in `reconfiguration.move`.
+> **Note**: The epoch is not passed as a parameter; instead, `ValidatorManagement` reads it from
+> `Reconfiguration.currentEpoch()`. This aligns with Aptos's pattern where `stake::on_new_epoch()` is
+> called before the epoch is incremented in `reconfiguration.move`.
+
+> **Note**: owner/operator are *not* synchronised from stake pools at epoch boundary — the
+> stake-pool is the source of truth for those roles and is read lazily via `Staking.getPool*()`.
 
 ---
 
 ### `evictUnderperformingValidators()`
 
-Auto-evict validators whose successful proposals fall below the configured threshold.
+Two-phase auto-eviction run by Reconfiguration during a transition.
 
 **Access Control**: RECONFIGURATION only
 
-**Behavior**:
-1. Check if `autoEvictEnabled` is true in `ValidatorConfig`; return immediately if disabled
-2. Read `autoEvictThreshold` from `ValidatorConfig`
-3. Read performance data from `ValidatorPerformanceTracker.getAllPerformances()`
-4. For each active validator:
-   - Skip if status is not ACTIVE (e.g., already PENDING_INACTIVE from manual leave)
-   - If `successfulProposals <= threshold`:
-     - Count remaining ACTIVE validators
-     - If this is the last ACTIVE validator, **break** (liveness protection)
-     - Change status to PENDING_INACTIVE
-     - Add to `_pendingInactive` array
-     - Emit `ValidatorAutoEvicted(pool, successfulProposals)` event
+**Guards:**
 
-> **Important**: Auto-evicted validators transition ACTIVE → PENDING_INACTIVE → INACTIVE within a **single epoch transition**. This is different from voluntary `leaveValidatorSet()` where validators have a one-epoch buffer. The eviction marks them as PENDING_INACTIVE, and the subsequent `onNewEpoch()` call (in the same `_applyReconfiguration()`) processes them to INACTIVE.
+- Returns immediately when `ValidatorConfig.allowValidatorSetChange == false` (audit fix #154).
+- Returns immediately for epochs `<= 1` (bootstrap protection — no performance history yet).
 
-**Liveness Protection**: The last active validator is never evicted to prevent consensus halt.
+**Phase 1 — Underbonded eviction (unconditional):**
+
+For every currently ACTIVE validator, read voting power via `Staking.getPoolVotingPower(pool)`. If it is
+below `ValidatorConfig.minimumBond`, mark the validator PENDING_INACTIVE and emit
+`ValidatorUnderbondedEvicted(pool, votingPower, minimumBond)`. This phase runs even if performance
+auto-eviction is disabled, to enforce the minimum-bond invariant at epoch boundaries.
+
+**Phase 2 — Performance eviction (optional):**
+
+Runs only when `autoEvictEnabled == true`. Reads per-validator success counts from the
+`ValidatorPerformanceTracker`. For each still-ACTIVE validator:
+
+- If the active-set count vs. performance-array length disagrees, emit `PerformanceLengthMismatch`
+  and skip Phase 2 (defensive).
+- Compute `successPct = successfulProposals * 100 / totalProposals` (0 if `totalProposals == 0`).
+  When `successPct < autoEvictThresholdPct` (0-100), mark the validator PENDING_INACTIVE and emit
+  `ValidatorAutoEvicted(pool, successfulProposals)`.
+
+**Liveness Protection (applies to both phases):** the last remaining would-be-ACTIVE validator is
+never evicted — if `remainingActive <= 1`, the loop breaks.
+
+> **Important**: Auto-evicted validators transition ACTIVE → PENDING_INACTIVE → INACTIVE within a
+> **single epoch transition**. This is different from voluntary `leaveValidatorSet()` where validators
+> have a one-epoch buffer.
 
 ---
 
@@ -525,23 +599,31 @@ Auto-evict validators whose successful proposals fall below the configured thres
 
 ---
 
-### `rotateConsensusKey()`
+### `rotateConsensusKey()` — Deferred (V3.5 audit fix D2-3)
 
-Rotate the validator's consensus key.
+Rotate the validator's consensus key. The key change is **deferred to the next epoch boundary**
+for BFT consistency; the active key continues to be used for this epoch.
 
 **Access Control**: Validator's operator only
 
 **Behavior**:
-1. Verify no reconfiguration (epoch transition) is in progress
-2. Verify validator exists
-3. Verify caller is operator
-4. Update consensus pubkey and PoP (takes effect immediately)
-5. Emit `ConsensusKeyRotated` event
+1. Verify no reconfiguration (epoch transition) is in progress.
+2. Verify validator exists.
+3. Verify caller is operator.
+4. Validate length (`BLS12381_PUBKEY_LENGTH = 48`) and run BLS PoP precompile on `(newPubkey, newPop)`.
+5. Revert `DuplicateConsensusPubkey` if any other live or pending validator already reserves the key.
+6. **Reserve** `newPubkey → validator` in `_pubkeyToValidator` immediately to prevent duplicates,
+   but store the key in `ValidatorRecord.pendingConsensusPubkey` / `pendingConsensusPop`. The active
+   `consensusPubkey` / `consensusPop` stay unchanged until `onNewEpoch()` promotes them
+   (step 6 of `onNewEpoch`).
+7. Emit `ConsensusKeyRotated(pool, newPubkey)`.
 
 **Reverts**:
-- `ReconfigurationInProgress` - Epoch transition in progress
-- `ValidatorNotFound` - Validator not registered
-- `NotOperator` - Caller is not the operator
+- `ReconfigurationInProgress` — epoch transition in progress
+- `ValidatorNotFound` — validator not registered
+- `NotOperator` — caller is not the operator
+- `InvalidConsensusPubkeyLength` / `InvalidConsensusPopLength` / `InvalidConsensusPopVerification`
+- `DuplicateConsensusPubkey` — key already used by another validator (or pending rotation)
 
 ---
 
@@ -589,7 +671,9 @@ Set a new fee recipient address.
 | `registerValidator` | StakePool operator (verified via Staking) |
 | `joinValidatorSet` | Validator's operator (verified via Staking) |
 | `leaveValidatorSet` | Validator's operator (verified via Staking) |
-| `rotateConsensusKey` | Validator's operator (verified via Staking) |
+| `rotateConsensusKey` | Validator's operator (verified via Staking); applied at next epoch |
+| `forceLeaveValidatorSet` | GOVERNANCE only |
+| `initialize` | GENESIS only (one-shot) |
 | `setFeeRecipient` | Validator's operator (verified via Staking) |
 | `onNewEpoch` | RECONFIGURATION only |
 | `evictUnderperformingValidators` | RECONFIGURATION only |
@@ -618,16 +702,20 @@ function _getValidatorVotingPower(address stakePool) internal view returns (uint
 
 ## Unstake Protection for Active Validators
 
-Active validators (status ACTIVE or PENDING_INACTIVE) have unstake protection enforced at the StakePool level:
+Active validators (status ACTIVE, PENDING_INACTIVE, or PENDING_ACTIVE) have unstake protection enforced at the StakePool level:
 
 ```solidity
 // In StakePool._unstake():
 IValidatorManagement validatorMgmt = IValidatorManagement(SystemAddresses.VALIDATOR_MANAGER);
 if (validatorMgmt.isValidator(address(this))) {
     ValidatorStatus status = validatorMgmt.getValidatorStatus(address(this));
-    if (status == ValidatorStatus.ACTIVE || status == ValidatorStatus.PENDING_INACTIVE) {
+    if (
+        status == ValidatorStatus.ACTIVE
+        || status == ValidatorStatus.PENDING_INACTIVE
+        || status == ValidatorStatus.PENDING_ACTIVE
+    ) {
         uint256 minBond = IValidatorConfig(SystemAddresses.VALIDATOR_CONFIG).minimumBond();
-        
+
         // Simple check: activeStake after unstake must be >= minBond
         if (activeStake - amount < minBond) {
             revert Errors.WithdrawalWouldBreachMinimumBond(activeStake - amount, minBond);
@@ -635,6 +723,8 @@ if (validatorMgmt.isValidator(address(this))) {
     }
 }
 ```
+
+> **Why PENDING_ACTIVE is covered**: a validator that has joined the set but not yet been promoted at the epoch boundary must still keep its declared bond above `minimumBond`, otherwise it could join with less stake than the protocol requires. This matches the fix in commit `808108d` (`fix(staking): enforce minBond on unstake for PENDING_ACTIVE validators`).
 
 **Key Security Properties**:
 1. Active validators cannot reduce `activeStake` below `minimumBond`
@@ -795,7 +885,7 @@ validatorManager.leaveValidatorSet(pool);
 7. **No Direct StakePool Calls**: All pool queries go through Staking factory
 8. **Reconfiguration Guard**: Operations blocked during epoch transitions (Aptos `assert_reconfig_not_in_progress` pattern)
 9. **Last Validator Protection**: Cannot remove the last active validator (would halt consensus)
-10. **Auto-Eviction Safety**: Underperforming validators are evicted based on governance-configured on-chain parameters (`autoEvictEnabled`, `autoEvictThreshold`). The last active validator is never evicted.
+10. **Auto-Eviction Safety**: Underperforming validators are evicted based on governance-configured on-chain parameters (`autoEvictEnabled`, `autoEvictThresholdPct`). The last active validator is never evicted. A dedicated underbonded-eviction sweep also runs unconditionally so validators that drop below `minimumBond` are removed at the next boundary.
 11. **Leave Flexibility**: Validators can cancel join requests by leaving from PENDING_ACTIVE state
 12. **Unstake Protection**: Active validators cannot reduce `activeStake` below `minimumBond` (simple direct check)
 13. **Lockup Auto-Renewal**: Active validators have lockups auto-renewed at epoch boundaries (Aptos-style), ensuring voting power = activeStake
@@ -922,15 +1012,17 @@ Added security checks to match Aptos's `stake.move` validator management:
 - Added `ValidatorAutoEvicted(address stakePool, uint64 successfulProposals)` event
 
 **Behavior**:
-- Reads `autoEvictEnabled` and `autoEvictThreshold` from `ValidatorConfig`
+- Reads `autoEvictEnabled` and `autoEvictThresholdPct` from `ValidatorConfig`
 - Reads performance data from `ValidatorPerformanceTracker.getAllPerformances()`
-- Validators with `successfulProposals <= autoEvictThreshold` are marked PENDING_INACTIVE
+- Validators with `successPct < autoEvictThresholdPct` are marked PENDING_INACTIVE
 - Evicted validators transition ACTIVE → PENDING_INACTIVE → INACTIVE within a single epoch (no buffer)
 - Last active validator is never evicted (liveness protection)
 
 **Configuration** (in `ValidatorConfig`):
 - `autoEvictEnabled` (bool): governance-controlled on/off switch (default: false)
-- `autoEvictThreshold` (uint256): minimum successful proposals to avoid eviction (default: 0)
+- `autoEvictThresholdPct` (uint64, 0-100): minimum success **percentage** required to avoid eviction.
+  The old `autoEvictThreshold` (`uint256` raw count) field is kept as
+  `__deprecated_autoEvictThreshold` for storage-layout compatibility and is unused.
 - Both follow the pending config pattern (applied at epoch boundary via `setForNextEpoch`/`applyPendingConfig`)
 
 **Ordering in `_applyReconfiguration()`**:


### PR DESCRIPTION
## Summary

Cross-checked every `spec_v2/` document against the current `src/` and corrected the drift that accumulated since v1.2.0. Docs-only change — no source changes.

- **System addresses**: remapped stale `0x1625F2xxx` entries throughout every spec to match the current segmentation (`0x1625F1xxx` runtime configs, `0x1625F2xxx` staking+validator, `0x1625F3xxx` governance, `0x1625F4xxx` oracle, `0x1625F5xxx` precompiles) from `src/foundation/SystemAddresses.sol`.
- **runtime**: added the new `GovernanceConfig` contract section, rewrote `VersionConfig` to the pending-config pattern (replacing the removed `setMajorVersion`), fixed `RandomnessConfig.ConfigV2Data` widths (`uint64` → `uint128`), corrected the `GovernanceConfig` interface (`uint128 minVotingThreshold`, struct return on `getPendingConfig`, parameterless events, voting-duration bounds), and renamed `autoEvictThreshold` → `autoEvictThresholdPct`.
- **blocker**: reordered `checkAndStartTransition` so eviction runs before the DKG/immediate branch, documented `_applyReconfiguration` ordering, fixed `Blocker.onBlockStart` steps (`PerformanceTracker.updateStatistics` first), added `governanceReconfigure` and `NewEpochEvent`.
- **governance**: added `MAX_PROPOSAL_TARGETS = 100`, the sentinel-id convention, and `ExecutionFailed(uint64, bytes)` so raw revert data is bubbled; corrected `TooManyProposalTargets` parameter names.
- **oracle**: strict sequential-nonce rule (`currentNonce + 1`), `DataRecord` now carries `blockNumber`, callbacks return `bool shouldStore`, added full `OracleTaskConfig` / `OnDemandOracleTaskConfig` sections.
- **oracle_evm_bridge**: `MessageSent` carries `block_number`, `GBridgeReceiver` validates against immutable `trustedSourceId` (replacing the removed `processedNonces` mapping; `__deprecated` slot retained for layout compatibility), `BlockchainEventHandler` returns `shouldStore`.
- **validator_management**: include `PENDING_ACTIVE` in the unstake-protection status check, cross-referencing commit `808108d`.

## Test plan

- [ ] Manual review: open each edited spec and confirm it still reads coherently end-to-end.
- [ ] Spot-check system addresses against `src/foundation/SystemAddresses.sol`.
- [ ] Spot-check interface signatures against the corresponding `src/*/*.sol` files.
- [ ] Follow-up (not in this PR): stale `@dev` comment in `src/staking/IValidatorManagement.sol:187` claims `rotateConsensusKey` takes effect immediately — the implementation uses the deferred pending-apply pattern. Worth a small source-only fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)