### PR TITLE
test(poc): DKG target set diverges from actual epoch set across pending ValidatorConfig

### DIFF
--- a/test/unit/DkgDivergencePoC.t.sol
+++ b/test/unit/DkgDivergencePoC.t.sol
@@ -1,0 +1,304 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import { Test } from "forge-std/Test.sol";
+import { ValidatorManagement } from "../../src/staking/ValidatorManagement.sol";
+import { IValidatorManagement } from "../../src/staking/IValidatorManagement.sol";
+import { Staking } from "../../src/staking/Staking.sol";
+import { IStakePool } from "../../src/staking/IStakePool.sol";
+import { StakingConfig } from "../../src/runtime/StakingConfig.sol";
+import { ValidatorConfig } from "../../src/runtime/ValidatorConfig.sol";
+import { Timestamp } from "../../src/runtime/Timestamp.sol";
+import { SystemAddresses } from "../../src/foundation/SystemAddresses.sol";
+import { ValidatorStatus, ValidatorConsensusInfo } from "../../src/foundation/Types.sol";
+import { MockBlsPopVerify } from "../utils/MockBlsPopVerify.sol";
+
+/// Minimal Reconfiguration mock: exposes isTransitionInProgress + currentEpoch only.
+contract MockReconfiguration {
+    uint64 public currentEpoch;
+    function isTransitionInProgress() external pure returns (bool) { return false; }
+    function incrementEpoch() external { currentEpoch++; }
+}
+
+/// @title DkgDivergencePoC
+/// @notice PoC for gravity-audit#112 — DKG target validator set diverges from
+///         the actual next-epoch validator set when a pending ValidatorConfig
+///         change is queued across the reconfiguration boundary.
+///
+/// ──────────────────────────────────────────────────────────────────────────
+/// Flow (origin/main, Reconfiguration.sol):
+///   checkAndStartTransition():
+///     evictUnderperformingValidators()
+///     _startDkgSession():
+///         targets = getNextValidatorConsensusInfos()   // STEP A — CURRENT config
+///   finishTransition():
+///     _applyReconfiguration():
+///         ValidatorConfig.applyPendingConfig()         // config flips here
+///         onNewEpoch() → _computeNextEpochValidatorSet() // STEP B — NEW config
+///
+/// STEP A and STEP B run the SAME pure computation with DIFFERENT inputs from
+/// ValidatorConfig.  Whenever a queued pending config changes any input the
+/// computation reads, the two sets diverge and the off-chain DKG key shares
+/// are attributed to a committee that never runs the epoch.
+/// ──────────────────────────────────────────────────────────────────────────
+///
+/// This file demonstrates three independent divergence vectors:
+///   1. minimumBond — pending_active passes/fails the min-bond filter.
+///   2. votingPowerIncreaseLimitPct — pending_active fits/exceeds the VP cap.
+///   3. maximumBond — per-validator voting power cap shifts currentTotal,
+///      shifting maxIncrease, indirectly flipping (2).
+///
+/// Related: PR #70 (this repo) proposes a one-line fix that replaces
+///   getNextValidatorConsensusInfos() with getActiveValidators().  That fix
+///   fails on all three vectors and introduces a new Critical: PENDING_ACTIVE
+///   validators would be excluded from DKG targets, so newly-joining validators
+///   activated by onNewEpoch() never receive VRF key shares.
+contract DkgDivergencePoC is Test {
+    ValidatorManagement public vm_;
+    Staking public staking;
+    StakingConfig public stakingConfig;
+    ValidatorConfig public validatorConfig;
+    Timestamp public ts;
+    MockReconfiguration public reconfig;
+
+    address alice = makeAddr("alice");
+    address bob   = makeAddr("bob");
+    address carol = makeAddr("carol");
+    address dan   = makeAddr("dan");   // "victim" validator for min/max bond cases
+    address eve   = makeAddr("eve");   // second victim for VP-limit case
+
+    uint256 constant MIN_BOND_DEFAULT = 10 ether;
+    uint256 constant MAX_BOND_DEFAULT = 1000 ether;
+    uint64  constant UNBONDING = 7 days * 1_000_000;
+    uint64  constant VP_LIMIT_DEFAULT = 50;    // max allowed by ValidatorConfig
+    uint256 constant MAX_SET_SIZE = 100;
+
+    bytes constant POP = hex"abcdef1234567890";
+    bytes constant NET = hex"0102030405060708";
+    bytes constant FN  = hex"0807060504030201";
+    uint256 constant MIN_STAKE = 1 ether;
+    uint64  constant LOCKUP = 14 days * 1_000_000;
+    uint64  constant T0 = 1_000_000_000_000_000;
+
+    function setUp() public {
+        vm.etch(SystemAddresses.STAKE_CONFIG,     address(new StakingConfig()).code);
+        vm.etch(SystemAddresses.VALIDATOR_CONFIG, address(new ValidatorConfig()).code);
+        vm.etch(SystemAddresses.TIMESTAMP,        address(new Timestamp()).code);
+        vm.etch(SystemAddresses.STAKING,          address(new Staking()).code);
+        vm.etch(SystemAddresses.VALIDATOR_MANAGER,address(new ValidatorManagement()).code);
+        vm.etch(SystemAddresses.RECONFIGURATION,  address(new MockReconfiguration()).code);
+        vm.etch(SystemAddresses.BLS_POP_VERIFY_PRECOMPILE, address(new MockBlsPopVerify()).code);
+
+        stakingConfig   = StakingConfig(SystemAddresses.STAKE_CONFIG);
+        validatorConfig = ValidatorConfig(SystemAddresses.VALIDATOR_CONFIG);
+        ts      = Timestamp(SystemAddresses.TIMESTAMP);
+        staking = Staking(SystemAddresses.STAKING);
+        vm_     = ValidatorManagement(SystemAddresses.VALIDATOR_MANAGER);
+        reconfig = MockReconfiguration(SystemAddresses.RECONFIGURATION);
+
+        vm.prank(SystemAddresses.GENESIS);
+        stakingConfig.initialize(MIN_STAKE, LOCKUP, UNBONDING, 10 ether);
+        vm.prank(SystemAddresses.GENESIS);
+        validatorConfig.initialize(
+            MIN_BOND_DEFAULT, MAX_BOND_DEFAULT, UNBONDING, true,
+            VP_LIMIT_DEFAULT, MAX_SET_SIZE, false, 0
+        );
+        vm.prank(SystemAddresses.BLOCK);
+        ts.updateGlobalTime(alice, T0);
+
+        vm.deal(alice, 10_000 ether);
+        vm.deal(bob,   10_000 ether);
+        vm.deal(carol, 10_000 ether);
+        vm.deal(dan,   10_000 ether);
+        vm.deal(eve,   10_000 ether);
+    }
+
+    // ------------------------------------------------------------------------
+    // helpers
+    // ------------------------------------------------------------------------
+
+    function _createPool(address owner, uint256 amount) internal returns (address pool) {
+        uint64 lockedUntil = ts.nowMicroseconds() + LOCKUP;
+        vm.prank(owner);
+        pool = staking.createPool{ value: amount }(owner, owner, owner, owner, lockedUntil);
+    }
+
+    function _register(address owner, uint256 amount, string memory moniker) internal returns (address pool) {
+        pool = _createPool(owner, amount);
+        bytes memory pub = abi.encodePacked(pool, bytes28(keccak256(abi.encodePacked(pool))));
+        vm.prank(owner);
+        vm_.registerValidator(pool, moniker, pub, POP, NET, FN);
+    }
+
+    function _registerAndJoin(address owner, uint256 amount, string memory moniker) internal returns (address pool) {
+        pool = _register(owner, amount, moniker);
+        vm.prank(owner);
+        vm_.joinValidatorSet(pool);
+    }
+
+    function _advanceEpoch() internal {
+        vm.prank(SystemAddresses.RECONFIGURATION);
+        vm_.onNewEpoch();
+        reconfig.incrementEpoch();
+    }
+
+    function _contains(ValidatorConsensusInfo[] memory xs, address who) internal pure returns (bool) {
+        for (uint256 i = 0; i < xs.length; i++) if (xs[i].validator == who) return true;
+        return false;
+    }
+
+    /// Wraps ValidatorConfig.setForNextEpoch so individual tests only specify
+    /// the parameter they want to queue.
+    function _queueValidatorConfig(
+        uint256 newMinBond,
+        uint256 newMaxBond,
+        uint64 newVpLimit
+    ) internal {
+        vm.prank(SystemAddresses.GOVERNANCE);
+        validatorConfig.setForNextEpoch(
+            newMinBond, newMaxBond, UNBONDING, true,
+            newVpLimit, MAX_SET_SIZE, false, 0
+        );
+    }
+
+    function _applyValidatorConfig() internal {
+        vm.prank(SystemAddresses.RECONFIGURATION);
+        validatorConfig.applyPendingConfig();
+    }
+
+    // ========================================================================
+    // Scenario 1 — pending minimumBond change
+    // ========================================================================
+
+    /// STEP A reads minimumBond=OLD, dan (stake=50) passes.
+    /// STEP B reads minimumBond=NEW, dan fails and is reverted to INACTIVE.
+    /// Divergence: dan in DKG target, not in actual epoch set.
+    function test_CONFIRMED_divergence_via_minimumBond() public {
+        _registerAndJoin(alice, 100 ether, "alice");
+        _registerAndJoin(bob,   100 ether, "bob");
+        _registerAndJoin(carol, 100 ether, "carol");
+        _advanceEpoch();
+
+        address pD = _registerAndJoin(dan, 50 ether, "dan");
+
+        // Queue: minimumBond 10 → 60. dan (50) no longer qualifies.
+        _queueValidatorConfig(60 ether, MAX_BOND_DEFAULT, VP_LIMIT_DEFAULT);
+
+        // STEP A — what _startDkgSession reads.
+        ValidatorConsensusInfo[] memory dkgTargets = vm_.getNextValidatorConsensusInfos();
+        assertTrue(_contains(dkgTargets, pD), "STEP A: dan in DKG target (OLD minBond=10)");
+        assertEq(dkgTargets.length, 4, "STEP A: 4 validators targeted");
+
+        // STEP B — what _applyReconfiguration commits.
+        _applyValidatorConfig();
+        _advanceEpoch();
+        ValidatorConsensusInfo[] memory actualSet = vm_.getActiveValidators();
+
+        assertFalse(_contains(actualSet, pD), "STEP B: dan NOT in actual set (NEW minBond=60)");
+        assertEq(uint8(vm_.getValidator(pD).status), uint8(ValidatorStatus.INACTIVE), "dan reverted INACTIVE");
+        assertTrue(dkgTargets.length != actualSet.length, "DKG target and actual epoch set diverged");
+    }
+
+    // ========================================================================
+    // Scenario 2 — pending votingPowerIncreaseLimitPct change
+    // ========================================================================
+
+    /// Governance tightens the VP increase limit AFTER DKG target is computed.
+    /// STEP A reads limit=HIGH, both dan and eve (each 30 ETH) fit under the
+    /// allowed increase (100 * HIGH%).
+    /// STEP B reads limit=LOW, only dan fits; eve is moved to toKeepPending
+    /// and stays in PENDING_ACTIVE rather than activating.
+    /// Divergence: eve in DKG target, not in actual epoch set.
+    function test_CONFIRMED_divergence_via_votingPowerIncreaseLimitPct() public {
+        // Current active total = 300 ETH (alice+bob+carol).
+        _registerAndJoin(alice, 100 ether, "alice");
+        _registerAndJoin(bob,   100 ether, "bob");
+        _registerAndJoin(carol, 100 ether, "carol");
+        _advanceEpoch();
+
+        address pD = _registerAndJoin(dan, 30 ether, "dan");
+        address pE = _registerAndJoin(eve, 30 ether, "eve");
+
+        // Start permissive: VP_LIMIT_HIGH lets both dan+eve in.
+        //   maxIncrease_high = 300 * 50% = 150 → 30 + 30 = 60 < 150 ✓
+        // Queue: VP_LIMIT_LOW = 10 → maxIncrease_low = 30 → only first fits.
+        uint64 VP_LOW = 10;
+        _queueValidatorConfig(MIN_BOND_DEFAULT, MAX_BOND_DEFAULT, VP_LOW);
+
+        // STEP A — HIGH limit still active.
+        ValidatorConsensusInfo[] memory dkgTargets = vm_.getNextValidatorConsensusInfos();
+        assertTrue(_contains(dkgTargets, pD), "STEP A: dan in DKG target");
+        assertTrue(_contains(dkgTargets, pE), "STEP A: eve in DKG target");
+        assertEq(dkgTargets.length, 5, "STEP A: 5 validators targeted");
+
+        // STEP B — LOW limit now active; only one of dan/eve fits.
+        _applyValidatorConfig();
+        _advanceEpoch();
+        ValidatorConsensusInfo[] memory actualSet = vm_.getActiveValidators();
+
+        assertEq(actualSet.length, 4, "STEP B: only 4 validators activated");
+        bool danActive = _contains(actualSet, pD);
+        bool eveActive = _contains(actualSet, pE);
+        assertTrue(danActive != eveActive, "STEP B: exactly one of dan/eve activates");
+
+        // Whichever of dan/eve was held in pending got DKG key shares but no seat.
+        address ghost = danActive ? pE : pD;
+        assertFalse(_contains(actualSet, ghost), "ghost validator not in actual set");
+        assertTrue(_contains(dkgTargets, ghost), "ghost validator WAS in DKG target");
+        assertEq(
+            uint8(vm_.getValidator(ghost).status),
+            uint8(ValidatorStatus.PENDING_ACTIVE),
+            "ghost left in PENDING_ACTIVE by toKeepPending"
+        );
+    }
+
+    // ========================================================================
+    // Scenario 3 — pending maximumBond change
+    // ========================================================================
+
+    /// maximumBond caps each validator's voting power inside
+    /// _getValidatorVotingPower().  Lowering it before DKG but not applying
+    /// until onNewEpoch():
+    ///   - shrinks currentTotal at STEP B relative to STEP A
+    ///   - shrinks maxIncrease at STEP B
+    ///   - changes which pending_active fit
+    /// Concretely: three founders stake way above the new cap; dan's 60 ETH
+    /// pending stake fits under STEP A's maxIncrease but not under STEP B's.
+    function test_CONFIRMED_divergence_via_maximumBond() public {
+        // Founders each stake 1000 ETH → currentTotal_A = 3000 ETH (capped by MAX_BOND_DEFAULT=1000).
+        _registerAndJoin(alice, 1000 ether, "alice");
+        _registerAndJoin(bob,   1000 ether, "bob");
+        _registerAndJoin(carol, 1000 ether, "carol");
+        _advanceEpoch();
+
+        // dan joins with 60 ETH pending.
+        address pD = _registerAndJoin(dan, 60 ether, "dan");
+
+        // Tighten VP_LIMIT so the cap boundary matters (5% of total).
+        // Queue: lower maximumBond 1000 → 100 AND limitPct 50 → 5.
+        //   STEP A caps: currentTotal_A = 3000, limit 50% → maxIncrease_A = 1500 → dan (60) fits trivially.
+        //   STEP B caps: currentTotal_B = min(power,100)*3 = 300, limit 5% → maxIncrease_B = 15
+        //                dan (60) no longer fits.
+        uint64  VP_LOW    = 5;
+        uint256 NEW_MAX_BOND = 100 ether;
+        _queueValidatorConfig(MIN_BOND_DEFAULT, NEW_MAX_BOND, VP_LOW);
+
+        // STEP A — old maximumBond and old limit.
+        ValidatorConsensusInfo[] memory dkgTargets = vm_.getNextValidatorConsensusInfos();
+        assertTrue(_contains(dkgTargets, pD), "STEP A: dan in DKG target");
+        assertEq(dkgTargets.length, 4, "STEP A: 4 validators targeted");
+
+        // STEP B — new maximumBond compresses currentTotal, new limit shrinks maxIncrease.
+        _applyValidatorConfig();
+        _advanceEpoch();
+        ValidatorConsensusInfo[] memory actualSet = vm_.getActiveValidators();
+
+        assertFalse(_contains(actualSet, pD), "STEP B: dan NOT in actual set");
+        assertEq(
+            uint8(vm_.getValidator(pD).status),
+            uint8(ValidatorStatus.PENDING_ACTIVE),
+            "dan kept PENDING_ACTIVE by toKeepPending"
+        );
+        assertTrue(dkgTargets.length != actualSet.length, "DKG target and actual epoch set diverged");
+    }
+}


### PR DESCRIPTION
## Summary

PoC demonstrating that `_startDkgSession()` and `onNewEpoch()` read `ValidatorConfig` at different times across the reconfiguration boundary. If governance queues a pending `ValidatorConfig` change, the DKG target set computed at STEP A diverges from the actual epoch set committed at STEP B. Off-chain DKG key shares end up attributed to a validator committee that never runs the epoch.

**Three independent divergence vectors, one test each, all passing.**

## Flow

```
checkAndStartTransition():
    evictUnderperformingValidators()
    _startDkgSession():
        targets = getNextValidatorConsensusInfos()   // STEP A — CURRENT ValidatorConfig

finishTransition():
    _applyReconfiguration():
        ValidatorConfig.applyPendingConfig()         // config flips here
        onNewEpoch() → _computeNextEpochValidatorSet() // STEP B — NEW ValidatorConfig
```

STEP A and STEP B run the **same** pure function with **different** inputs. Any pending `ValidatorConfig` field that `_computeNextEpochValidatorSet()` reads is a divergence source.

## Scenarios covered

| # | Field | What changes between A and B |
|---|---|---|
| 1 | `minimumBond` | `pending_active` passes/fails the min-bond filter |
| 2 | `votingPowerIncreaseLimitPct` | `pending_active` fits/exceeds the VP cap |
| 3 | `maximumBond` | per-validator cap shifts `currentTotal`, shifting `maxIncrease` |

`autoEvictEnabled` / `autoEvictThreshold` are **not** divergence sources on origin/main — `evictUnderperformingValidators()` is only called once (before DKG) and is not re-run in `_applyReconfiguration()`, so pending eviction-config changes only affect the *next* transition. This is why gravity-audit#112's original scenario as written no longer applies verbatim, but its root cause (pending-config time gap) generalizes to the three fields above.

## Relationship to historical issues and PR #70

- **gravity-audit#112** — closed by us as duplicate of gravity-audit#114. This PoC shows #112 is **not** a duplicate: #114 was about call *order* (evict before DKG), #112 is about *config staleness* (DKG reads old ValidatorConfig, onNewEpoch reads new ValidatorConfig). Fixing #114 does **not** fix #112 — this PoC intentionally omits eviction to isolate the remaining pending-config path and still triggers divergence.
- **gravity-audit#114** — genuinely fixed on origin/main by reordering `evictUnderperformingValidators()` before `_startDkgSession()`. Unchanged by this PoC.
- **PR #70** — proposes `getNextValidatorConsensusInfos() → getActiveValidators()`. This PoC demonstrates why that fix is insufficient **and** regressive:
  - Fails on scenario 1 (minimumBond): `getActiveValidators()` still excludes `PENDING_ACTIVE`, so the new-epoch set still differs from it under the new min bond.
  - Fails on scenarios 2 and 3 (VP limit / max bond): same timing gap, just different input fields.
  - **Introduces a new Critical:** `getActiveValidators()` excludes `PENDING_ACTIVE`, so newly-joining validators activated by `onNewEpoch()` would receive no DKG key shares and participate in consensus without VRF material.

## Remediation options

Three candidate fixes — trade-offs explicitly called out so a design decision can be made before coding.

### Option A — Apply pending ValidatorConfig inside `_startDkgSession()`

Move `ValidatorConfig.applyPendingConfig()` from `_applyReconfiguration()` to the top of `_startDkgSession()`, before reading targets. Remove it from `_applyReconfiguration()`.

```solidity
function _startDkgSession(RandomnessConfig.RandomnessConfigData memory config) internal {
    // NEW: flush pending config so target computation matches what onNewEpoch will commit
    ValidatorConfig(SystemAddresses.VALIDATOR_CONFIG).applyPendingConfig();

    ValidatorConsensusInfo[] memory dealers = ...getCurValidatorConsensusInfos();
    ValidatorConsensusInfo[] memory targets = ...getNextValidatorConsensusInfos();
    ...
}
```

- ✅ Smallest code change; single source of truth for "effective config at target-compute time".
- ⚠️ **Semantic shift**: governance's pending config now takes effect at DKG *start*, not at epoch boundary. Off-chain tooling that assumes "pending until finishTransition" breaks.
- ⚠️ **Non-atomic with the rest of `_applyReconfiguration`**: other configs (Consensus/Execution/etc.) still apply later. If DKG fails and the transition is abandoned, ValidatorConfig is already mutated while the others are not — cross-config invariants can be violated for an arbitrary window.

### Option B — Read-only preview (recommended)

Keep the apply sequence intact. Let `_startDkgSession()` *read* the pending config without applying it, and pass those values through a pure preview variant of `_computeNextEpochValidatorSet()`.

```solidity
// ValidatorConfig already has getPendingConfig(); nothing to add there.

// ValidatorManagement.sol — new pure-read overload
struct NextEpochConfigSnapshot {
    uint256 minimumBond;
    uint256 maximumBond;
    uint64  votingPowerIncreaseLimitPct;
}

function getNextValidatorConsensusInfosWith(NextEpochConfigSnapshot memory cs)
    external view returns (ValidatorConsensusInfo[] memory)
{
    return _computeNextEpochValidatorSetWith(cs).validators;
}

// _computeNextEpochValidatorSetWith is _computeNextEpochValidatorSet refactored
// to take the three config values as parameters instead of reading them from
// ValidatorConfig. The existing _computeNextEpochValidatorSet becomes a thin
// wrapper that reads the live config and delegates.

// Reconfiguration._startDkgSession
(bool hasPending, ValidatorConfig.PendingConfig memory p) =
    ValidatorConfig(SystemAddresses.VALIDATOR_CONFIG).getPendingConfig();

NextEpochConfigSnapshot memory cs = hasPending
    ? NextEpochConfigSnapshot(p.minimumBond, p.maximumBond, p.votingPowerIncreaseLimitPct)
    : NextEpochConfigSnapshot(
        VC.minimumBond(), VC.maximumBond(), VC.votingPowerIncreaseLimitPct()
    );

targets = IValidatorManagement(SystemAddresses.VALIDATOR_MANAGER)
    .getNextValidatorConsensusInfosWith(cs);
```

- ✅ **No semantic shift**: pending config still applies at epoch boundary. Governance UX unchanged.
- ✅ **Atomic**: no state mutation at DKG start. If DKG fails, nothing to roll back.
- ✅ Guarantees STEP A ≡ STEP B by construction (both call `_computeNextEpochValidatorSetWith` with the same snapshot).
- ⚠️ Two call sites must agree on the snapshot. Mitigation: have `onNewEpoch()` also go through `_computeNextEpochValidatorSetWith` using live config values post-apply; `_computeNextEpochValidatorSet` then becomes a pure wrapper over the snapshot form.

### Option C — Verify on finish

Keep everything as-is, but in `finishTransition()`, after `_applyReconfiguration()`, recompute the target set and compare with the set DKG was generated for. On mismatch, revert — chain halts until governance resolves the contradiction.

```solidity
function _startDkgSession(...) internal {
    ...
    _storedDkgTargetHash = _hashValidatorSet(targets);
    IDKG(SystemAddresses.DKG).start(currentEpoch, config, dealers, targets);
    ...
}

function finishTransition(bytes calldata dkgResult) external {
    ...
    _applyReconfiguration();  // commits new config + onNewEpoch
    bytes32 actualHash = _hashValidatorSet(
        IValidatorManagement(SystemAddresses.VALIDATOR_MANAGER).getActiveValidators()
    );
    if (actualHash != _storedDkgTargetHash) revert DkgTargetSetMismatch();
    IDKG(SystemAddresses.DKG).finish(dkgResult);
}
```

- ✅ **Detects every divergence source** — including any we haven't enumerated — as a defensive backstop.
- ⚠️ **Does not prevent divergence**, only aborts the epoch transition on detection. If governance keeps a contradictory pending config queued, the chain stays on the old epoch until the contradiction is resolved (liveness issue).
- Good to pair with Option B as belt-and-suspenders: B prevents the known sources, C catches any new source introduced by future refactors.

### Recommendation

**B + C.** B prevents the known divergence sources at the source. C backstops against future regressions and any we missed. Both preserve the existing `applyPendingConfig` semantics.

## Files

- `test/unit/DkgDivergencePoC.t.sol` (new, test-only)

## Test plan

- [x] `forge test --match-path test/unit/DkgDivergencePoC.t.sol -vv` → 3 passed, 0 failed
- [ ] Reviewer confirms the three scenarios correspond to real governance flows in production
- [ ] Decision on remediation approach (A / B / C / B+C)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
