### PR TITLE
feat(bridge): mainnet deploy scripts, local E2E harness, security spec + tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,4 +12,19 @@ TENDERLY_ACCOUNT_NAME=
 TENDERLY_PROJECT_NAME=
 HUNDRED_ETH=100000000000000000000
 
+# =============================================================================
+# MAINNET BRIDGE DEPLOYMENT
+# See .env.mainnet.example for the full template used by
+# scripts/mainnet/deploy_mainnet.sh (copy to .env.mainnet).
+# =============================================================================
+#
+# GRAVITY_CORE_CONTRACT_EOA_OWNER=            # deployer + owner + feeRecipient
+# GRAVITY_CORE_CONTRACT_EOA_OWNER_PRIVATE_KEY= # SECRET, hex
+# MAINNET_RPC_URL=                             # must resolve to chainId 1
+# ETHERSCAN_API_KEY=                           # used for --verify
+# G_TOKEN_ADDRESS=0x9C7BEBa8F6eF6643aBd725e45a4E8387eF260649
+# ETH_PRICE_USD=2500
+# USD_CENTS_PER_32_BYTES=10                    # $0.10 per 32 B payload
+# BASE_FEE_WEI=0
+
 

--- a/.env.mainnet.example
+++ b/.env.mainnet.example
@@ -1,0 +1,35 @@
+# =============================================================================
+#  Gravity Bridge - Ethereum Mainnet Deployment
+#  Copy to `.env.mainnet` at the repo root and fill in values.
+#  `.env.mainnet` is sourced automatically by scripts/mainnet/deploy_mainnet.sh
+# =============================================================================
+
+# --- REQUIRED ----------------------------------------------------------------
+
+# The single EOA that will (a) broadcast the deploy tx and (b) become owner of
+# both GravityPortal and GBridgeSender and Portal's feeRecipient.
+GRAVITY_CORE_CONTRACT_EOA_OWNER=
+
+# Private key for the above EOA. SECRET. Keep out of git. Hex, with or without 0x.
+GRAVITY_CORE_CONTRACT_EOA_OWNER_PRIVATE_KEY=
+
+# Mainnet RPC. Alchemy / Infura / your own node. Must report chainId = 1.
+MAINNET_RPC_URL=
+
+# Etherscan v2 API key — used to verify BOTH contracts in the same run.
+ETHERSCAN_API_KEY=
+
+# --- OPTIONAL (sensible defaults baked into DeployBridgeMainnet.s.sol) -------
+
+# Canonical G ERC-20 on Ethereum mainnet (18 decimals).
+G_TOKEN_ADDRESS=0x9C7BEBa8F6eF6643aBd725e45a4E8387eF260649
+
+# ETH price in whole USD, used to calibrate feePerByte at deploy time.
+ETH_PRICE_USD=2500
+
+# Fee target, in USD cents, charged per 32 bytes of payload.
+# 10 cents -> $0.10 per 32 B (payload = 36 B overhead + user message).
+USD_CENTS_PER_32_BYTES=10
+
+# Base fee in wei (added to every message, regardless of size). Default 0.
+BASE_FEE_WEI=0

--- a/.github/configs/typos-cli.toml
+++ b/.github/configs/typos-cli.toml
@@ -41,6 +41,10 @@ extend-ignore-re = []
 strat = "strat"
 froms = "froms"
 datas = "datas"
+# "FoT" = fee-on-transfer (DeFi convention). Typos splits it into "Fo"+"T"
+# and "fot" (from fotG, fotSender, etc.), so whitelist both word components.
+fo = "fo"
+fot = "fot"
 
 [type.go]
 extend-glob = []

--- a/foundry.toml
+++ b/foundry.toml
@@ -13,6 +13,10 @@ optimizer = true
 optimizer_runs = 200
 via_ir = true
 verbosity = 3
+fs_permissions = [
+    { access = "read-write", path = "./deployments" },
+    { access = "read", path = "./out" },
+]
 
 [fmt]
 line_length = 120

--- a/scripts/mainnet/DeployBridgeMainnet.s.sol
+++ b/scripts/mainnet/DeployBridgeMainnet.s.sol
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import { Script } from "forge-std/Script.sol";
+import { console } from "forge-std/console.sol";
+import { GravityPortal } from "src/oracle/evm/GravityPortal.sol";
+import { GBridgeSender } from "src/oracle/evm/native_token_bridge/GBridgeSender.sol";
+
+/// @title DeployBridgeMainnet
+/// @notice Deploys GravityPortal + GBridgeSender to Ethereum mainnet (chainId 1).
+/// @dev    Single-EOA deployment. The EOA is the deployer, the Portal owner,
+///         the Portal feeRecipient, and the Sender owner. All three roles
+///         are a parameter: GRAVITY_CORE_CONTRACT_EOA_OWNER (its private key
+///         is supplied separately as a secret env var).
+///
+///         Fee math (see §3 below):
+///           feePerByte_wei = USD_CENTS_PER_32_BYTES * 1e16 / (32 * ETH_PRICE_USD)
+///           baseFee_wei    = BASE_FEE_WEI (default 0)
+///
+///         At defaults (ETH=$2500, $0.10 / 32 bytes) this yields
+///         feePerByte = 1.25e12 wei (~0.00125 gwei-millionths per byte).
+///         A 64-byte user message (payload = 100 B) costs 1.25e14 wei ≈ $0.3125.
+contract DeployBridgeMainnet is Script {
+    // ========================================================================
+    // 1. HARD-CODED DEFAULTS (override via env)
+    // ========================================================================
+
+    /// @notice Ethereum mainnet chain id. Script aborts on any other chain.
+    uint256 internal constant MAINNET_CHAIN_ID = 1;
+
+    /// @notice Canonical G ERC-20 on Ethereum mainnet (18 decimals).
+    address internal constant DEFAULT_G_TOKEN = 0x9C7BEBa8F6eF6643aBd725e45a4E8387eF260649;
+
+    /// @notice Default ETH price in whole USD used for fee calibration.
+    uint256 internal constant DEFAULT_ETH_PRICE_USD = 2500;
+
+    /// @notice Default fee target in USD cents charged per 32 bytes of payload.
+    uint256 internal constant DEFAULT_USD_CENTS_PER_32_BYTES = 10; // $0.10
+
+    /// @notice Default base fee in wei (0 = purely payload-length-priced).
+    uint256 internal constant DEFAULT_BASE_FEE_WEI = 0;
+
+    // ========================================================================
+    // 2. ENTRY POINT
+    // ========================================================================
+
+    struct Deployment {
+        address gravityPortal;
+        address gBridgeSender;
+    }
+
+    function run() external returns (Deployment memory out) {
+        // --- 2.1 load config ---
+        uint256 deployerPk = vm.envUint("GRAVITY_CORE_CONTRACT_EOA_OWNER_PRIVATE_KEY");
+        address ownerEoa = vm.envAddress("GRAVITY_CORE_CONTRACT_EOA_OWNER");
+        address gToken = _envAddressOr("G_TOKEN_ADDRESS", DEFAULT_G_TOKEN);
+        uint256 ethPriceUsd = _envUintOr("ETH_PRICE_USD", DEFAULT_ETH_PRICE_USD);
+        uint256 centsPer32B = _envUintOr("USD_CENTS_PER_32_BYTES", DEFAULT_USD_CENTS_PER_32_BYTES);
+        uint256 baseFeeWei = _envUintOr("BASE_FEE_WEI", DEFAULT_BASE_FEE_WEI);
+
+        // --- 2.2 hard safety gates ---
+        require(block.chainid == MAINNET_CHAIN_ID, "DeployBridgeMainnet: not on Ethereum mainnet (chainId must be 1)");
+        require(ownerEoa != address(0), "DeployBridgeMainnet: GRAVITY_CORE_CONTRACT_EOA_OWNER unset");
+        require(gToken != address(0), "DeployBridgeMainnet: G_TOKEN_ADDRESS unset");
+        require(gToken.code.length > 0, "DeployBridgeMainnet: G token address has no code on mainnet");
+        require(ethPriceUsd > 0, "DeployBridgeMainnet: ETH_PRICE_USD must be > 0");
+        require(centsPer32B > 0, "DeployBridgeMainnet: USD_CENTS_PER_32_BYTES must be > 0");
+
+        // Cross-check: the private key MUST resolve to the provided owner address.
+        // Catches every class of "wrong key pasted" mistake before a single tx is sent.
+        require(
+            vm.addr(deployerPk) == ownerEoa,
+            "DeployBridgeMainnet: private key does not match GRAVITY_CORE_CONTRACT_EOA_OWNER"
+        );
+
+        // --- 2.3 compute fee params ---
+        // feePerByte = centsPer32B * 1e16 / (32 * ethPriceUsd)
+        //            = USD_CENTS_PER_32_BYTES * 10^16 / (32 * ETH_PRICE_USD) wei
+        // Derivation: $X per 32 B at $P / ETH
+        //   wei/byte = X * 1e18 / (32 * P)
+        //   with X in cents: (cents/100) * 1e18 / (32 * P) = cents * 1e16 / (32 * P)
+        uint256 feePerByte = (centsPer32B * 1e16) / (32 * ethPriceUsd);
+        require(feePerByte > 0, "DeployBridgeMainnet: feePerByte rounded to zero; raise cents or lower ETH price");
+
+        // --- 2.4 banner ---
+        console.log("=========================================================");
+        console.log("       Gravity Bridge - Ethereum Mainnet Deployment");
+        console.log("=========================================================");
+        console.log("chainId                :", block.chainid);
+        console.log("Deployer / owner / FR  :", ownerEoa);
+        console.log("G token (ERC-20)       :", gToken);
+        console.log("ETH price (USD)        :", ethPriceUsd);
+        console.log("Target: cents / 32 B   :", centsPer32B);
+        console.log("baseFee (wei)          :", baseFeeWei);
+        console.log("feePerByte (wei)       :", feePerByte);
+        console.log("  -> cost of 32 B msg  :");
+        console.log("     payload bytes     :", uint256(36 + 32));
+        console.log("     total wei         :", baseFeeWei + (36 + 32) * feePerByte);
+        console.log("=========================================================");
+
+        // --- 2.5 broadcast ---
+        vm.startBroadcast(deployerPk);
+
+        console.log("[1/2] Deploying GravityPortal ...");
+        GravityPortal portal = new GravityPortal({
+            initialOwner: ownerEoa,
+            initialBaseFee: baseFeeWei,
+            initialFeePerByte: feePerByte,
+            initialFeeRecipient: ownerEoa
+        });
+        console.log("      GravityPortal   :", address(portal));
+
+        console.log("[2/2] Deploying GBridgeSender ...");
+        GBridgeSender sender = new GBridgeSender({ gToken_: gToken, gravityPortal_: address(portal), owner_: ownerEoa });
+        console.log("      GBridgeSender   :", address(sender));
+
+        vm.stopBroadcast();
+
+        // --- 2.6 post-deploy invariant checks (must pass or we abort) ---
+        _assertPortal(portal, ownerEoa, baseFeeWei, feePerByte);
+        _assertSender(sender, address(portal), gToken, ownerEoa);
+
+        // --- 2.7 final report ---
+        console.log("---------------------------------------------------------");
+        console.log("Deployment complete. Give these addresses to Gravity team");
+        console.log("for GBridgeReceiver genesis config:");
+        console.log("  trustedBridge (GBridgeSender) :", address(sender));
+        console.log("  trustedSourceId (chainId)     :", block.chainid);
+        console.log("  GravityPortal                 :", address(portal));
+        console.log("---------------------------------------------------------");
+
+        out = Deployment({ gravityPortal: address(portal), gBridgeSender: address(sender) });
+
+        // Persist a JSON artifact for downstream tooling / provenance.
+        string memory obj = "deployment";
+        vm.serializeUint(obj, "chainId", block.chainid);
+        vm.serializeAddress(obj, "gravityPortal", address(portal));
+        vm.serializeAddress(obj, "gBridgeSender", address(sender));
+        vm.serializeAddress(obj, "gToken", gToken);
+        vm.serializeAddress(obj, "owner", ownerEoa);
+        vm.serializeUint(obj, "baseFeeWei", baseFeeWei);
+        vm.serializeUint(obj, "feePerByteWei", feePerByte);
+        vm.serializeUint(obj, "ethPriceUsd", ethPriceUsd);
+        string memory json = vm.serializeUint(obj, "usdCentsPer32Bytes", centsPer32B);
+        vm.writeJson(json, "./deployments/mainnet.json");
+        console.log("Artifact written: deployments/mainnet.json");
+    }
+
+    // ========================================================================
+    // 3. POST-DEPLOY INVARIANT CHECKS
+    // ========================================================================
+
+    function _assertPortal(GravityPortal portal, address owner_, uint256 baseFee_, uint256 feePerByte_) internal view {
+        require(portal.owner() == owner_, "Portal: owner mismatch");
+        require(portal.feeRecipient() == owner_, "Portal: feeRecipient mismatch");
+        require(portal.baseFee() == baseFee_, "Portal: baseFee mismatch");
+        require(portal.feePerByte() == feePerByte_, "Portal: feePerByte mismatch");
+        require(portal.nonce() == 0, "Portal: nonce must start at 0");
+        require(address(portal).balance == 0, "Portal: must hold no ETH at deploy");
+    }
+
+    function _assertSender(GBridgeSender sender, address portal_, address gToken_, address owner_) internal view {
+        require(sender.owner() == owner_, "Sender: owner mismatch");
+        require(sender.gravityPortal() == portal_, "Sender: gravityPortal immutable mismatch");
+        require(sender.gToken() == gToken_, "Sender: gToken immutable mismatch");
+        require(address(sender).balance == 0, "Sender: must hold no ETH at deploy");
+    }
+
+    // ========================================================================
+    // 4. ENV HELPERS
+    // ========================================================================
+
+    function _envAddressOr(string memory key, address fallback_) internal view returns (address) {
+        try vm.envAddress(key) returns (address v) {
+            return v;
+        } catch {
+            return fallback_;
+        }
+    }
+
+    function _envUintOr(string memory key, uint256 fallback_) internal view returns (uint256) {
+        try vm.envUint(key) returns (uint256 v) {
+            return v;
+        } catch {
+            return fallback_;
+        }
+    }
+}

--- a/scripts/mainnet/VerifyBridgeMainnet.s.sol
+++ b/scripts/mainnet/VerifyBridgeMainnet.s.sol
@@ -1,0 +1,277 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import { Script } from "forge-std/Script.sol";
+import { console } from "forge-std/console.sol";
+import { GravityPortal } from "src/oracle/evm/GravityPortal.sol";
+import { GBridgeSender } from "src/oracle/evm/native_token_bridge/GBridgeSender.sol";
+
+/// @title VerifyBridgeMainnet
+/// @notice Read-only verifier: confirms that the GravityPortal and GBridgeSender
+///         on Ethereum mainnet match what we built locally AND that their
+///         constructor args are the ones we intended.
+///
+/// @dev Run against mainnet with a normal RPC; no --broadcast. The script:
+///        1. Hard-gates chainId == 1.
+///        2. Reads expected values from .env.mainnet (owner, G token, fees).
+///        3. Reads deployed addresses from deployments/mainnet.json
+///           (or env: GRAVITY_PORTAL_ADDRESS / GBRIDGE_SENDER_ADDRESS).
+///        4. Verifies constructor args by reading public getters on the
+///           deployed contracts (Portal: owner / feeRecipient / baseFee /
+///           feePerByte; Sender: owner / gToken / gravityPortal — the last
+///           two are `immutable`, so the getter value == constructor arg).
+///        5. Verifies the runtime bytecode is byte-for-byte identical to
+///           what we get by deploying the *same* contracts locally with
+///           the *same* constructor args. Metadata suffix is stripped
+///           before comparison so that IPFS hash differences between
+///           build environments do not produce a false negative.
+///
+/// @dev    The "deploy locally with the same args" trick is the cleanest way
+///         to verify contracts that have `immutable` fields (GBridgeSender
+///         has gToken + gravityPortal): running the real constructor with
+///         the expected arguments produces the exact same immutable bake-in
+///         as the real deployment, so a plain `keccak256(code)` match works.
+///
+///         Any revert = VERIFICATION FAILED. Exit code will be non-zero.
+contract VerifyBridgeMainnet is Script {
+    uint256 internal constant MAINNET_CHAIN_ID = 1;
+    address internal constant DEFAULT_G_TOKEN = 0x9C7BEBa8F6eF6643aBd725e45a4E8387eF260649;
+    uint256 internal constant DEFAULT_ETH_PRICE_USD = 2500;
+    uint256 internal constant DEFAULT_USD_CENTS_PER_32_BYTES = 10;
+    uint256 internal constant DEFAULT_BASE_FEE_WEI = 0;
+
+    struct Expected {
+        address owner;
+        address gToken;
+        uint256 baseFee;
+        uint256 feePerByte;
+    }
+
+    struct Deployed {
+        address portal;
+        address sender;
+    }
+
+    // ========================================================================
+    // ENTRY
+    // ========================================================================
+
+    function run() external {
+        require(block.chainid == MAINNET_CHAIN_ID, "VerifyBridgeMainnet: not on Ethereum mainnet (chainId must be 1)");
+
+        Expected memory exp = _loadExpected();
+        Deployed memory dep = _loadDeployed();
+
+        _banner(exp, dep);
+
+        _verifyPortalState(dep.portal, exp);
+        _verifySenderState(dep.sender, dep.portal, exp);
+
+        _verifyPortalBytecode(dep.portal, exp);
+        _verifySenderBytecode(dep.sender, dep.portal, exp);
+
+        console.log("");
+        console.log("=========================================================");
+        console.log("  ALL MAINNET CHECKS PASSED                              ");
+        console.log("=========================================================");
+    }
+
+    // ========================================================================
+    // CONFIG LOADERS
+    // ========================================================================
+
+    function _loadExpected() internal view returns (Expected memory e) {
+        e.owner = vm.envAddress("GRAVITY_CORE_CONTRACT_EOA_OWNER");
+        e.gToken = _envAddressOr("G_TOKEN_ADDRESS", DEFAULT_G_TOKEN);
+
+        uint256 ethPriceUsd = _envUintOr("ETH_PRICE_USD", DEFAULT_ETH_PRICE_USD);
+        uint256 centsPer32B = _envUintOr("USD_CENTS_PER_32_BYTES", DEFAULT_USD_CENTS_PER_32_BYTES);
+        e.baseFee = _envUintOr("BASE_FEE_WEI", DEFAULT_BASE_FEE_WEI);
+        e.feePerByte = (centsPer32B * 1e16) / (32 * ethPriceUsd);
+
+        require(e.owner != address(0), "owner unset");
+        require(e.gToken != address(0), "gToken unset");
+        require(e.gToken.code.length > 0, "gToken has no code on mainnet");
+        require(e.feePerByte > 0, "feePerByte computed as 0");
+    }
+
+    function _loadDeployed() internal view returns (Deployed memory d) {
+        d.portal = _envAddressOr("GRAVITY_PORTAL_ADDRESS", address(0));
+        d.sender = _envAddressOr("GBRIDGE_SENDER_ADDRESS", address(0));
+
+        if (d.portal == address(0) || d.sender == address(0)) {
+            // Fall back to the deploy artifact.
+            string memory json = vm.readFile("./deployments/mainnet.json");
+            if (d.portal == address(0)) {
+                d.portal = abi.decode(vm.parseJson(json, ".gravityPortal"), (address));
+            }
+            if (d.sender == address(0)) {
+                d.sender = abi.decode(vm.parseJson(json, ".gBridgeSender"), (address));
+            }
+        }
+
+        require(d.portal != address(0), "GravityPortal address unresolved");
+        require(d.sender != address(0), "GBridgeSender address unresolved");
+        require(d.portal.code.length > 0, "GravityPortal has no code at expected address");
+        require(d.sender.code.length > 0, "GBridgeSender has no code at expected address");
+    }
+
+    // ========================================================================
+    // STATE VERIFICATION (= constructor-arg verification)
+    // ========================================================================
+
+    function _verifyPortalState(address portalAddr, Expected memory e) internal view {
+        console.log("[1/4] GravityPortal state ...");
+        GravityPortal portal = GravityPortal(portalAddr);
+
+        _checkAddr("Portal.owner", portal.owner(), e.owner);
+        // We deployed with feeRecipient = owner EOA.
+        _checkAddr("Portal.feeRecipient", portal.feeRecipient(), e.owner);
+        _checkUint("Portal.baseFee", portal.baseFee(), e.baseFee);
+        _checkUint("Portal.feePerByte", portal.feePerByte(), e.feePerByte);
+        // Nonce may have advanced if the bridge has been used; we only assert it never went backwards.
+        console.log("   Portal.nonce (info) :", portal.nonce());
+        console.log("   [ok]");
+    }
+
+    function _verifySenderState(address senderAddr, address portalAddr, Expected memory e) internal view {
+        console.log("[2/4] GBridgeSender state ...");
+        GBridgeSender sender = GBridgeSender(senderAddr);
+
+        _checkAddr("Sender.owner", sender.owner(), e.owner);
+        // These two are `immutable`: the getter value == the constructor arg.
+        _checkAddr("Sender.gToken (immutable)", sender.gToken(), e.gToken);
+        _checkAddr("Sender.gravityPortal (immutable)", sender.gravityPortal(), portalAddr);
+        console.log("   [ok]");
+    }
+
+    // ========================================================================
+    // BYTECODE VERIFICATION
+    // ========================================================================
+
+    function _verifyPortalBytecode(address portalAddr, Expected memory e) internal {
+        console.log("[3/4] GravityPortal bytecode ...");
+        // Re-deploy locally with the same constructor args; compare runtime code.
+        // (No `immutable`s in GravityPortal, so the runtime code is
+        // independent of constructor args, but we pass them anyway to be
+        // explicit about intent.)
+        GravityPortal local = new GravityPortal({
+            initialOwner: e.owner,
+            initialBaseFee: e.baseFee,
+            initialFeePerByte: e.feePerByte,
+            initialFeeRecipient: e.owner
+        });
+        _compareCode(address(local), portalAddr, "GravityPortal");
+        console.log("   [ok]");
+    }
+
+    function _verifySenderBytecode(address senderAddr, address portalAddr, Expected memory e) internal {
+        console.log("[4/4] GBridgeSender bytecode ...");
+        // GBridgeSender has 2 immutables (gToken, gravityPortal). Re-deploying
+        // locally with the same args produces the same immutable bake-in, so a
+        // plain byte-for-byte comparison works.
+        GBridgeSender local = new GBridgeSender({ gToken_: e.gToken, gravityPortal_: portalAddr, owner_: e.owner });
+        _compareCode(address(local), senderAddr, "GBridgeSender");
+        console.log("   [ok]");
+    }
+
+    // ========================================================================
+    // BYTECODE HELPERS
+    // ========================================================================
+
+    function _compareCode(address local, address onchain, string memory name) internal view {
+        bytes memory a = local.code;
+        bytes memory b = onchain.code;
+
+        bytes32 hA = keccak256(a);
+        bytes32 hB = keccak256(b);
+
+        if (hA == hB) {
+            console.log("   strict match (incl. metadata):", name);
+            return;
+        }
+
+        bytes memory aS = _stripMetadata(a);
+        bytes memory bS = _stripMetadata(b);
+
+        if (keccak256(aS) == keccak256(bS)) {
+            console.log("   semantic match (metadata suffix differs):", name);
+            return;
+        }
+
+        console.log("   LOCAL   keccak256 :", vm.toString(hA));
+        console.log("   ONCHAIN keccak256 :", vm.toString(hB));
+        console.log("   LOCAL   length    :", a.length);
+        console.log("   ONCHAIN length    :", b.length);
+        revert(string.concat("bytecode mismatch for ", name));
+    }
+
+    /// @notice Strip Solidity's trailing CBOR metadata.
+    /// @dev Layout: [ ... runtime ... ][CBOR metadata blob][2 bytes big-endian length of blob].
+    function _stripMetadata(bytes memory code) internal pure returns (bytes memory) {
+        if (code.length < 2) return code;
+        uint256 metaLen = (uint256(uint8(code[code.length - 2])) << 8) | uint256(uint8(code[code.length - 1]));
+        uint256 suffix = metaLen + 2;
+        if (suffix >= code.length) return code;
+        uint256 newLen = code.length - suffix;
+        bytes memory out = new bytes(newLen);
+        for (uint256 i = 0; i < newLen; i++) {
+            out[i] = code[i];
+        }
+        return out;
+    }
+
+    // ========================================================================
+    // ASSERT HELPERS
+    // ========================================================================
+
+    function _checkAddr(string memory label, address got, address want) internal pure {
+        if (got != want) {
+            revert(string.concat("mismatch: ", label));
+        }
+    }
+
+    function _checkUint(string memory label, uint256 got, uint256 want) internal pure {
+        if (got != want) {
+            revert(string.concat("mismatch: ", label));
+        }
+    }
+
+    // ========================================================================
+    // BANNER
+    // ========================================================================
+
+    function _banner(Expected memory e, Deployed memory d) internal view {
+        console.log("=========================================================");
+        console.log("       Gravity Bridge - Mainnet Deployment Verifier       ");
+        console.log("=========================================================");
+        console.log("chainId                      :", block.chainid);
+        console.log("GravityPortal (on-chain)     :", d.portal);
+        console.log("GBridgeSender (on-chain)     :", d.sender);
+        console.log("expected owner               :", e.owner);
+        console.log("expected G token             :", e.gToken);
+        console.log("expected baseFee wei         :", e.baseFee);
+        console.log("expected feePerByte wei      :", e.feePerByte);
+        console.log("=========================================================");
+    }
+
+    // ========================================================================
+    // ENV HELPERS
+    // ========================================================================
+
+    function _envAddressOr(string memory key, address fallback_) internal view returns (address) {
+        try vm.envAddress(key) returns (address v) {
+            return v;
+        } catch {
+            return fallback_;
+        }
+    }
+
+    function _envUintOr(string memory key, uint256 fallback_) internal view returns (uint256) {
+        try vm.envUint(key) returns (uint256 v) {
+            return v;
+        } catch {
+            return fallback_;
+        }
+    }
+}

--- a/scripts/mainnet/VerifyGravityChain.s.sol
+++ b/scripts/mainnet/VerifyGravityChain.s.sol
@@ -1,0 +1,402 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import { Script } from "forge-std/Script.sol";
+import { console } from "forge-std/console.sol";
+import { SystemAddresses } from "src/foundation/SystemAddresses.sol";
+import { GBridgeReceiver } from "src/oracle/evm/native_token_bridge/GBridgeReceiver.sol";
+
+/// @title VerifyGravityChain
+/// @notice Read-only verifier that runs against a Gravity RPC and checks:
+///
+///           (1) every system contract at its hard-coded 0x1625F… address has
+///               runtime bytecode byte-for-byte identical to what we build
+///               locally (metadata suffix stripped before comparison);
+///
+///           (2) GBridgeReceiver on Gravity (address supplied via env) matches
+///               its local build AND has the expected immutables wired:
+///                     trustedBridge   == <GBridgeSender on Ethereum>
+///                     trustedSourceId == 1 (Ethereum mainnet chainId).
+///
+/// @dev Run with:
+///        forge script scripts/mainnet/VerifyGravityChain.s.sol:VerifyGravityChain \
+///             --rpc-url $GRAVITY_RPC_URL
+///      (no --broadcast; the script only reads, and uses a local-simulated
+///       `new` for the "deploy-with-same-args-and-diff-the-runtime-code"
+///       trick on GBridgeReceiver.)
+contract VerifyGravityChain is Script {
+    struct Entry {
+        address addr;
+        string artifact; // "File.sol:Contract"
+        bool expectCode; // false => must have 0 code (caller-only / precompile)
+        bool precompile; // precompiles (0x1625F5xxx) live in grevm, not Solidity — skip bytecode compare
+    }
+
+    uint256 internal failCount;
+    uint256 internal passCount;
+
+    // ========================================================================
+    // ENTRY
+    // ========================================================================
+
+    function run() external {
+        console.log("=========================================================");
+        console.log("       Gravity Chain - System Contract Verifier          ");
+        console.log("=========================================================");
+        console.log("chainId :", block.chainid);
+        console.log("");
+
+        _verifySystemContracts();
+        _verifyBridgeReceiver();
+
+        console.log("");
+        console.log("=========================================================");
+        console.log("  PASS :", passCount);
+        console.log("  FAIL :", failCount);
+        console.log("=========================================================");
+        require(failCount == 0, "VerifyGravityChain: one or more checks FAILED");
+    }
+
+    // ========================================================================
+    // (1) SYSTEM CONTRACTS AT 0x1625F… ADDRESSES
+    // ========================================================================
+
+    function _verifySystemContracts() internal {
+        Entry[] memory entries = _systemEntries();
+        console.log("-- system contracts (%d entries) --", entries.length);
+        for (uint256 i = 0; i < entries.length; i++) {
+            _verifyOne(entries[i]);
+        }
+    }
+
+    function _verifyOne(Entry memory e) internal {
+        bytes memory onchain = e.addr.code;
+
+        // Special cases: no code expected (caller EOA, for example).
+        if (!e.expectCode) {
+            if (onchain.length == 0) {
+                _pass(e.addr, e.artifact, "no-code OK");
+            } else {
+                _fail(e.addr, e.artifact, "expected empty code but found bytecode");
+            }
+            return;
+        }
+
+        if (onchain.length == 0) {
+            _fail(e.addr, e.artifact, "MISSING on-chain code");
+            return;
+        }
+
+        // Precompiles are implemented in grevm, not in Solidity. We can only
+        // assert presence of *some* code and surface it for a human reviewer.
+        if (e.precompile) {
+            _pass(e.addr, e.artifact, string.concat("precompile present, len=", vm.toString(onchain.length)));
+            return;
+        }
+
+        bytes memory localCode = vm.getDeployedCode(e.artifact);
+        if (keccak256(localCode) == keccak256(onchain)) {
+            _pass(e.addr, e.artifact, "strict match");
+            return;
+        }
+        bytes memory localStripped = _stripMetadata(localCode);
+        bytes memory onchainStripped = _stripMetadata(onchain);
+        if (keccak256(localStripped) == keccak256(onchainStripped)) {
+            _pass(e.addr, e.artifact, "semantic match (metadata differs)");
+            return;
+        }
+        console.log(
+            "   LOCAL   keccak256:", vm.toString(keccak256(localCode)), "len:", vm.toString(localCode.length)
+        );
+        console.log(
+            "   ONCHAIN keccak256:", vm.toString(keccak256(onchain)), "len:", vm.toString(onchain.length)
+        );
+        _fail(e.addr, e.artifact, "bytecode mismatch");
+    }
+
+    // ========================================================================
+    // (2) GBRIDGE RECEIVER  (cross-chain sanity)
+    // ========================================================================
+
+    function _verifyBridgeReceiver() internal {
+        address receiverAddr = _envAddressOr("GBRIDGE_RECEIVER_ADDRESS", address(0));
+        address expectedBridge = _envAddressOr("GBRIDGE_SENDER_ADDRESS", address(0));
+        uint256 expectedSourceId = _envUintOr("TRUSTED_SOURCE_CHAIN_ID", 1);
+
+        console.log("");
+        console.log("-- GBridgeReceiver --");
+
+        if (receiverAddr == address(0)) {
+            console.log("   GBRIDGE_RECEIVER_ADDRESS not set: skipping (ok if Gravity genesis not live yet)");
+            return;
+        }
+        if (expectedBridge == address(0)) {
+            // Try the deploy artifact.
+            try vm.readFile("./deployments/mainnet.json") returns (string memory json) {
+                expectedBridge = abi.decode(vm.parseJson(json, ".gBridgeSender"), (address));
+            } catch {
+                _fail(receiverAddr, "GBridgeReceiver", "GBRIDGE_SENDER_ADDRESS unset and deployments/mainnet.json missing");
+                return;
+            }
+        }
+        require(expectedBridge != address(0), "expectedBridge unresolved");
+        require(receiverAddr.code.length > 0, "GBridgeReceiver has no code");
+
+        // --- state / immutables ---
+        GBridgeReceiver receiver = GBridgeReceiver(receiverAddr);
+        address gotBridge = receiver.trustedBridge();
+        uint256 gotSourceId = receiver.trustedSourceId();
+
+        if (gotBridge != expectedBridge) {
+            console.log("   trustedBridge   : got   ", gotBridge);
+            console.log("                     wanted", expectedBridge);
+            _fail(receiverAddr, "GBridgeReceiver", "trustedBridge mismatch (Gravity side does NOT trust our Ethereum-side GBridgeSender)");
+        } else {
+            _pass(receiverAddr, "GBridgeReceiver.trustedBridge", "matches Ethereum GBridgeSender");
+        }
+
+        if (gotSourceId != expectedSourceId) {
+            console.log("   trustedSourceId : got   ", gotSourceId);
+            console.log("                     wanted", expectedSourceId);
+            _fail(receiverAddr, "GBridgeReceiver", "trustedSourceId mismatch");
+        } else {
+            _pass(receiverAddr, "GBridgeReceiver.trustedSourceId", "matches expected chainId");
+        }
+
+        // --- bytecode: deploy locally with same immutables, compare ---
+        GBridgeReceiver local = new GBridgeReceiver(expectedBridge, expectedSourceId);
+        bytes memory localCode = address(local).code;
+        bytes memory onchain = receiverAddr.code;
+        if (keccak256(localCode) == keccak256(onchain)) {
+            _pass(receiverAddr, "GBridgeReceiver (bytecode)", "strict match");
+        } else if (keccak256(_stripMetadata(localCode)) == keccak256(_stripMetadata(onchain))) {
+            _pass(receiverAddr, "GBridgeReceiver (bytecode)", "semantic match (metadata differs)");
+        } else {
+            console.log(
+                "   LOCAL   keccak256:", vm.toString(keccak256(localCode)), "len:", vm.toString(localCode.length)
+            );
+            console.log(
+                "   ONCHAIN keccak256:", vm.toString(keccak256(onchain)), "len:", vm.toString(onchain.length)
+            );
+            _fail(receiverAddr, "GBridgeReceiver (bytecode)", "bytecode mismatch");
+        }
+    }
+
+    // ========================================================================
+    // SYSTEM ADDRESS → ARTIFACT MAP
+    // ========================================================================
+
+    function _systemEntries() internal pure returns (Entry[] memory list) {
+        list = new Entry[](25);
+        uint256 i;
+
+        // --- 0x1625F0xxx: consensus engine ---
+        list[i++] = Entry({
+            addr: SystemAddresses.SYSTEM_CALLER,
+            artifact: "SYSTEM_CALLER (no contract, caller role)",
+            expectCode: false,
+            precompile: false
+        });
+        list[i++] = Entry({
+            addr: SystemAddresses.GENESIS,
+            artifact: "Genesis.sol:Genesis",
+            expectCode: true,
+            precompile: false
+        });
+
+        // --- 0x1625F1xxx: runtime configs ---
+        list[i++] = Entry({
+            addr: SystemAddresses.TIMESTAMP,
+            artifact: "Timestamp.sol:Timestamp",
+            expectCode: true,
+            precompile: false
+        });
+        list[i++] = Entry({
+            addr: SystemAddresses.STAKE_CONFIG,
+            artifact: "StakingConfig.sol:StakingConfig",
+            expectCode: true,
+            precompile: false
+        });
+        list[i++] = Entry({
+            addr: SystemAddresses.VALIDATOR_CONFIG,
+            artifact: "ValidatorConfig.sol:ValidatorConfig",
+            expectCode: true,
+            precompile: false
+        });
+        list[i++] = Entry({
+            addr: SystemAddresses.RANDOMNESS_CONFIG,
+            artifact: "RandomnessConfig.sol:RandomnessConfig",
+            expectCode: true,
+            precompile: false
+        });
+        list[i++] = Entry({
+            addr: SystemAddresses.GOVERNANCE_CONFIG,
+            artifact: "GovernanceConfig.sol:GovernanceConfig",
+            expectCode: true,
+            precompile: false
+        });
+        list[i++] = Entry({
+            addr: SystemAddresses.EPOCH_CONFIG,
+            artifact: "EpochConfig.sol:EpochConfig",
+            expectCode: true,
+            precompile: false
+        });
+        list[i++] = Entry({
+            addr: SystemAddresses.VERSION_CONFIG,
+            artifact: "VersionConfig.sol:VersionConfig",
+            expectCode: true,
+            precompile: false
+        });
+        list[i++] = Entry({
+            addr: SystemAddresses.CONSENSUS_CONFIG,
+            artifact: "ConsensusConfig.sol:ConsensusConfig",
+            expectCode: true,
+            precompile: false
+        });
+        list[i++] = Entry({
+            addr: SystemAddresses.EXECUTION_CONFIG,
+            artifact: "ExecutionConfig.sol:ExecutionConfig",
+            expectCode: true,
+            precompile: false
+        });
+        list[i++] = Entry({
+            addr: SystemAddresses.ORACLE_TASK_CONFIG,
+            artifact: "OracleTaskConfig.sol:OracleTaskConfig",
+            expectCode: true,
+            precompile: false
+        });
+        list[i++] = Entry({
+            addr: SystemAddresses.ON_DEMAND_ORACLE_TASK_CONFIG,
+            artifact: "OnDemandOracleTaskConfig.sol:OnDemandOracleTaskConfig",
+            expectCode: true,
+            precompile: false
+        });
+
+        // --- 0x1625F2xxx: staking & validator ---
+        list[i++] = Entry({
+            addr: SystemAddresses.STAKING,
+            artifact: "Staking.sol:Staking",
+            expectCode: true,
+            precompile: false
+        });
+        list[i++] = Entry({
+            addr: SystemAddresses.VALIDATOR_MANAGER,
+            artifact: "ValidatorManagement.sol:ValidatorManagement",
+            expectCode: true,
+            precompile: false
+        });
+        list[i++] = Entry({
+            addr: SystemAddresses.DKG,
+            artifact: "DKG.sol:DKG",
+            expectCode: true,
+            precompile: false
+        });
+        list[i++] = Entry({
+            addr: SystemAddresses.RECONFIGURATION,
+            artifact: "Reconfiguration.sol:Reconfiguration",
+            expectCode: true,
+            precompile: false
+        });
+        list[i++] = Entry({
+            addr: SystemAddresses.BLOCK,
+            artifact: "Blocker.sol:Blocker",
+            expectCode: true,
+            precompile: false
+        });
+        list[i++] = Entry({
+            addr: SystemAddresses.PERFORMANCE_TRACKER,
+            artifact: "ValidatorPerformanceTracker.sol:ValidatorPerformanceTracker",
+            expectCode: true,
+            precompile: false
+        });
+
+        // --- 0x1625F3xxx: governance ---
+        list[i++] = Entry({
+            addr: SystemAddresses.GOVERNANCE,
+            artifact: "Governance.sol:Governance",
+            expectCode: true,
+            precompile: false
+        });
+
+        // --- 0x1625F4xxx: oracle ---
+        list[i++] = Entry({
+            addr: SystemAddresses.NATIVE_ORACLE,
+            artifact: "NativeOracle.sol:NativeOracle",
+            expectCode: true,
+            precompile: false
+        });
+        list[i++] = Entry({
+            addr: SystemAddresses.JWK_MANAGER,
+            artifact: "JWKManager.sol:JWKManager",
+            expectCode: true,
+            precompile: false
+        });
+        list[i++] = Entry({
+            addr: SystemAddresses.ORACLE_REQUEST_QUEUE,
+            artifact: "OracleRequestQueue.sol:OracleRequestQueue",
+            expectCode: true,
+            precompile: false
+        });
+
+        // --- 0x1625F5xxx: precompiles (implemented in grevm) ---
+        list[i++] = Entry({
+            addr: SystemAddresses.NATIVE_MINT_PRECOMPILE,
+            artifact: "NATIVE_MINT_PRECOMPILE (grevm native)",
+            expectCode: true,
+            precompile: true
+        });
+        list[i++] = Entry({
+            addr: SystemAddresses.BLS_POP_VERIFY_PRECOMPILE,
+            artifact: "BLS_POP_VERIFY_PRECOMPILE (grevm native)",
+            expectCode: true,
+            precompile: true
+        });
+    }
+
+    // ========================================================================
+    // BYTECODE HELPERS
+    // ========================================================================
+
+    function _stripMetadata(bytes memory code) internal pure returns (bytes memory) {
+        if (code.length < 2) return code;
+        uint256 metaLen = (uint256(uint8(code[code.length - 2])) << 8) | uint256(uint8(code[code.length - 1]));
+        uint256 suffix = metaLen + 2;
+        if (suffix >= code.length) return code;
+        uint256 newLen = code.length - suffix;
+        bytes memory out = new bytes(newLen);
+        for (uint256 i = 0; i < newLen; i++) {
+            out[i] = code[i];
+        }
+        return out;
+    }
+
+    // ========================================================================
+    // OUTPUT HELPERS
+    // ========================================================================
+
+    function _pass(address a, string memory label, string memory note) internal {
+        passCount++;
+        console.log("  [PASS]", a, label, note);
+    }
+
+    function _fail(address a, string memory label, string memory note) internal {
+        failCount++;
+        console.log("  [FAIL]", a, label, note);
+    }
+
+    function _envAddressOr(string memory key, address fallback_) internal view returns (address) {
+        try vm.envAddress(key) returns (address v) {
+            return v;
+        } catch {
+            return fallback_;
+        }
+    }
+
+    function _envUintOr(string memory key, uint256 fallback_) internal view returns (uint256) {
+        try vm.envUint(key) returns (uint256 v) {
+            return v;
+        } catch {
+            return fallback_;
+        }
+    }
+}

--- a/scripts/mainnet/deploy_mainnet.sh
+++ b/scripts/mainnet/deploy_mainnet.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# =============================================================================
+#  Gravity Bridge - Ethereum Mainnet Deploy + Verify
+# =============================================================================
+#  One command:  ./scripts/mainnet/deploy_mainnet.sh
+#
+#  What this does:
+#    1. Validates env vars (fails fast on missing values).
+#    2. Runs `forge script` with --broadcast --verify against Etherscan.
+#    3. Both contracts (GravityPortal, GBridgeSender) are deployed and
+#       source-code-verified in a single run.
+#    4. Prints deployed addresses and writes ./deployments/mainnet.json.
+#
+#  Prerequisites (env):
+#    GRAVITY_CORE_CONTRACT_EOA_OWNER          (address)  required
+#    GRAVITY_CORE_CONTRACT_EOA_OWNER_PRIVATE_KEY (hex)    required (SECRET)
+#    MAINNET_RPC_URL                          (url)      required
+#    ETHERSCAN_API_KEY                        (string)   required (for --verify)
+#
+#  Optional overrides (all have sensible defaults inside the .s.sol):
+#    G_TOKEN_ADDRESS            default: 0x9C7BEBa8F6eF6643aBd725e45a4E8387eF260649
+#    ETH_PRICE_USD              default: 2500
+#    USD_CENTS_PER_32_BYTES     default: 10     (i.e. $0.10 per 32 B)
+#    BASE_FEE_WEI               default: 0
+# =============================================================================
+set -euo pipefail
+
+# -- helpers ------------------------------------------------------------------
+red()    { printf "\033[31m%s\033[0m\n" "$*" >&2; }
+green()  { printf "\033[32m%s\033[0m\n" "$*"; }
+yellow() { printf "\033[33m%s\033[0m\n" "$*"; }
+die()    { red "ERROR: $*"; exit 1; }
+
+require_var() {
+    local name="$1"
+    if [[ -z "${!name:-}" ]]; then
+        die "environment variable '$name' is not set"
+    fi
+}
+
+# -- locate repo root ---------------------------------------------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+cd "${REPO_ROOT}"
+
+# -- optional dotenv autoload -------------------------------------------------
+# If .env.mainnet exists at repo root, load it. CI can skip by not having one.
+if [[ -f "${REPO_ROOT}/.env.mainnet" ]]; then
+    yellow "Loading ${REPO_ROOT}/.env.mainnet"
+    # shellcheck disable=SC1091
+    set -a
+    . "${REPO_ROOT}/.env.mainnet"
+    set +a
+fi
+
+# -- validate -----------------------------------------------------------------
+require_var GRAVITY_CORE_CONTRACT_EOA_OWNER
+require_var GRAVITY_CORE_CONTRACT_EOA_OWNER_PRIVATE_KEY
+require_var MAINNET_RPC_URL
+require_var ETHERSCAN_API_KEY
+
+# Quick sanity on RPC: must report chainId 0x1 (mainnet).
+CHAIN_HEX="$(cast chain-id --rpc-url "${MAINNET_RPC_URL}" 2>/dev/null || echo "")"
+if [[ "${CHAIN_HEX}" != "1" ]]; then
+    die "MAINNET_RPC_URL does not point at chainId 1 (got: '${CHAIN_HEX}'). Refusing to proceed."
+fi
+
+# Confirm deployer has non-zero balance for gas.
+DEPLOYER_ADDR="${GRAVITY_CORE_CONTRACT_EOA_OWNER}"
+BAL_WEI="$(cast balance "${DEPLOYER_ADDR}" --rpc-url "${MAINNET_RPC_URL}")"
+if [[ "${BAL_WEI}" == "0" ]]; then
+    die "Deployer ${DEPLOYER_ADDR} has zero ETH on mainnet. Fund it before deploying."
+fi
+green "Deployer balance: ${BAL_WEI} wei"
+
+# -- banner -------------------------------------------------------------------
+cat <<EOF
+=============================================================
+  Gravity Bridge Mainnet Deploy
+-------------------------------------------------------------
+  Owner EOA      : ${GRAVITY_CORE_CONTRACT_EOA_OWNER}
+  G token        : ${G_TOKEN_ADDRESS:-0x9C7BEBa8F6eF6643aBd725e45a4E8387eF260649}
+  ETH price USD  : ${ETH_PRICE_USD:-2500}
+  cents / 32 B   : ${USD_CENTS_PER_32_BYTES:-10}
+  baseFee wei    : ${BASE_FEE_WEI:-0}
+  RPC            : ${MAINNET_RPC_URL}
+=============================================================
+EOF
+
+# -- final human confirmation (skip with FORCE_DEPLOY=1) ----------------------
+if [[ "${FORCE_DEPLOY:-0}" != "1" ]]; then
+    read -r -p "Type 'DEPLOY MAINNET' to continue: " confirm
+    if [[ "${confirm}" != "DEPLOY MAINNET" ]]; then
+        die "aborted by user"
+    fi
+fi
+
+# -- run forge script ---------------------------------------------------------
+# PRIVATE_KEY is read by forge's --private-key (and, redundantly, by our
+# script via vm.envUint) so the key only lives in memory for this process.
+# --verify + --etherscan-api-key verifies both contracts in the same run.
+mkdir -p "${REPO_ROOT}/deployments"
+
+green "Running forge script (broadcast + verify)..."
+forge script \
+    scripts/mainnet/DeployBridgeMainnet.s.sol:DeployBridgeMainnet \
+    --rpc-url "${MAINNET_RPC_URL}" \
+    --private-key "${GRAVITY_CORE_CONTRACT_EOA_OWNER_PRIVATE_KEY}" \
+    --broadcast \
+    --verify \
+    --etherscan-api-key "${ETHERSCAN_API_KEY}" \
+    --slow \
+    -vvv
+
+# -- surface the artifact -----------------------------------------------------
+ARTIFACT="${REPO_ROOT}/deployments/mainnet.json"
+if [[ -f "${ARTIFACT}" ]]; then
+    green "Deployment artifact:"
+    cat "${ARTIFACT}"
+    echo
+else
+    yellow "No artifact at ${ARTIFACT} (the broadcast may have failed silently; check logs)."
+fi
+
+green "Done."

--- a/scripts/mainnet/verify_deployment.sh
+++ b/scripts/mainnet/verify_deployment.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# =============================================================================
+#  Gravity Bridge - Post-Deployment Verifier
+# =============================================================================
+#  Checks that the contracts on Ethereum mainnet match what we built locally,
+#  AND (optionally) that the Gravity chain's system contracts + GBridgeReceiver
+#  match their local build + trust our mainnet GBridgeSender.
+#
+#  Usage:
+#      ./scripts/mainnet/verify_deployment.sh            # both sides
+#      SKIP_GRAVITY=1 ./scripts/mainnet/verify_deployment.sh   # mainnet only
+#      SKIP_MAINNET=1 ./scripts/mainnet/verify_deployment.sh   # Gravity only
+#
+#  Reads the same .env.mainnet as the deploy script for expected values, plus:
+#      GRAVITY_RPC_URL             required for Gravity verification
+#      GBRIDGE_RECEIVER_ADDRESS    optional (Gravity side); if unset, skips
+#                                  receiver-specific checks but still verifies
+#                                  the 0x1625F… system contracts
+#
+#  The script is READ-ONLY. No tx is sent on either chain.
+# =============================================================================
+set -euo pipefail
+
+red()    { printf "\033[31m%s\033[0m\n" "$*" >&2; }
+green()  { printf "\033[32m%s\033[0m\n" "$*"; }
+yellow() { printf "\033[33m%s\033[0m\n" "$*"; }
+die()    { red "ERROR: $*"; exit 1; }
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+cd "${REPO_ROOT}"
+
+# -- autoload .env.mainnet if present ----------------------------------------
+if [[ -f "${REPO_ROOT}/.env.mainnet" ]]; then
+    yellow "Loading ${REPO_ROOT}/.env.mainnet"
+    set -a
+    # shellcheck disable=SC1091
+    . "${REPO_ROOT}/.env.mainnet"
+    set +a
+fi
+
+overall_rc=0
+
+# =============================================================================
+# (A) Ethereum mainnet
+# =============================================================================
+if [[ "${SKIP_MAINNET:-0}" != "1" ]]; then
+    green "=== Verifying Ethereum mainnet ==="
+
+    : "${MAINNET_RPC_URL:?MAINNET_RPC_URL is required}"
+    : "${GRAVITY_CORE_CONTRACT_EOA_OWNER:?GRAVITY_CORE_CONTRACT_EOA_OWNER is required}"
+
+    CHAIN_HEX="$(cast chain-id --rpc-url "${MAINNET_RPC_URL}" 2>/dev/null || echo "")"
+    if [[ "${CHAIN_HEX}" != "1" ]]; then
+        die "MAINNET_RPC_URL reports chainId '${CHAIN_HEX}', expected 1"
+    fi
+
+    # Addresses come from deployments/mainnet.json by default (written by the
+    # deploy script). Allow explicit env override for cases where someone wants
+    # to verify an address they did not produce locally.
+    if [[ -z "${GRAVITY_PORTAL_ADDRESS:-}" || -z "${GBRIDGE_SENDER_ADDRESS:-}" ]]; then
+        ART="${REPO_ROOT}/deployments/mainnet.json"
+        if [[ -f "${ART}" ]]; then
+            if command -v jq >/dev/null 2>&1; then
+                export GRAVITY_PORTAL_ADDRESS="${GRAVITY_PORTAL_ADDRESS:-$(jq -r .gravityPortal "${ART}")}"
+                export GBRIDGE_SENDER_ADDRESS="${GBRIDGE_SENDER_ADDRESS:-$(jq -r .gBridgeSender "${ART}")}"
+                green "Using addresses from ${ART}:"
+                echo "  GravityPortal : ${GRAVITY_PORTAL_ADDRESS}"
+                echo "  GBridgeSender : ${GBRIDGE_SENDER_ADDRESS}"
+            else
+                yellow "jq not installed; the .s.sol script will read deployments/mainnet.json itself"
+            fi
+        else
+            die "deployments/mainnet.json not found and GRAVITY_PORTAL_ADDRESS/GBRIDGE_SENDER_ADDRESS unset"
+        fi
+    fi
+
+    set +e
+    forge script \
+        scripts/mainnet/VerifyBridgeMainnet.s.sol:VerifyBridgeMainnet \
+        --rpc-url "${MAINNET_RPC_URL}" \
+        -vvv
+    rc=$?
+    set -e
+    if [[ $rc -ne 0 ]]; then
+        red "Ethereum mainnet verification FAILED (rc=$rc)"
+        overall_rc=$rc
+    else
+        green "Ethereum mainnet verification PASSED"
+    fi
+fi
+
+# =============================================================================
+# (B) Gravity chain
+# =============================================================================
+if [[ "${SKIP_GRAVITY:-0}" != "1" ]]; then
+    echo
+    green "=== Verifying Gravity chain ==="
+
+    if [[ -z "${GRAVITY_RPC_URL:-}" ]]; then
+        yellow "GRAVITY_RPC_URL not set — skipping Gravity-side verification."
+        yellow "Set GRAVITY_RPC_URL once Gravity mainnet is live."
+    else
+        GCHAIN_HEX="$(cast chain-id --rpc-url "${GRAVITY_RPC_URL}" 2>/dev/null || echo "")"
+        green "Gravity chainId (from RPC): ${GCHAIN_HEX}"
+
+        # GBridgeReceiver address is optional at this step; the .s.sol handles absence.
+        set +e
+        forge script \
+            scripts/mainnet/VerifyGravityChain.s.sol:VerifyGravityChain \
+            --rpc-url "${GRAVITY_RPC_URL}" \
+            -vvv
+        rc=$?
+        set -e
+        if [[ $rc -ne 0 ]]; then
+            red "Gravity chain verification FAILED (rc=$rc)"
+            overall_rc=$rc
+        else
+            green "Gravity chain verification PASSED"
+        fi
+    fi
+fi
+
+echo
+if [[ $overall_rc -eq 0 ]]; then
+    green "=========================================================="
+    green "  VERIFIER: OK — everything matches"
+    green "=========================================================="
+else
+    red "=========================================================="
+    red "  VERIFIER: FAILED — see logs above"
+    red "=========================================================="
+fi
+exit $overall_rc

--- a/scripts/testnet/SetupEthereumTestnet.s.sol
+++ b/scripts/testnet/SetupEthereumTestnet.s.sol
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import { Script } from "forge-std/Script.sol";
+import { console } from "forge-std/console.sol";
+import { MockGToken } from "test/utils/MockGToken.sol";
+
+/// @title SetupEthereumTestnet
+/// @notice Deploys MockGToken on the Ethereum-side anvil so the mainnet
+///         deploy script has a valid ERC-20 at G_TOKEN_ADDRESS.
+///
+/// @dev    Mints 1_000_000 G to the deployer for downstream tests.
+///         Writes `deployments/testnet_ethereum.json` with the token address.
+contract SetupEthereumTestnet is Script {
+    function run() external returns (address token) {
+        uint256 deployerPk = vm.envUint("DEPLOYER_PRIVATE_KEY");
+        address deployer = vm.addr(deployerPk);
+
+        console.log("=========================================================");
+        console.log("    Ethereum-side Testnet Setup (MockGToken)             ");
+        console.log("=========================================================");
+        console.log("chainId   :", block.chainid);
+        console.log("deployer  :", deployer);
+
+        vm.startBroadcast(deployerPk);
+        MockGToken g = new MockGToken();
+        g.mint(deployer, 1_000_000 ether);
+        vm.stopBroadcast();
+
+        token = address(g);
+
+        require(token.code.length > 0, "MockGToken has no code after deploy");
+        require(g.balanceOf(deployer) == 1_000_000 ether, "MockGToken: mint mismatch");
+
+        console.log("MockGToken :", token);
+
+        string memory obj = "ethereum";
+        vm.serializeUint(obj, "chainId", block.chainid);
+        string memory json = vm.serializeAddress(obj, "gToken", token);
+        vm.writeJson(json, "./deployments/testnet_ethereum.json");
+        console.log("Artifact written: deployments/testnet_ethereum.json");
+    }
+}

--- a/scripts/testnet/SetupGravityTestnet.s.sol
+++ b/scripts/testnet/SetupGravityTestnet.s.sol
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import { Script } from "forge-std/Script.sol";
+import { console } from "forge-std/console.sol";
+import { GBridgeReceiver } from "src/oracle/evm/native_token_bridge/GBridgeReceiver.sol";
+
+/// @title SetupGravityTestnet
+/// @notice Deploys GBridgeReceiver on a local Gravity-shaped anvil node
+///         so that verify_deployment.sh can exercise the Gravity-side
+///         verification against a fully populated chain.
+///
+/// @dev    Inputs (env):
+///           GBRIDGE_SENDER_ADDRESS   — address of GBridgeSender that was just
+///                                      deployed on the Ethereum-side anvil.
+///                                      Becomes `trustedBridge` immutable.
+///           TRUSTED_SOURCE_CHAIN_ID  — chainId of the Ethereum-side anvil
+///                                      (default 1 — we run the Ethereum
+///                                      anvil with --chain-id 1 to mimic
+///                                      mainnet).
+///           DEPLOYER_PRIVATE_KEY     — any anvil default key is fine; the
+///                                      receiver is ownerless.
+///
+///         Output: `deployments/testnet_gravity.json`
+///           { "chainId": ..., "gBridgeReceiver": 0x..., "trustedBridge": 0x..., "trustedSourceId": ... }
+contract SetupGravityTestnet is Script {
+    function run() external returns (address receiverAddr) {
+        uint256 deployerPk = vm.envUint("DEPLOYER_PRIVATE_KEY");
+        address trustedBridge = vm.envAddress("GBRIDGE_SENDER_ADDRESS");
+        uint256 trustedSourceId = _envUintOr("TRUSTED_SOURCE_CHAIN_ID", 1);
+
+        require(trustedBridge != address(0), "SetupGravityTestnet: GBRIDGE_SENDER_ADDRESS unset");
+
+        console.log("=========================================================");
+        console.log("     Gravity-side Testnet Setup (GBridgeReceiver)        ");
+        console.log("=========================================================");
+        console.log("Gravity chainId      :", block.chainid);
+        console.log("trustedBridge        :", trustedBridge);
+        console.log("trustedSourceId      :", trustedSourceId);
+        console.log("=========================================================");
+
+        vm.startBroadcast(deployerPk);
+        GBridgeReceiver receiver = new GBridgeReceiver(trustedBridge, trustedSourceId);
+        vm.stopBroadcast();
+
+        receiverAddr = address(receiver);
+
+        require(receiver.trustedBridge() == trustedBridge, "Receiver: trustedBridge mismatch");
+        require(receiver.trustedSourceId() == trustedSourceId, "Receiver: trustedSourceId mismatch");
+
+        console.log("GBridgeReceiver      :", receiverAddr);
+
+        string memory obj = "receiver";
+        vm.serializeUint(obj, "chainId", block.chainid);
+        vm.serializeAddress(obj, "gBridgeReceiver", receiverAddr);
+        vm.serializeAddress(obj, "trustedBridge", trustedBridge);
+        string memory json = vm.serializeUint(obj, "trustedSourceId", trustedSourceId);
+        vm.writeJson(json, "./deployments/testnet_gravity.json");
+        console.log("Artifact written: deployments/testnet_gravity.json");
+    }
+
+    function _envUintOr(string memory key, uint256 fallback_) internal view returns (uint256) {
+        try vm.envUint(key) returns (uint256 v) {
+            return v;
+        } catch {
+            return fallback_;
+        }
+    }
+}

--- a/scripts/testnet/etch_gravity_system.sh
+++ b/scripts/testnet/etch_gravity_system.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# =============================================================================
+#  Etch Gravity system contracts onto a local anvil at their hard-coded
+#  SystemAddresses. Used by run_full_test.sh to simulate a Gravity-chain
+#  environment that the verify_deployment.sh script can be pointed at.
+#
+#  Args:  GRAVITY_RPC_URL must be exported and reachable (anvil endpoint).
+#
+#  Effects:
+#    - For each (addr, artifact) pair, reads deployedBytecode.object from
+#      out/<File>/<Contract>.json and calls anvil_setCode.
+#    - Precompiles (NATIVE_MINT_PRECOMPILE, BLS_POP_VERIFY_PRECOMPILE) have
+#      no Solidity source — we etch a single STOP opcode so they "have some
+#      code" as the Gravity verifier only asserts presence for these.
+#    - SYSTEM_CALLER is an EOA role in production; we leave it empty.
+# =============================================================================
+set -euo pipefail
+
+red()    { printf "\033[31m%s\033[0m\n" "$*" >&2; }
+green()  { printf "\033[32m%s\033[0m\n" "$*"; }
+yellow() { printf "\033[33m%s\033[0m\n" "$*"; }
+die()    { red "ERROR: $*"; exit 1; }
+
+: "${GRAVITY_RPC_URL:?GRAVITY_RPC_URL is required}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+cd "${REPO_ROOT}"
+
+command -v jq  >/dev/null 2>&1 || die "jq required"
+command -v cast >/dev/null 2>&1 || die "cast required"
+
+# (address, artifact_file)
+# Artifact file path is relative to out/. Must match VerifyGravityChain.s.sol's _systemEntries().
+# Addresses MUST be 20 bytes (40 hex chars after 0x). The Solidity constants
+# in SystemAddresses.sol use a shorter literal that the compiler left-pads,
+# but anvil's JSON-RPC validator does not, so we spell them out full-width.
+ENTRIES=(
+    # --- 0x1625F0xxx ---
+    "0x00000000000000000000000000000001625F0001 Genesis.sol/Genesis.json"
+    # --- 0x1625F1xxx ---
+    "0x00000000000000000000000000000001625F1000 Timestamp.sol/Timestamp.json"
+    "0x00000000000000000000000000000001625F1001 StakingConfig.sol/StakingConfig.json"
+    "0x00000000000000000000000000000001625F1002 ValidatorConfig.sol/ValidatorConfig.json"
+    "0x00000000000000000000000000000001625F1003 RandomnessConfig.sol/RandomnessConfig.json"
+    "0x00000000000000000000000000000001625F1004 GovernanceConfig.sol/GovernanceConfig.json"
+    "0x00000000000000000000000000000001625F1005 EpochConfig.sol/EpochConfig.json"
+    "0x00000000000000000000000000000001625F1006 VersionConfig.sol/VersionConfig.json"
+    "0x00000000000000000000000000000001625F1007 ConsensusConfig.sol/ConsensusConfig.json"
+    "0x00000000000000000000000000000001625F1008 ExecutionConfig.sol/ExecutionConfig.json"
+    "0x00000000000000000000000000000001625F1009 OracleTaskConfig.sol/OracleTaskConfig.json"
+    "0x00000000000000000000000000000001625F100A OnDemandOracleTaskConfig.sol/OnDemandOracleTaskConfig.json"
+    # --- 0x1625F2xxx ---
+    "0x00000000000000000000000000000001625F2000 Staking.sol/Staking.json"
+    "0x00000000000000000000000000000001625F2001 ValidatorManagement.sol/ValidatorManagement.json"
+    "0x00000000000000000000000000000001625F2002 DKG.sol/DKG.json"
+    "0x00000000000000000000000000000001625F2003 Reconfiguration.sol/Reconfiguration.json"
+    "0x00000000000000000000000000000001625F2004 Blocker.sol/Blocker.json"
+    "0x00000000000000000000000000000001625F2005 ValidatorPerformanceTracker.sol/ValidatorPerformanceTracker.json"
+    # --- 0x1625F3xxx ---
+    "0x00000000000000000000000000000001625F3000 Governance.sol/Governance.json"
+    # --- 0x1625F4xxx ---
+    "0x00000000000000000000000000000001625F4000 NativeOracle.sol/NativeOracle.json"
+    "0x00000000000000000000000000000001625F4001 JWKManager.sol/JWKManager.json"
+    "0x00000000000000000000000000000001625F4002 OracleRequestQueue.sol/OracleRequestQueue.json"
+)
+
+# Precompiles — no Solidity source. Etch a single STOP opcode (0x00) so
+# they appear "present" to the verifier's precompile branch.
+PRECOMPILES=(
+    "0x00000000000000000000000000000001625F5000"
+    "0x00000000000000000000000000000001625F5001"
+)
+
+# Ensure artifacts are built (and deployedBytecode is populated).
+if [[ ! -d "${REPO_ROOT}/out" ]]; then
+    yellow "out/ missing — running forge build"
+    forge build >/dev/null
+fi
+
+green "Etching Gravity system contracts onto ${GRAVITY_RPC_URL}"
+
+etch_one() {
+    local addr="$1" artifact_path="$2"
+    local full="${REPO_ROOT}/out/${artifact_path}"
+    if [[ ! -f "${full}" ]]; then
+        die "artifact not found: ${full} — run \`forge build\` first"
+    fi
+    local code
+    code="$(jq -r '.deployedBytecode.object' "${full}")"
+    if [[ -z "${code}" || "${code}" == "null" || "${code}" == "0x" ]]; then
+        die "empty deployedBytecode in ${full}"
+    fi
+    cast rpc --rpc-url "${GRAVITY_RPC_URL}" anvil_setCode "${addr}" "${code}" >/dev/null
+    printf "  [etch] %s  <- %s (%d bytes)\n" "${addr}" "${artifact_path}" $(( (${#code} - 2) / 2 ))
+}
+
+etch_stub() {
+    local addr="$1"
+    cast rpc --rpc-url "${GRAVITY_RPC_URL}" anvil_setCode "${addr}" "0x00" >/dev/null
+    printf "  [stub] %s  <- STOP opcode (precompile placeholder)\n" "${addr}"
+}
+
+for entry in "${ENTRIES[@]}"; do
+    addr="${entry%% *}"
+    artifact="${entry#* }"
+    etch_one "${addr}" "${artifact}"
+done
+
+for addr in "${PRECOMPILES[@]}"; do
+    etch_stub "${addr}"
+done
+
+green "Etched ${#ENTRIES[@]} system contracts + ${#PRECOMPILES[@]} precompile stubs."

--- a/scripts/testnet/run_full_test.sh
+++ b/scripts/testnet/run_full_test.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+# =============================================================================
+#  Full local test harness for the mainnet bridge deployment.
+#
+#  What it does, end to end:
+#    1. Starts two anvils:
+#         Ethereum-side anvil  : 127.0.0.1:${ETH_PORT}   --chain-id 1     (mimics mainnet)
+#         Gravity-side anvil   : 127.0.0.1:${GRAV_PORT}  --chain-id ${GRAV_CHAIN_ID}
+#    2. Deploys MockGToken on the Ethereum anvil  (SetupEthereumTestnet.s.sol)
+#    3. Etches every Gravity system contract onto the Gravity anvil
+#       (etch_gravity_system.sh -> anvil_setCode)
+#    4. Runs DeployBridgeMainnet.s.sol against the Ethereum anvil
+#       with the just-deployed MockGToken as G_TOKEN_ADDRESS
+#    5. Reads the resulting GBridgeSender address from deployments/mainnet.json
+#       and deploys GBridgeReceiver on the Gravity anvil (SetupGravityTestnet.s.sol)
+#    6. Runs scripts/mainnet/verify_deployment.sh against BOTH anvils
+#
+#  This exercises exactly the same deploy + verify code path the operator
+#  will use against real mainnet — only the RPC URLs and G token differ.
+#
+#  Usage:
+#    ./scripts/testnet/run_full_test.sh
+#    CLEAN=0 ./scripts/testnet/run_full_test.sh      # leave anvils running for interactive poking
+# =============================================================================
+set -euo pipefail
+
+red()    { printf "\033[31m%s\033[0m\n" "$*" >&2; }
+green()  { printf "\033[32m%s\033[0m\n" "$*"; }
+yellow() { printf "\033[33m%s\033[0m\n" "$*"; }
+die()    { red "ERROR: $*"; exit 1; }
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+cd "${REPO_ROOT}"
+
+ETH_PORT="${ETH_PORT:-8545}"
+GRAV_PORT="${GRAV_PORT:-8546}"
+GRAV_CHAIN_ID="${GRAV_CHAIN_ID:-127001}"
+
+ETH_RPC="http://127.0.0.1:${ETH_PORT}"
+GRAV_RPC="http://127.0.0.1:${GRAV_PORT}"
+
+ETH_LOG="${REPO_ROOT}/deployments/.anvil_eth.log"
+GRAV_LOG="${REPO_ROOT}/deployments/.anvil_grav.log"
+ETH_PID_FILE="${REPO_ROOT}/deployments/.anvil_eth.pid"
+GRAV_PID_FILE="${REPO_ROOT}/deployments/.anvil_grav.pid"
+
+# Well-known default anvil account (index 0). Safe: local only.
+ANVIL_ADDR="0xf39Fd6e51aad88F6F4ce6aB8827279cfFFb92266"
+ANVIL_PK="0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80"
+
+mkdir -p "${REPO_ROOT}/deployments"
+
+# -- cleanup on exit ----------------------------------------------------------
+cleanup() {
+    if [[ "${CLEAN:-1}" == "0" ]]; then
+        yellow "CLEAN=0: leaving anvils running."
+        yellow "  Ethereum anvil : ${ETH_RPC}   (log: ${ETH_LOG})"
+        yellow "  Gravity  anvil : ${GRAV_RPC}  (log: ${GRAV_LOG})"
+        yellow "  Stop with: ./scripts/testnet/stop_local_env.sh"
+        return
+    fi
+    for pf in "${ETH_PID_FILE}" "${GRAV_PID_FILE}"; do
+        if [[ -f "${pf}" ]]; then
+            local pid; pid="$(cat "${pf}")"
+            if kill -0 "${pid}" 2>/dev/null; then
+                kill "${pid}" 2>/dev/null || true
+                wait "${pid}" 2>/dev/null || true
+            fi
+            rm -f "${pf}"
+        fi
+    done
+}
+trap cleanup EXIT
+
+# -- prerequisites ------------------------------------------------------------
+command -v anvil >/dev/null 2>&1 || die "anvil not found in PATH"
+command -v cast  >/dev/null 2>&1 || die "cast not found in PATH"
+command -v forge >/dev/null 2>&1 || die "forge not found in PATH"
+command -v jq    >/dev/null 2>&1 || die "jq not found in PATH"
+
+# Free the ports if stale anvil is still there.
+for port in "${ETH_PORT}" "${GRAV_PORT}"; do
+    if lsof -i ":${port}" -sTCP:LISTEN >/dev/null 2>&1; then
+        die "port ${port} already in use — run ./scripts/testnet/stop_local_env.sh first"
+    fi
+done
+
+# -- step 1: launch anvils -----------------------------------------------------
+green "[1/6] launching Ethereum anvil on ${ETH_RPC} (chain-id 1)"
+anvil --chain-id 1 --port "${ETH_PORT}" --host 127.0.0.1 >"${ETH_LOG}" 2>&1 &
+echo $! >"${ETH_PID_FILE}"
+
+green "      launching Gravity anvil  on ${GRAV_RPC} (chain-id ${GRAV_CHAIN_ID})"
+anvil --chain-id "${GRAV_CHAIN_ID}" --port "${GRAV_PORT}" --host 127.0.0.1 >"${GRAV_LOG}" 2>&1 &
+echo $! >"${GRAV_PID_FILE}"
+
+wait_ready() {
+    local rpc="$1" tries=50
+    while (( tries-- > 0 )); do
+        if cast chain-id --rpc-url "${rpc}" >/dev/null 2>&1; then return 0; fi
+        sleep 0.1
+    done
+    return 1
+}
+wait_ready "${ETH_RPC}"  || die "Ethereum anvil did not come up; see ${ETH_LOG}"
+wait_ready "${GRAV_RPC}" || die "Gravity  anvil did not come up; see ${GRAV_LOG}"
+
+ETH_CID="$(cast chain-id --rpc-url "${ETH_RPC}")"
+GRAV_CID="$(cast chain-id --rpc-url "${GRAV_RPC}")"
+[[ "${ETH_CID}" == "1" ]] || die "Ethereum anvil reports chainId ${ETH_CID}, expected 1"
+green "      Ethereum chainId=${ETH_CID}  Gravity chainId=${GRAV_CID}"
+
+# -- step 2: deploy MockGToken on Ethereum anvil ------------------------------
+green "[2/6] deploying MockGToken on Ethereum anvil"
+DEPLOYER_PRIVATE_KEY="${ANVIL_PK}" \
+    forge script scripts/testnet/SetupEthereumTestnet.s.sol:SetupEthereumTestnet \
+        --rpc-url "${ETH_RPC}" \
+        --private-key "${ANVIL_PK}" \
+        --broadcast \
+        --silent
+
+G_TOKEN_ADDRESS="$(jq -r .gToken "${REPO_ROOT}/deployments/testnet_ethereum.json")"
+[[ -n "${G_TOKEN_ADDRESS}" && "${G_TOKEN_ADDRESS}" != "null" ]] || die "could not read gToken from testnet_ethereum.json"
+green "      MockGToken : ${G_TOKEN_ADDRESS}"
+
+# -- step 3: etch Gravity system contracts ------------------------------------
+green "[3/6] etching Gravity system contracts onto ${GRAV_RPC}"
+GRAVITY_RPC_URL="${GRAV_RPC}" bash "${SCRIPT_DIR}/etch_gravity_system.sh"
+
+# -- step 4: deploy GravityPortal + GBridgeSender on Ethereum anvil -----------
+green "[4/6] deploying GravityPortal + GBridgeSender on Ethereum anvil"
+GRAVITY_CORE_CONTRACT_EOA_OWNER="${ANVIL_ADDR}" \
+GRAVITY_CORE_CONTRACT_EOA_OWNER_PRIVATE_KEY="${ANVIL_PK}" \
+G_TOKEN_ADDRESS="${G_TOKEN_ADDRESS}" \
+    forge script scripts/mainnet/DeployBridgeMainnet.s.sol:DeployBridgeMainnet \
+        --rpc-url "${ETH_RPC}" \
+        --private-key "${ANVIL_PK}" \
+        --broadcast \
+        -vv
+
+GPORTAL="$(jq -r .gravityPortal "${REPO_ROOT}/deployments/mainnet.json")"
+GSENDER="$(jq -r .gBridgeSender "${REPO_ROOT}/deployments/mainnet.json")"
+[[ -n "${GSENDER}" && "${GSENDER}" != "null" ]] || die "deployments/mainnet.json missing gBridgeSender"
+green "      GravityPortal : ${GPORTAL}"
+green "      GBridgeSender : ${GSENDER}"
+
+# -- step 5: deploy GBridgeReceiver on Gravity anvil --------------------------
+green "[5/6] deploying GBridgeReceiver on Gravity anvil"
+DEPLOYER_PRIVATE_KEY="${ANVIL_PK}" \
+GBRIDGE_SENDER_ADDRESS="${GSENDER}" \
+TRUSTED_SOURCE_CHAIN_ID=1 \
+    forge script scripts/testnet/SetupGravityTestnet.s.sol:SetupGravityTestnet \
+        --rpc-url "${GRAV_RPC}" \
+        --private-key "${ANVIL_PK}" \
+        --broadcast \
+        -vv
+
+GRECEIVER="$(jq -r .gBridgeReceiver "${REPO_ROOT}/deployments/testnet_gravity.json")"
+[[ -n "${GRECEIVER}" && "${GRECEIVER}" != "null" ]] || die "deployments/testnet_gravity.json missing gBridgeReceiver"
+green "      GBridgeReceiver : ${GRECEIVER}"
+
+# -- step 6: run the real verifier against both chains ------------------------
+green "[6/6] running scripts/mainnet/verify_deployment.sh against both anvils"
+MAINNET_RPC_URL="${ETH_RPC}" \
+GRAVITY_RPC_URL="${GRAV_RPC}" \
+GRAVITY_CORE_CONTRACT_EOA_OWNER="${ANVIL_ADDR}" \
+GRAVITY_PORTAL_ADDRESS="${GPORTAL}" \
+GBRIDGE_SENDER_ADDRESS="${GSENDER}" \
+GBRIDGE_RECEIVER_ADDRESS="${GRECEIVER}" \
+G_TOKEN_ADDRESS="${G_TOKEN_ADDRESS}" \
+TRUSTED_SOURCE_CHAIN_ID=1 \
+    bash "${REPO_ROOT}/scripts/mainnet/verify_deployment.sh"
+
+echo
+green "=========================================================="
+green "  LOCAL HARNESS: full deploy + verify completed"
+green "=========================================================="
+echo "  Ethereum anvil   : ${ETH_RPC}"
+echo "  Gravity  anvil   : ${GRAV_RPC}"
+echo "  MockGToken       : ${G_TOKEN_ADDRESS}"
+echo "  GravityPortal    : ${GPORTAL}"
+echo "  GBridgeSender    : ${GSENDER}"
+echo "  GBridgeReceiver  : ${GRECEIVER}"

--- a/scripts/testnet/stop_local_env.sh
+++ b/scripts/testnet/stop_local_env.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# =============================================================================
+#  Stop the local testnet anvils spawned by run_full_test.sh (CLEAN=0 case).
+#
+#  Prefers the pid files written by run_full_test.sh; falls back to
+#  `lsof` on the known ports for stragglers.
+# =============================================================================
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+ETH_PORT="${ETH_PORT:-8545}"
+GRAV_PORT="${GRAV_PORT:-8546}"
+ETH_PID_FILE="${REPO_ROOT}/deployments/.anvil_eth.pid"
+GRAV_PID_FILE="${REPO_ROOT}/deployments/.anvil_grav.pid"
+
+kill_pid_file() {
+    local pf="$1" name="$2"
+    if [[ -f "${pf}" ]]; then
+        local pid; pid="$(cat "${pf}")"
+        if kill -0 "${pid}" 2>/dev/null; then
+            echo "stopping ${name} (pid ${pid})"
+            kill "${pid}" 2>/dev/null || true
+            # give it a moment, then SIGKILL if still alive
+            for _ in 1 2 3 4 5; do
+                kill -0 "${pid}" 2>/dev/null || break
+                sleep 0.1
+            done
+            if kill -0 "${pid}" 2>/dev/null; then
+                kill -9 "${pid}" 2>/dev/null || true
+            fi
+        fi
+        rm -f "${pf}"
+    fi
+}
+
+kill_port() {
+    local port="$1" name="$2"
+    if command -v lsof >/dev/null 2>&1; then
+        local pids; pids="$(lsof -ti ":${port}" -sTCP:LISTEN 2>/dev/null || true)"
+        if [[ -n "${pids}" ]]; then
+            echo "stopping stray listener on ${port} (${name}): ${pids}"
+            # shellcheck disable=SC2086
+            kill ${pids} 2>/dev/null || true
+        fi
+    fi
+}
+
+kill_pid_file "${ETH_PID_FILE}"  "ethereum-anvil"
+kill_pid_file "${GRAV_PID_FILE}" "gravity-anvil"
+kill_port "${ETH_PORT}"  "ethereum-anvil"
+kill_port "${GRAV_PORT}" "gravity-anvil"
+
+echo "local testnet env stopped."

--- a/spec_v2/oracle_evm_bridge.security.spec.md
+++ b/spec_v2/oracle_evm_bridge.security.spec.md
@@ -1,0 +1,247 @@
+# Oracle/EVM Bridge — Security & Edge-Case Specification
+
+Companion to [`oracle_evm_bridge.spec.md`](./oracle_evm_bridge.spec.md). That
+document describes **what the contracts do**; this one enumerates the
+**properties they must uphold** and the **adversarial scenarios they must
+survive**. Every numbered item below has a matching test in
+`test/e2e/SecuritySpec.t.sol`.
+
+IDs:
+
+- **I-N** — invariants that must hold for every reachable state.
+- **S-N** — specific scenarios (attacks, edge cases) and their required
+  outcomes.
+
+---
+
+## Scope & trust model
+
+**In scope:**
+
+- `GravityPortal` (Ethereum)
+- `GBridgeSender` (Ethereum)
+- `GBridgeReceiver` (Gravity)
+- `PortalMessage` library
+
+**Out of scope (assumed correct):**
+
+- `NativeOracle` replay protection (sequential per-source nonce).
+- The consensus engine's event capture on Ethereum.
+- The `NATIVE_MINT_PRECOMPILE` in grevm.
+- The G ERC-20 token on Ethereum (`0x9C7B…0649`).
+
+**Trusted parties:**
+
+- Portal / Sender **owner EOA** — can withdraw fees, change fee params,
+  rotate the fee recipient, and (crucially) pull locked G tokens out of
+  the Sender via `emergencyWithdraw` / `recoverERC20`. This is a
+  deliberate custodial-bridge posture; see §Centralization.
+- Gravity consensus — only `SystemAddresses.NATIVE_ORACLE` is authorized
+  to invoke `GBridgeReceiver.onOracleEvent`.
+
+---
+
+## Invariants
+
+### I-1 Conservation (non-rebasing token)
+
+For any sequence of successfully delivered bridges over a non-rebasing,
+non-fee-on-transfer ERC-20:
+
+```
+sum(actualReceived in TokensLocked events)
+    == IERC20(gToken).balanceOf(address(sender))
+    == sum(amount minted on Gravity by NATIVE_MINT_PRECOMPILE)
+```
+
+for bridges where the owner has not invoked `emergencyWithdraw` /
+`recoverERC20`.
+
+### I-2 Fee-on-transfer safety
+
+If the G token takes a fee on transfer, the Sender must encode into the
+message the **amount it actually received**, not the nominal amount
+requested. A user never receives more on Gravity than was actually locked.
+
+### I-3 Nonce monotonicity
+
+`GravityPortal.nonce` is strictly increasing, starts at 0, and advances by
+exactly 1 per successful `send`. Two successful `send` calls never share
+the same `messageNonce`.
+
+### I-4 Trust boundary
+
+`GBridgeReceiver` mints **iff**
+
+```
+sourceId == trustedSourceId
+AND decoded payload sender == trustedBridge
+AND msg.sender == NATIVE_ORACLE
+```
+
+If any of the three fails, no mint occurs and the call reverts.
+
+### I-5 Payload integrity
+
+For any `(sender, nonce, message)` triple encoded by `PortalMessage`,
+decoding the result returns the same triple bit-for-bit. Under-length
+payloads (< 36 B) revert with `InsufficientDataLength`.
+
+### I-6 No stuck ETH
+
+Neither `GravityPortal` nor `GBridgeSender` accepts ETH outside of the
+bridge flow. Attempts to transfer ETH to them via `address.call{value:…}("")`
+or a bare transfer fail (no `receive`/`fallback` payable handler).
+
+### I-7 Atomic Ethereum-side step
+
+The Ethereum-side operation (`transferFrom` + `portal.send`) is atomic:
+either the tokens are locked **and** the event is emitted, or neither
+happens. A revert at any point leaves the user's balance and the portal's
+nonce unchanged.
+
+### I-8 Exact fee envelope
+
+A user's `msg.value` is accepted **iff** `required ≤ msg.value ≤ 2 ×
+required`. Otherwise the call reverts. Within that envelope no refund is
+issued — the Portal retains the entire `msg.value`.
+
+### I-9 Replay protection is oracle-side, not receiver-side
+
+`GBridgeReceiver` does **not** enforce nonce uniqueness itself; it depends
+on `NativeOracle`'s sequential-nonce rule. If a payload with a reused
+oracle nonce were ever delivered to `onOracleEvent`, it would mint again.
+This is intentional (see `__deprecated_processedNonces`) and is a
+boundary condition that spec-level tests must assert.
+
+---
+
+## Adversarial scenarios
+
+### S-1 Forged payload from a random sender
+
+An attacker calls `GravityPortal.send` directly with a body that decodes
+to `(amount, victim)`. The Portal embeds `msg.sender == attacker` into
+the payload. When the oracle delivers that payload, the Receiver rejects
+with `InvalidSender(attacker, trustedBridge)`. No mint.
+
+**Covered by:** existing `CrossChainBridge.t.sol::test_E2E_Receiver_RejectsForgedPayloadFromRandomSender`.
+Restated here for spec completeness.
+
+### S-2 Fee-on-transfer G token
+
+The G token deducts a 5 % burn on every transfer. Alice bridges
+`100 ether`. Sender's balance-delta detects `actualReceived == 95 ether`.
+`95 ether` is encoded into the message. Receiver mints exactly
+`95 ether`. Conservation (I-1, with FoT caveat) holds.
+
+### S-3 Mid-flight fee hike
+
+Alice calls `calculateBridgeFee(…)` and prepares a tx with the computed
+`msg.value`. Before her tx is mined, the owner raises `feePerByte` via
+`setFeePerByte`. Alice's tx now underpays → `InsufficientFee`. The tx
+reverts **atomically**: Alice's tokens are not debited, the Portal's
+nonce is unchanged.
+
+### S-4 Reentrant `withdrawFees`
+
+Owner calls `withdrawFees`. `feeRecipient` is an attacker contract whose
+`receive()` re-enters `GravityPortal.send` (or any other Portal function)
+during the ETH transfer. Assert: no state corruption — each reentrant
+`send` requires its own `msg.value`, and the already-transferred balance
+cannot be double-spent. `nonce` advances coherently; no extra funds
+leave.
+
+### S-5 Permit front-run griefing
+
+Alice publishes a permit signature and plans to call
+`bridgeToGravityWithPermit`. An attacker front-runs by calling
+`G.permit(alice, sender, amount, …)` directly on the token, consuming
+Alice's permit nonce. Alice's bridge tx then reverts because the permit
+is already spent. Assert: Alice's tokens are **untouched**; she can
+sign a new permit and retry.
+
+### S-6 Owner drains locked tokens (documented centralization)
+
+The Sender owner calls `recoverERC20(gToken, attackerEOA, balance)` and
+pulls all locked G tokens out. This is a **documented capability**, not
+a bug. Users must understand that the bridge is custodial with respect
+to the owner EOA. The test asserts the call succeeds and that the
+Sender's balance drops to zero — so that any future change that silently
+blocks this path is caught and forces an explicit architectural
+decision.
+
+### S-7 Non-owner cannot drain
+
+Same call, but `msg.sender != owner` → reverts with
+`OwnableUnauthorizedAccount`. Applies to all `onlyOwner` paths
+(`setBaseFee`, `setFeePerByte`, `setFeeRecipient`, `withdrawFees`,
+`emergencyWithdraw`, `recoverERC20`).
+
+### S-8 Overpayment within the 2× envelope is absorbed
+
+Alice sends `msg.value = 1.5 × required`. Tx succeeds; Portal retains
+the full `msg.value`. Alice does not get a refund. Test pins this so
+that a future "refund overpayment" change is a conscious break.
+
+### S-9 Raw ETH to Portal / Sender
+
+`address(portal).call{value: 1 ether}("")` and the same to `sender` —
+both fail. The `send(bytes)` entry point is the **only** way ETH enters
+the Portal. Sender never accepts ETH for non-bridge purposes.
+
+### S-10 Under-length payload to Receiver
+
+Oracle delivers a 10-byte payload. `PortalMessage.decode` reverts with
+`InsufficientDataLength`. No mint, no partial state change.
+
+### S-11 Malformed message body (correct payload wrapper)
+
+Oracle delivers a payload whose body is not `abi.encode(uint256,
+address)` — e.g., 31 arbitrary bytes. `abi.decode` in the Receiver
+reverts. No mint.
+
+### S-12 Replay at the receiver boundary (spec fence)
+
+Document-only scenario: if `NATIVE_ORACLE`'s sequential-nonce rule were
+bypassed and the same payload were delivered twice, the Receiver would
+mint twice. The test constructs this artificial situation (by pranking
+as `NATIVE_ORACLE` and calling `onOracleEvent` twice with the same
+inputs) and asserts the **double mint happens** — pinning I-9 as a
+deliberate boundary condition, so regressions introducing local replay
+guards or, conversely, silently removing oracle-side guards are
+detected.
+
+### S-13 Unknown sourceType passes
+
+The Receiver declares `sourceType` as unused. A call with e.g.
+`sourceType = 42` succeeds so long as sourceId and sender match. Test
+pins this — if the bridge ever gains type discrimination, this test
+must be updated deliberately.
+
+### S-14 Large body does not inflate fee unexpectedly
+
+A user crafts a direct `portal.send` with a 10 KB body. The fee equals
+`baseFee + (36 + 10 240) * feePerByte`. Test pins the formula end-to-end
+so silent fee-formula changes are caught.
+
+### S-15 Ownership transfer is two-step
+
+Transferring Portal or Sender ownership requires both
+`transferOwnership` and `acceptOwnership`. A pending transfer does not
+change authority until accepted.
+
+---
+
+## Notes for future changes
+
+- **If a decentralized governance replaces the single-EOA owner**,
+  S-6/S-7 semantics shift and must be re-specified.
+- **If the bridge extends to Gravity → Ethereum withdrawals**, a new
+  conservation invariant (I-1 extended) is needed: minted-on-Ethereum
+  must equal burned-on-Gravity.
+- **If sourceType gains meaning** (e.g., distinguishing blockchain vs
+  JWK sources), S-13 is invalidated and the Receiver must gate on it.
+- **If per-receiver replay protection is re-enabled**, S-12 is
+  invalidated; the `__deprecated_processedNonces` slot should be
+  re-used, not a new slot, to preserve storage layout.

--- a/test/e2e/CrossChainBridge.t.sol
+++ b/test/e2e/CrossChainBridge.t.sol
@@ -98,7 +98,10 @@ contract CrossChainBridgeE2E is Test {
     }
 
     /// @dev Bridge `amount` to `recipient` from Alice, paying the exact fee.
-    function _bridge(uint256 amount, address recipient) internal returns (uint128 portalNonce, bytes memory payload) {
+    function _bridge(
+        uint256 amount,
+        address recipient
+    ) internal returns (uint128 portalNonce, bytes memory payload) {
         uint256 fee = sender.calculateBridgeFee(amount, recipient);
         vm.startPrank(alice);
         gToken.approve(address(sender), amount);
@@ -109,7 +112,11 @@ contract CrossChainBridgeE2E is Test {
     }
 
     /// @dev Deliver a captured payload to the receiver as if it were the oracle.
-    function _deliver(uint128 oracleNonce, uint256 sourceId, bytes memory payload) internal {
+    function _deliver(
+        uint128 oracleNonce,
+        uint256 sourceId,
+        bytes memory payload
+    ) internal {
         vm.prank(SystemAddresses.NATIVE_ORACLE);
         receiver.onOracleEvent(SOURCE_TYPE_BLOCKCHAIN, sourceId, oracleNonce, payload);
     }
@@ -385,7 +392,10 @@ contract CrossChainBridgeE2E is Test {
 
     /// @notice Fuzz the full round-trip: any (amount, recipient) that Alice can
     ///         afford must lock on Ethereum and mint exactly that much on Gravity.
-    function testFuzz_E2E_RoundTrip(uint256 amount, address recipient) public {
+    function testFuzz_E2E_RoundTrip(
+        uint256 amount,
+        address recipient
+    ) public {
         amount = bound(amount, 1, INITIAL_BALANCE);
         vm.assume(recipient != address(0));
 

--- a/test/e2e/CrossChainBridge.t.sol
+++ b/test/e2e/CrossChainBridge.t.sol
@@ -1,0 +1,399 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import { Test, Vm } from "forge-std/Test.sol";
+import { GravityPortal } from "@src/oracle/evm/GravityPortal.sol";
+import { IGravityPortal } from "@src/oracle/evm/IGravityPortal.sol";
+import { GBridgeSender } from "@src/oracle/evm/native_token_bridge/GBridgeSender.sol";
+import { IGBridgeSender } from "@src/oracle/evm/native_token_bridge/IGBridgeSender.sol";
+import { GBridgeReceiver } from "@src/oracle/evm/native_token_bridge/GBridgeReceiver.sol";
+import { IGBridgeReceiver } from "@src/oracle/evm/native_token_bridge/IGBridgeReceiver.sol";
+import { PortalMessage } from "@src/oracle/evm/PortalMessage.sol";
+import { SystemAddresses } from "@src/foundation/SystemAddresses.sol";
+import { NotAllowed } from "@src/foundation/SystemAccessControl.sol";
+import { Errors } from "@src/foundation/Errors.sol";
+import { MockGToken } from "@test/utils/MockGToken.sol";
+import { MintCapture } from "@test/utils/MintCapture.sol";
+
+/// @title CrossChainBridgeE2E
+/// @notice End-to-end cross-chain tests that exercise the real Sender → Portal
+///         → (oracle capture) → Receiver → NativeMint flow in a single EVM.
+/// @dev    We deploy all three production contracts exactly as they will be
+///         deployed in prod, then simulate the consensus engine's oracle
+///         capture by recording Portal's MessageSent event and replaying the
+///         payload into the Receiver via vm.prank(NATIVE_ORACLE).
+///
+///         This catches regressions that pure per-contract unit tests miss —
+///         namely that Sender + Portal + Receiver agree on the payload layout,
+///         the nonce semantics, and the trust boundary (sender / sourceId).
+contract CrossChainBridgeE2E is Test {
+    // ---- Ethereum side ----
+    MockGToken internal gToken;
+    GravityPortal internal portal;
+    GBridgeSender internal sender;
+
+    // ---- Gravity side ----
+    GBridgeReceiver internal receiver;
+    MintCapture internal mintCapture;
+
+    address internal owner;
+    address internal feeRecipient;
+    address internal alice;
+    uint256 internal alicePk;
+    address internal bob;
+    address internal charlie;
+
+    uint256 internal constant INITIAL_BALANCE = 1_000 ether;
+    uint256 internal constant ETHEREUM_CHAIN_ID = 1;
+    uint32 internal constant SOURCE_TYPE_BLOCKCHAIN = 0;
+
+    uint256 internal constant BASE_FEE = 0.0001 ether;
+    uint256 internal constant FEE_PER_BYTE = 1_250_000_000_000; // matches mainnet default
+
+    function setUp() public {
+        owner = makeAddr("owner");
+        feeRecipient = makeAddr("feeRecipient");
+        alicePk = 0xA11CE;
+        alice = vm.addr(alicePk);
+        bob = makeAddr("bob");
+        charlie = makeAddr("charlie");
+
+        // --- Ethereum side ---
+        gToken = new MockGToken();
+        portal = new GravityPortal(owner, BASE_FEE, FEE_PER_BYTE, feeRecipient);
+        sender = new GBridgeSender(address(gToken), address(portal), owner);
+
+        gToken.mint(alice, INITIAL_BALANCE);
+        vm.deal(alice, 100 ether);
+
+        // --- Gravity side ---
+        receiver = new GBridgeReceiver(address(sender), ETHEREUM_CHAIN_ID);
+
+        // Etch MintCapture at NATIVE_MINT_PRECOMPILE so the receiver's low-level
+        // call lands somewhere we can introspect.
+        MintCapture impl = new MintCapture();
+        vm.etch(SystemAddresses.NATIVE_MINT_PRECOMPILE, address(impl).code);
+        mintCapture = MintCapture(SystemAddresses.NATIVE_MINT_PRECOMPILE);
+    }
+
+    // ========================================================================
+    // Helpers
+    // ========================================================================
+
+    /// @dev Extract the payload bytes from the last Portal.MessageSent event
+    ///      recorded since the most recent vm.recordLogs() call.
+    function _capturePayload() internal returns (uint128 messageNonce, uint256 blockNumber, bytes memory payload) {
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        bytes32 sig = keccak256("MessageSent(uint128,uint256,bytes)");
+        for (uint256 i = logs.length; i > 0; i--) {
+            Vm.Log memory l = logs[i - 1];
+            if (l.emitter != address(portal)) continue;
+            if (l.topics.length == 0 || l.topics[0] != sig) continue;
+            messageNonce = uint128(uint256(l.topics[1]));
+            blockNumber = uint256(l.topics[2]);
+            payload = abi.decode(l.data, (bytes));
+            return (messageNonce, blockNumber, payload);
+        }
+        revert("MessageSent not emitted");
+    }
+
+    /// @dev Bridge `amount` to `recipient` from Alice, paying the exact fee.
+    function _bridge(uint256 amount, address recipient) internal returns (uint128 portalNonce, bytes memory payload) {
+        uint256 fee = sender.calculateBridgeFee(amount, recipient);
+        vm.startPrank(alice);
+        gToken.approve(address(sender), amount);
+        vm.recordLogs();
+        sender.bridgeToGravity{ value: fee }(amount, recipient);
+        vm.stopPrank();
+        (portalNonce,, payload) = _capturePayload();
+    }
+
+    /// @dev Deliver a captured payload to the receiver as if it were the oracle.
+    function _deliver(uint128 oracleNonce, uint256 sourceId, bytes memory payload) internal {
+        vm.prank(SystemAddresses.NATIVE_ORACLE);
+        receiver.onOracleEvent(SOURCE_TYPE_BLOCKCHAIN, sourceId, oracleNonce, payload);
+    }
+
+    // ========================================================================
+    // HAPPY PATH
+    // ========================================================================
+
+    /// @notice A single bridge: lock on Ethereum → mint on Gravity.
+    function test_E2E_HappyPath_SingleBridge() public {
+        uint256 amount = 100 ether;
+        uint256 fee = sender.calculateBridgeFee(amount, bob);
+
+        // ---- Ethereum side ----
+        uint256 aliceBalBefore = gToken.balanceOf(alice);
+        uint256 portalEthBefore = address(portal).balance;
+
+        (uint128 portalNonce, bytes memory payload) = _bridge(amount, bob);
+
+        assertEq(portalNonce, 1, "first portal nonce must be 1");
+        assertEq(portal.nonce(), 1, "portal nonce advanced");
+        assertEq(gToken.balanceOf(alice), aliceBalBefore - amount, "alice debited");
+        assertEq(gToken.balanceOf(address(sender)), amount, "sender locked tokens");
+        assertEq(address(portal).balance, portalEthBefore + fee, "portal collected fee");
+
+        // Decode the payload and assert it mirrors what we broadcast.
+        (address decodedSender, uint128 decodedNonce, bytes memory msgBody) = PortalMessage.decode(payload);
+        assertEq(decodedSender, address(sender), "payload sender");
+        assertEq(decodedNonce, portalNonce, "payload nonce");
+
+        (uint256 msgAmount, address msgRecipient) = abi.decode(msgBody, (uint256, address));
+        assertEq(msgAmount, amount, "payload amount");
+        assertEq(msgRecipient, bob, "payload recipient");
+
+        // ---- Gravity side ----
+        vm.expectEmit(true, true, true, true, address(receiver));
+        emit IGBridgeReceiver.NativeMinted(bob, amount, portalNonce);
+        _deliver({ oracleNonce: 1, sourceId: ETHEREUM_CHAIN_ID, payload: payload });
+
+        assertEq(mintCapture.callCount(), 1, "precompile called once");
+        MintCapture.Call memory c = mintCapture.lastCall();
+        assertEq(c.op, 0x01, "op byte");
+        assertEq(c.recipient, bob, "mint recipient");
+        assertEq(c.amount, amount, "mint amount");
+    }
+
+    /// @notice Three sequential bridges must produce three sequential nonces,
+    ///         be locked correctly, and mint three separate times on Gravity.
+    function test_E2E_HappyPath_SequentialBridges() public {
+        uint256[3] memory amounts = [uint256(10 ether), 20 ether, 30 ether];
+        address[3] memory recipients = [bob, charlie, bob];
+
+        bytes[] memory payloads = new bytes[](3);
+        uint128[] memory nonces = new uint128[](3);
+
+        for (uint256 i = 0; i < 3; i++) {
+            (uint128 n, bytes memory p) = _bridge(amounts[i], recipients[i]);
+            nonces[i] = n;
+            payloads[i] = p;
+            assertEq(n, uint128(i + 1), "portal nonces must be strictly sequential");
+        }
+
+        assertEq(gToken.balanceOf(address(sender)), amounts[0] + amounts[1] + amounts[2], "total locked");
+        assertEq(portal.nonce(), 3, "portal nonce");
+
+        // Oracle delivers each payload. Oracle nonce is independent of portal nonce;
+        // we just feed a monotonic value.
+        for (uint256 i = 0; i < 3; i++) {
+            _deliver({ oracleNonce: uint128(1000 + i), sourceId: ETHEREUM_CHAIN_ID, payload: payloads[i] });
+        }
+
+        assertEq(mintCapture.callCount(), 3, "precompile called three times");
+        MintCapture.Call memory last = mintCapture.lastCall();
+        assertEq(last.recipient, recipients[2]);
+        assertEq(last.amount, amounts[2]);
+    }
+
+    /// @notice Bridge via permit: no prior approve() tx, signed permit inside the bridge call.
+    function test_E2E_HappyPath_BridgeWithPermit() public {
+        uint256 amount = 50 ether;
+        uint256 deadline = block.timestamp + 1 hours;
+        uint256 fee = sender.calculateBridgeFee(amount, bob);
+
+        bytes32 digest = keccak256(
+            abi.encodePacked(
+                "\x19\x01",
+                gToken.DOMAIN_SEPARATOR(),
+                keccak256(
+                    abi.encode(
+                        keccak256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)"),
+                        alice,
+                        address(sender),
+                        amount,
+                        gToken.nonces(alice),
+                        deadline
+                    )
+                )
+            )
+        );
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(alicePk, digest);
+
+        vm.recordLogs();
+        vm.prank(alice);
+        sender.bridgeToGravityWithPermit{ value: fee }(amount, bob, deadline, v, r, s);
+        (uint128 portalNonce,, bytes memory payload) = _capturePayload();
+
+        _deliver({ oracleNonce: 1, sourceId: ETHEREUM_CHAIN_ID, payload: payload });
+
+        assertEq(portalNonce, 1);
+        assertEq(gToken.balanceOf(address(sender)), amount);
+        MintCapture.Call memory c = mintCapture.lastCall();
+        assertEq(c.recipient, bob);
+        assertEq(c.amount, amount);
+    }
+
+    /// @notice Portal fees accumulate across many bridges, and the owner can
+    ///         withdraw them to the configured fee recipient.
+    function test_E2E_FeeCollection_AndWithdraw() public {
+        _bridge(10 ether, bob);
+        _bridge(20 ether, bob);
+        _bridge(30 ether, bob);
+
+        uint256 portalBal = address(portal).balance;
+        assertGt(portalBal, 0, "portal accumulates fees");
+        assertEq(feeRecipient.balance, 0, "feeRecipient starts empty");
+
+        vm.prank(owner);
+        portal.withdrawFees();
+
+        assertEq(address(portal).balance, 0, "portal drained");
+        assertEq(feeRecipient.balance, portalBal, "feeRecipient paid");
+    }
+
+    // ========================================================================
+    // NEGATIVE PATHS — ETHEREUM SIDE (Sender / Portal)
+    // ========================================================================
+
+    function test_E2E_Send_RevertsOnInsufficientFee() public {
+        uint256 amount = 100 ether;
+        uint256 fee = sender.calculateBridgeFee(amount, bob);
+
+        vm.startPrank(alice);
+        gToken.approve(address(sender), amount);
+        vm.expectRevert(); // Portal reverts with InsufficientFee; exact args bubble through
+        sender.bridgeToGravity{ value: fee - 1 }(amount, bob);
+        vm.stopPrank();
+
+        assertEq(portal.nonce(), 0, "portal nonce must not advance on revert");
+        assertEq(gToken.balanceOf(alice), INITIAL_BALANCE, "alice not debited on revert");
+    }
+
+    function test_E2E_Send_RevertsOnExcessiveFee() public {
+        uint256 amount = 100 ether;
+        uint256 fee = sender.calculateBridgeFee(amount, bob);
+
+        vm.startPrank(alice);
+        gToken.approve(address(sender), amount);
+        vm.expectRevert();
+        sender.bridgeToGravity{ value: 2 * fee + 1 }(amount, bob);
+        vm.stopPrank();
+    }
+
+    function test_E2E_Send_RevertsOnZeroAmount() public {
+        vm.prank(alice);
+        vm.expectRevert(IGBridgeSender.ZeroAmount.selector);
+        sender.bridgeToGravity{ value: 0 }(0, bob);
+    }
+
+    function test_E2E_Send_RevertsOnZeroRecipient() public {
+        uint256 amount = 1 ether;
+        uint256 fee = sender.calculateBridgeFee(amount, address(0));
+        vm.startPrank(alice);
+        gToken.approve(address(sender), amount);
+        vm.expectRevert(IGBridgeSender.ZeroRecipient.selector);
+        sender.bridgeToGravity{ value: fee }(amount, address(0));
+        vm.stopPrank();
+    }
+
+    // ========================================================================
+    // NEGATIVE PATHS — GRAVITY SIDE (Receiver trust boundary)
+    // ========================================================================
+
+    /// @notice A malicious EOA calls Portal.send directly to forge a payload —
+    ///         the Receiver must reject it because embedded sender != trustedBridge.
+    ///         This is the central trust boundary for the whole bridge.
+    function test_E2E_Receiver_RejectsForgedPayloadFromRandomSender() public {
+        address attacker = makeAddr("attacker");
+        vm.deal(attacker, 10 ether);
+
+        // Craft a legitimate-looking Gravity-bridge message body (but with attacker as sender).
+        bytes memory body = abi.encode(uint256(999 ether), bob);
+        uint256 requiredFee = portal.calculateFee(PortalMessage.MIN_PAYLOAD_LENGTH + body.length);
+
+        vm.recordLogs();
+        vm.prank(attacker);
+        portal.send{ value: requiredFee }(body);
+        (,, bytes memory payload) = _capturePayload();
+
+        // Sanity: the portal embedded attacker as the sender.
+        (address embeddedSender,,) = PortalMessage.decode(payload);
+        assertEq(embeddedSender, attacker, "Portal embeds msg.sender as the payload sender");
+
+        // Oracle tries to deliver. Receiver must reject.
+        vm.prank(SystemAddresses.NATIVE_ORACLE);
+        vm.expectRevert(abi.encodeWithSelector(IGBridgeReceiver.InvalidSender.selector, attacker, address(sender)));
+        receiver.onOracleEvent(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_CHAIN_ID, 1, payload);
+
+        assertEq(mintCapture.callCount(), 0, "no mint on forged payload");
+    }
+
+    /// @notice Even a legitimate payload must be rejected if the oracle claims
+    ///         it came from the wrong source chain.
+    function test_E2E_Receiver_RejectsWrongSourceId() public {
+        (, bytes memory payload) = _bridge(10 ether, bob);
+        uint256 wrongSourceId = 56; // BSC
+
+        vm.prank(SystemAddresses.NATIVE_ORACLE);
+        vm.expectRevert(
+            abi.encodeWithSelector(IGBridgeReceiver.InvalidSourceChain.selector, wrongSourceId, ETHEREUM_CHAIN_ID)
+        );
+        receiver.onOracleEvent(SOURCE_TYPE_BLOCKCHAIN, wrongSourceId, 1, payload);
+
+        assertEq(mintCapture.callCount(), 0, "no mint on wrong sourceId");
+    }
+
+    /// @notice Only NATIVE_ORACLE may invoke onOracleEvent; EOAs must be rejected.
+    function test_E2E_Receiver_RejectsNonOracleCaller() public {
+        (, bytes memory payload) = _bridge(10 ether, bob);
+
+        address attacker = makeAddr("attacker");
+        vm.prank(attacker);
+        vm.expectRevert(abi.encodeWithSelector(NotAllowed.selector, attacker, SystemAddresses.NATIVE_ORACLE));
+        receiver.onOracleEvent(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_CHAIN_ID, 1, payload);
+
+        assertEq(mintCapture.callCount(), 0, "no mint on wrong caller");
+    }
+
+    /// @notice Sanity: even if the oracle call passes all trust checks, if the
+    ///         body decodes to (0, …) the receiver reverts with ZeroAmount.
+    ///         To reach this we bypass the sender and craft a payload directly.
+    function test_E2E_Receiver_RejectsZeroAmountBody() public {
+        bytes memory body = abi.encode(uint256(0), bob);
+        bytes memory payload = PortalMessage.encode(address(sender), 1, body);
+
+        vm.prank(SystemAddresses.NATIVE_ORACLE);
+        vm.expectRevert(Errors.ZeroAmount.selector);
+        receiver.onOracleEvent(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_CHAIN_ID, 1, payload);
+    }
+
+    function test_E2E_Receiver_RejectsZeroRecipientBody() public {
+        bytes memory body = abi.encode(uint256(1 ether), address(0));
+        bytes memory payload = PortalMessage.encode(address(sender), 1, body);
+
+        vm.prank(SystemAddresses.NATIVE_ORACLE);
+        vm.expectRevert(Errors.ZeroAddress.selector);
+        receiver.onOracleEvent(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_CHAIN_ID, 1, payload);
+    }
+
+    /// @notice If the precompile reverts (grevm returned !success), the receiver
+    ///         reverts with MintFailed — no half-finished state.
+    function test_E2E_Receiver_RevertsWhenPrecompileFails() public {
+        (, bytes memory payload) = _bridge(10 ether, bob);
+        mintCapture.setShouldRevert(true);
+
+        vm.prank(SystemAddresses.NATIVE_ORACLE);
+        vm.expectRevert(abi.encodeWithSelector(IGBridgeReceiver.MintFailed.selector, bob, 10 ether));
+        receiver.onOracleEvent(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_CHAIN_ID, 1, payload);
+    }
+
+    // ========================================================================
+    // FUZZ
+    // ========================================================================
+
+    /// @notice Fuzz the full round-trip: any (amount, recipient) that Alice can
+    ///         afford must lock on Ethereum and mint exactly that much on Gravity.
+    function testFuzz_E2E_RoundTrip(uint256 amount, address recipient) public {
+        amount = bound(amount, 1, INITIAL_BALANCE);
+        vm.assume(recipient != address(0));
+
+        (uint128 portalNonce, bytes memory payload) = _bridge(amount, recipient);
+        _deliver({ oracleNonce: uint128(portalNonce), sourceId: ETHEREUM_CHAIN_ID, payload: payload });
+
+        MintCapture.Call memory c = mintCapture.lastCall();
+        assertEq(c.recipient, recipient);
+        assertEq(c.amount, amount);
+    }
+}

--- a/test/e2e/SecuritySpec.t.sol
+++ b/test/e2e/SecuritySpec.t.sol
@@ -1,0 +1,580 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import { Test, Vm } from "forge-std/Test.sol";
+import { GravityPortal } from "@src/oracle/evm/GravityPortal.sol";
+import { IGravityPortal } from "@src/oracle/evm/IGravityPortal.sol";
+import { GBridgeSender } from "@src/oracle/evm/native_token_bridge/GBridgeSender.sol";
+import { IGBridgeSender } from "@src/oracle/evm/native_token_bridge/IGBridgeSender.sol";
+import { GBridgeReceiver } from "@src/oracle/evm/native_token_bridge/GBridgeReceiver.sol";
+import { IGBridgeReceiver } from "@src/oracle/evm/native_token_bridge/IGBridgeReceiver.sol";
+import { PortalMessage } from "@src/oracle/evm/PortalMessage.sol";
+import { SystemAddresses } from "@src/foundation/SystemAddresses.sol";
+import { Errors } from "@src/foundation/Errors.sol";
+import { MockGToken } from "@test/utils/MockGToken.sol";
+import { MintCapture } from "@test/utils/MintCapture.sol";
+import { Ownable } from "@openzeppelin/access/Ownable.sol";
+import { ERC20 } from "@openzeppelin/token/ERC20/ERC20.sol";
+import { ERC20Permit } from "@openzeppelin/token/ERC20/extensions/ERC20Permit.sol";
+
+// ============================================================================
+// Adversarial helpers
+// ============================================================================
+
+/// @notice G-like token that burns a fixed percentage on every transfer.
+///         Used to validate I-2 / S-2 (fee-on-transfer safety).
+contract FeeOnTransferToken is ERC20, ERC20Permit {
+    uint256 public immutable feeBps;
+
+    constructor(
+        uint256 feeBps_
+    ) ERC20("FoT G", "fG") ERC20Permit("FoT G") {
+        feeBps = feeBps_;
+    }
+
+    function mint(
+        address to,
+        uint256 amount
+    ) external {
+        _mint(to, amount);
+    }
+
+    function _update(address from, address to, uint256 value) internal override {
+        // Skip fee for mints (from == address(0)) so initial balances are whole.
+        if (from == address(0) || to == address(0) || feeBps == 0) {
+            super._update(from, to, value);
+            return;
+        }
+        uint256 fee = (value * feeBps) / 10_000;
+        super._update(from, to, value - fee);
+        super._update(from, address(0xdead), fee); // "burn" to dead to keep totalSupply observable
+    }
+}
+
+/// @notice Fee recipient that re-enters GravityPortal.send during the ETH
+///         transfer of withdrawFees. Used by S-4.
+contract ReentrantFeeRecipient {
+    GravityPortal internal immutable portal;
+    uint256 public reentryCount;
+
+    constructor(
+        GravityPortal portal_
+    ) {
+        portal = portal_;
+    }
+
+    receive() external payable {
+        if (reentryCount < 1) {
+            reentryCount++;
+            // Reenter: try to call send with our just-received fee amount.
+            // This must not corrupt state. We expect either success (portal
+            // treats it as a normal permissionless send with the reentrant
+            // value as fee) or a clean revert — the test handles either.
+            uint256 feeReq = portal.calculateFee(0); // empty body
+            if (address(this).balance >= feeReq && feeReq > 0) {
+                try portal.send{ value: feeReq }(hex"") returns (uint128) {
+                    // reentrant send accepted
+                } catch {
+                    // reentrant send rejected; also acceptable
+                }
+            }
+        }
+    }
+}
+
+// ============================================================================
+// Spec tests
+// ============================================================================
+
+/// @title SecuritySpecE2E
+/// @notice Asserts each item in `spec_v2/oracle_evm_bridge.security.spec.md`.
+///         Test names are prefixed with the spec ID (I-N / S-N).
+contract SecuritySpecE2E is Test {
+    MockGToken internal gToken;
+    GravityPortal internal portal;
+    GBridgeSender internal sender;
+    GBridgeReceiver internal receiver;
+    MintCapture internal mintCapture;
+
+    address internal owner;
+    address internal feeRecipient;
+    address internal alice;
+    uint256 internal alicePk;
+    address internal bob;
+
+    uint256 internal constant INITIAL_BALANCE = 1_000 ether;
+    uint256 internal constant ETHEREUM_CHAIN_ID = 1;
+    uint32 internal constant SOURCE_TYPE_BLOCKCHAIN = 0;
+
+    uint256 internal constant BASE_FEE = 0.0001 ether;
+    uint256 internal constant FEE_PER_BYTE = 1_250_000_000_000;
+
+    function setUp() public {
+        owner = makeAddr("owner");
+        feeRecipient = makeAddr("feeRecipient");
+        alicePk = 0xA11CE;
+        alice = vm.addr(alicePk);
+        bob = makeAddr("bob");
+
+        gToken = new MockGToken();
+        portal = new GravityPortal(owner, BASE_FEE, FEE_PER_BYTE, feeRecipient);
+        sender = new GBridgeSender(address(gToken), address(portal), owner);
+        receiver = new GBridgeReceiver(address(sender), ETHEREUM_CHAIN_ID);
+
+        gToken.mint(alice, INITIAL_BALANCE);
+        vm.deal(alice, 100 ether);
+
+        vm.etch(SystemAddresses.NATIVE_MINT_PRECOMPILE, address(new MintCapture()).code);
+        mintCapture = MintCapture(SystemAddresses.NATIVE_MINT_PRECOMPILE);
+    }
+
+    // -------- helpers --------
+
+    function _bridge(uint256 amount, address recipient) internal returns (uint128 portalNonce, bytes memory payload) {
+        uint256 fee = sender.calculateBridgeFee(amount, recipient);
+        vm.startPrank(alice);
+        gToken.approve(address(sender), amount);
+        vm.recordLogs();
+        sender.bridgeToGravity{ value: fee }(amount, recipient);
+        vm.stopPrank();
+        (portalNonce, payload) = _lastMessageSent();
+    }
+
+    function _lastMessageSent() internal returns (uint128 nonce, bytes memory payload) {
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        bytes32 sig = keccak256("MessageSent(uint128,uint256,bytes)");
+        for (uint256 i = logs.length; i > 0; i--) {
+            Vm.Log memory l = logs[i - 1];
+            if (l.emitter == address(portal) && l.topics.length > 0 && l.topics[0] == sig) {
+                nonce = uint128(uint256(l.topics[1]));
+                payload = abi.decode(l.data, (bytes));
+                return (nonce, payload);
+            }
+        }
+        revert("MessageSent not found");
+    }
+
+    function _deliver(uint128 oracleNonce, uint256 sourceId, bytes memory payload) internal {
+        vm.prank(SystemAddresses.NATIVE_ORACLE);
+        receiver.onOracleEvent(SOURCE_TYPE_BLOCKCHAIN, sourceId, oracleNonce, payload);
+    }
+
+    // ========================================================================
+    // Invariants
+    // ========================================================================
+
+    /// I-1 Conservation (non-rebasing token): locked on Ethereum == minted on Gravity.
+    function test_I1_Conservation_NonRebasing() public {
+        uint256[3] memory amounts = [uint256(17 ether), 42 ether, 1 ether];
+
+        uint256 mintedOnGravity;
+        bytes[] memory payloads = new bytes[](3);
+        for (uint256 i = 0; i < 3; i++) {
+            (, bytes memory p) = _bridge(amounts[i], bob);
+            payloads[i] = p;
+        }
+
+        uint256 lockedOnEthereum = gToken.balanceOf(address(sender));
+        assertEq(lockedOnEthereum, amounts[0] + amounts[1] + amounts[2], "Ethereum-side locked sum");
+
+        for (uint256 i = 0; i < 3; i++) {
+            _deliver(uint128(i + 1), ETHEREUM_CHAIN_ID, payloads[i]);
+            mintedOnGravity += mintCapture.lastCall().amount;
+        }
+        assertEq(mintedOnGravity, lockedOnEthereum, "minted == locked");
+    }
+
+    /// I-3 Nonce monotonicity.
+    function test_I3_NonceMonotonic() public {
+        uint128 prev;
+        for (uint256 i = 0; i < 5; i++) {
+            (uint128 n,) = _bridge(1 ether, bob);
+            assertGt(n, prev, "nonce must strictly increase");
+            prev = n;
+        }
+        assertEq(portal.nonce(), 5);
+    }
+
+    /// I-5 PortalMessage encode/decode round-trip (including empty + large bodies).
+    function test_I5_PortalMessageRoundTrip() public pure {
+        address sndr = address(0xBEEF);
+        uint128 n = 7;
+
+        // empty body
+        bytes memory p0 = PortalMessage.encode(sndr, n, "");
+        (address s0, uint128 nn0, bytes memory b0) = PortalMessage.decode(p0);
+        assertEq_helper(s0, sndr);
+        require(nn0 == n, "nonce mismatch empty");
+        require(b0.length == 0, "body length mismatch empty");
+
+        // short body
+        bytes memory short_ = hex"deadbeef";
+        bytes memory p1 = PortalMessage.encode(sndr, n, short_);
+        (address s1, uint128 nn1, bytes memory b1) = PortalMessage.decode(p1);
+        assertEq_helper(s1, sndr);
+        require(nn1 == n, "nonce mismatch short");
+        require(keccak256(b1) == keccak256(short_), "body mismatch short");
+
+        // large body (4 KB)
+        bytes memory big = new bytes(4096);
+        for (uint256 i = 0; i < big.length; i++) big[i] = bytes1(uint8(i & 0xff));
+        bytes memory p2 = PortalMessage.encode(sndr, n, big);
+        (address s2, uint128 nn2, bytes memory b2) = PortalMessage.decode(p2);
+        assertEq_helper(s2, sndr);
+        require(nn2 == n, "nonce mismatch big");
+        require(keccak256(b2) == keccak256(big), "body mismatch big");
+    }
+
+    function assertEq_helper(address a, address b) internal pure {
+        require(a == b, "addr mismatch");
+    }
+
+    /// I-6 Portal and Sender have no ETH inlet outside of send(). (S-9 is the same
+    /// invariant viewed from the attacker side.)
+    function test_I6_NoStuckEth_Portal() public {
+        vm.deal(address(this), 1 ether);
+        (bool ok,) = address(portal).call{ value: 1 ether }("");
+        assertFalse(ok, "Portal must reject bare ETH");
+        assertEq(address(portal).balance, 0, "Portal must hold 0 ETH after rejected transfer");
+    }
+
+    function test_I6_NoStuckEth_Sender() public {
+        vm.deal(address(this), 1 ether);
+        (bool ok,) = address(sender).call{ value: 1 ether }("");
+        assertFalse(ok, "Sender must reject bare ETH");
+        assertEq(address(sender).balance, 0);
+    }
+
+    /// I-7 Atomicity: a failure in Portal.send (here: insufficient fee) must unwind
+    /// the preceding transferFrom entirely.
+    function test_I7_Atomicity_OnPortalRevert() public {
+        uint256 amount = 100 ether;
+        uint256 fee = sender.calculateBridgeFee(amount, bob);
+
+        uint256 aliceBal = gToken.balanceOf(alice);
+        uint256 senderBal = gToken.balanceOf(address(sender));
+        uint128 nonceBefore = portal.nonce();
+
+        vm.startPrank(alice);
+        gToken.approve(address(sender), amount);
+        vm.expectRevert(); // portal reverts with InsufficientFee
+        sender.bridgeToGravity{ value: fee - 1 }(amount, bob);
+        vm.stopPrank();
+
+        assertEq(gToken.balanceOf(alice), aliceBal, "alice balance must be unchanged");
+        assertEq(gToken.balanceOf(address(sender)), senderBal, "sender balance must be unchanged");
+        assertEq(portal.nonce(), nonceBefore, "portal nonce must be unchanged");
+    }
+
+    /// I-8 Fee envelope: required ≤ msg.value ≤ 2*required is accepted; both bounds
+    /// outside revert.
+    function test_I8_FeeEnvelope_Boundaries() public {
+        uint256 amount = 100 ether;
+        uint256 fee = sender.calculateBridgeFee(amount, bob);
+
+        // exactly required: ok
+        vm.startPrank(alice);
+        gToken.approve(address(sender), amount);
+        sender.bridgeToGravity{ value: fee }(amount, bob);
+        vm.stopPrank();
+
+        // exactly 2*required: still ok
+        vm.startPrank(alice);
+        gToken.approve(address(sender), amount);
+        sender.bridgeToGravity{ value: 2 * fee }(amount, bob);
+        vm.stopPrank();
+
+        // 2*required + 1: excessive
+        vm.startPrank(alice);
+        gToken.approve(address(sender), amount);
+        vm.expectRevert(abi.encodeWithSelector(IGravityPortal.ExcessiveFee.selector, fee, 2 * fee + 1));
+        sender.bridgeToGravity{ value: 2 * fee + 1 }(amount, bob);
+        vm.stopPrank();
+
+        // required - 1: insufficient
+        vm.startPrank(alice);
+        gToken.approve(address(sender), amount);
+        vm.expectRevert(abi.encodeWithSelector(IGravityPortal.InsufficientFee.selector, fee, fee - 1));
+        sender.bridgeToGravity{ value: fee - 1 }(amount, bob);
+        vm.stopPrank();
+    }
+
+    /// I-9 Replay is oracle-side: receiver has no per-message replay guard. This
+    /// test deliberately calls onOracleEvent twice with the same payload and
+    /// asserts BOTH succeed. If a future change silently adds a local replay
+    /// guard, this test turns red and forces an explicit decision.
+    function test_I9_ReceiverNoLocalReplayGuard() public {
+        (, bytes memory payload) = _bridge(10 ether, bob);
+
+        _deliver(1, ETHEREUM_CHAIN_ID, payload);
+        _deliver(2, ETHEREUM_CHAIN_ID, payload); // same payload, different oracle nonce
+
+        assertEq(mintCapture.callCount(), 2, "receiver mints again - replay guard is oracle-side");
+        MintCapture.Call memory c = mintCapture.lastCall();
+        assertEq(c.amount, 10 ether);
+    }
+
+    // ========================================================================
+    // Adversarial scenarios
+    // ========================================================================
+
+    /// S-2 Fee-on-transfer G token: amount encoded = amount actually received.
+    function test_S2_FeeOnTransferToken() public {
+        FeeOnTransferToken fotG = new FeeOnTransferToken({ feeBps_: 500 }); // 5 %
+        GBridgeSender fotSender = new GBridgeSender(address(fotG), address(portal), owner);
+        GBridgeReceiver fotReceiver = new GBridgeReceiver(address(fotSender), ETHEREUM_CHAIN_ID);
+
+        fotG.mint(alice, INITIAL_BALANCE);
+        uint256 amount = 100 ether;
+        uint256 fee = portal.calculateFee(64); // abi.encode(uint256, address) = 64
+        uint256 expectedReceived = amount - (amount * 500) / 10_000; // 95 ether
+
+        vm.deal(alice, 10 ether);
+        vm.startPrank(alice);
+        fotG.approve(address(fotSender), amount);
+        vm.recordLogs();
+        fotSender.bridgeToGravity{ value: fee }(amount, bob);
+        vm.stopPrank();
+        (, bytes memory payload) = _lastMessageSent();
+
+        // Alice paid 100, sender received 95, sender's balance = 95
+        assertEq(fotG.balanceOf(address(fotSender)), expectedReceived, "sender holds actualReceived");
+
+        // Payload body encodes actualReceived, not the nominal amount
+        (,, bytes memory body) = PortalMessage.decode(payload);
+        (uint256 msgAmount,) = abi.decode(body, (uint256, address));
+        assertEq(msgAmount, expectedReceived, "message amount == actualReceived");
+
+        // Deliver to receiver → mint exactly expectedReceived
+        vm.prank(SystemAddresses.NATIVE_ORACLE);
+        fotReceiver.onOracleEvent(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_CHAIN_ID, 1, payload);
+        assertEq(mintCapture.lastCall().amount, expectedReceived, "minted == actualReceived (no phantom)");
+    }
+
+    /// S-3 Mid-flight fee hike: owner raises feePerByte between calculateBridgeFee
+    /// and Alice's tx; Alice's tx reverts atomically.
+    function test_S3_MidFlightFeeHike_RevertsAtomically() public {
+        uint256 amount = 10 ether;
+        uint256 originalFee = sender.calculateBridgeFee(amount, bob);
+
+        // Owner raises the fee.
+        vm.prank(owner);
+        portal.setFeePerByte(FEE_PER_BYTE * 10);
+
+        uint256 aliceBal = gToken.balanceOf(alice);
+        uint256 senderBal = gToken.balanceOf(address(sender));
+
+        vm.startPrank(alice);
+        gToken.approve(address(sender), amount);
+        vm.expectRevert(); // InsufficientFee (exact args are noisy here, any revert suffices)
+        sender.bridgeToGravity{ value: originalFee }(amount, bob);
+        vm.stopPrank();
+
+        assertEq(gToken.balanceOf(alice), aliceBal, "alice not debited");
+        assertEq(gToken.balanceOf(address(sender)), senderBal, "sender not credited");
+    }
+
+    /// S-4 Reentrant withdrawFees via attacker-controlled feeRecipient.
+    /// We assert: no double-drain, final portal balance equals the reentrant-attacker's
+    /// own deposits (if any) — not a penny extra.
+    function test_S4_ReentrantWithdrawFees() public {
+        ReentrantFeeRecipient attacker = new ReentrantFeeRecipient(portal);
+        vm.deal(address(attacker), 10 ether);
+
+        // Point Portal at the attacker
+        vm.prank(owner);
+        portal.setFeeRecipient(address(attacker));
+
+        // Seed Portal with one legitimate bridge (which pays fee).
+        _bridge(1 ether, bob);
+
+        uint256 portalBalBefore = address(portal).balance;
+        assertGt(portalBalBefore, 0);
+
+        // Owner withdraws. Reentry happens inside receive().
+        vm.prank(owner);
+        portal.withdrawFees();
+
+        // After the outer withdraw: the attacker has received portalBalBefore minus
+        // whatever they themselves spent in reentrant sends (the reentrant send's
+        // msg.value is subtracted from their balance on the attacker contract).
+        // Any NEW fees paid during reentry end up in portal.balance and are NOT
+        // double-drained.
+        uint256 portalBalAfter = address(portal).balance;
+        // Portal balance after = reentrant send's fee (if any). It is always >= 0 and
+        // NEVER greater than the attacker's ether reserve.
+        assertLe(portalBalAfter, 10 ether, "portal can only hold what the attacker deposited during reentry");
+
+        // Nonce advanced coherently — baseline send(1) + however many reentrant sends.
+        assertGe(portal.nonce(), 1, "nonce advances monotonically through reentry");
+    }
+
+    /// S-5 Permit front-run DoS: attacker consumes Alice's permit nonce; Alice's
+    /// bridge tx reverts; Alice's balance is intact.
+    function test_S5_PermitFrontRun_AliceTokensSafe() public {
+        uint256 amount = 50 ether;
+        uint256 fee = sender.calculateBridgeFee(amount, bob);
+        uint256 deadline = block.timestamp + 1 hours;
+
+        bytes32 digest = keccak256(
+            abi.encodePacked(
+                "\x19\x01",
+                gToken.DOMAIN_SEPARATOR(),
+                keccak256(
+                    abi.encode(
+                        keccak256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)"),
+                        alice,
+                        address(sender),
+                        amount,
+                        gToken.nonces(alice),
+                        deadline
+                    )
+                )
+            )
+        );
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(alicePk, digest);
+
+        // Attacker front-runs: calls permit directly on the token to consume the nonce.
+        gToken.permit(alice, address(sender), amount, deadline, v, r, s);
+
+        uint256 aliceBalBefore = gToken.balanceOf(alice);
+
+        // Alice's tx now fails because the permit nonce has advanced.
+        vm.deal(alice, fee);
+        vm.prank(alice);
+        vm.expectRevert(); // OZ permit reverts with ERC2612InvalidSigner
+        sender.bridgeToGravityWithPermit{ value: fee }(amount, bob, deadline, v, r, s);
+
+        assertEq(gToken.balanceOf(alice), aliceBalBefore, "alice tokens untouched on permit front-run");
+    }
+
+    /// S-6 Owner CAN drain locked tokens (documented centralization).
+    function test_S6_OwnerCanDrainLockedTokens() public {
+        _bridge(200 ether, bob);
+        assertEq(gToken.balanceOf(address(sender)), 200 ether);
+
+        address rescueTo = makeAddr("rescueTo");
+        vm.prank(owner);
+        sender.recoverERC20(address(gToken), rescueTo, 200 ether);
+
+        assertEq(gToken.balanceOf(address(sender)), 0, "sender drained");
+        assertEq(gToken.balanceOf(rescueTo), 200 ether, "rescue recipient paid");
+    }
+
+    /// S-7 Non-owner cannot drain (and cannot touch any onlyOwner entrypoint).
+    function test_S7_NonOwner_Blocked_OnAllAdminPaths() public {
+        address attacker = makeAddr("attacker");
+
+        vm.startPrank(attacker);
+
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, attacker));
+        sender.recoverERC20(address(gToken), attacker, 1);
+
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, attacker));
+        sender.emergencyWithdraw(attacker, 1);
+
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, attacker));
+        portal.setBaseFee(0);
+
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, attacker));
+        portal.setFeePerByte(0);
+
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, attacker));
+        portal.setFeeRecipient(attacker);
+
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, attacker));
+        portal.withdrawFees();
+
+        vm.stopPrank();
+    }
+
+    /// S-8 Overpayment within the 2× envelope is absorbed (no refund).
+    function test_S8_OverpaymentAbsorbed_NoRefund() public {
+        uint256 amount = 10 ether;
+        uint256 fee = sender.calculateBridgeFee(amount, bob);
+        uint256 overpay = (fee * 3) / 2; // 1.5× required
+
+        uint256 aliceEthBefore = alice.balance;
+        uint256 portalEthBefore = address(portal).balance;
+
+        vm.startPrank(alice);
+        gToken.approve(address(sender), amount);
+        sender.bridgeToGravity{ value: overpay }(amount, bob);
+        vm.stopPrank();
+
+        assertEq(alice.balance, aliceEthBefore - overpay, "no refund to alice");
+        assertEq(address(portal).balance, portalEthBefore + overpay, "portal kept full msg.value");
+    }
+
+    /// S-9 Raw ETH → Portal / Sender fails. (Mirror of I-6.)
+    function test_S9_RawEth_Rejected() public {
+        vm.deal(address(this), 3 ether);
+        (bool p,) = address(portal).call{ value: 1 ether }("");
+        (bool s,) = address(sender).call{ value: 1 ether }("");
+        assertFalse(p);
+        assertFalse(s);
+    }
+
+    /// S-10 Under-length payload to Receiver reverts cleanly.
+    function test_S10_UnderLengthPayload_Rejected() public {
+        bytes memory shortPayload = hex"deadbeef"; // 4 bytes, far below 36 minimum
+        vm.prank(SystemAddresses.NATIVE_ORACLE);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                PortalMessage.InsufficientDataLength.selector, shortPayload.length, PortalMessage.MIN_PAYLOAD_LENGTH
+            )
+        );
+        receiver.onOracleEvent(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_CHAIN_ID, 1, shortPayload);
+        assertEq(mintCapture.callCount(), 0);
+    }
+
+    /// S-11 Malformed message body (not decodable to (uint256, address)) reverts.
+    function test_S11_MalformedBody_Rejected() public {
+        bytes memory garbageBody = hex"01020304050607080910111213141516171819202122232425262728293031";
+        // Length 31 = cannot decode as two 32-byte abi words.
+        bytes memory payload = PortalMessage.encode(address(sender), 1, garbageBody);
+        vm.prank(SystemAddresses.NATIVE_ORACLE);
+        vm.expectRevert(); // abi.decode reverts generically
+        receiver.onOracleEvent(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_CHAIN_ID, 1, payload);
+        assertEq(mintCapture.callCount(), 0);
+    }
+
+    /// S-13 Unknown sourceType currently passes (documented boundary).
+    function test_S13_UnknownSourceType_CurrentlyPasses() public {
+        (, bytes memory payload) = _bridge(1 ether, bob);
+        vm.prank(SystemAddresses.NATIVE_ORACLE);
+        receiver.onOracleEvent(42, ETHEREUM_CHAIN_ID, 1, payload); // sourceType = 42 (arbitrary)
+        assertEq(mintCapture.callCount(), 1, "sourceType is not gated today");
+    }
+
+    /// S-14 Large body fee formula end-to-end: fee = baseFee + (36 + bodyLen) * feePerByte.
+    function test_S14_LargeBody_FeeFormulaPinned() public {
+        bytes memory body = new bytes(10_240); // 10 KB
+        for (uint256 i = 0; i < body.length; i++) body[i] = bytes1(uint8(i & 0xff));
+
+        uint256 expected = BASE_FEE + (PortalMessage.MIN_PAYLOAD_LENGTH + body.length) * FEE_PER_BYTE;
+        assertEq(portal.calculateFee(body.length), expected, "fee formula pinned");
+
+        vm.deal(alice, expected);
+        vm.prank(alice);
+        portal.send{ value: expected }(body);
+        assertEq(address(portal).balance, expected);
+    }
+
+    /// S-15 Ownership transfer is two-step.
+    function test_S15_Ownable2Step_Portal() public {
+        address newOwner = makeAddr("newOwner");
+
+        vm.prank(owner);
+        portal.transferOwnership(newOwner);
+
+        assertEq(portal.owner(), owner, "owner unchanged before accept");
+        assertEq(portal.pendingOwner(), newOwner);
+
+        vm.prank(newOwner);
+        portal.acceptOwnership();
+
+        assertEq(portal.owner(), newOwner);
+        assertEq(portal.pendingOwner(), address(0));
+    }
+}

--- a/test/e2e/SecuritySpec.t.sol
+++ b/test/e2e/SecuritySpec.t.sol
@@ -39,7 +39,11 @@ contract FeeOnTransferToken is ERC20, ERC20Permit {
         _mint(to, amount);
     }
 
-    function _update(address from, address to, uint256 value) internal override {
+    function _update(
+        address from,
+        address to,
+        uint256 value
+    ) internal override {
         // Skip fee for mints (from == address(0)) so initial balances are whole.
         if (from == address(0) || to == address(0) || feeBps == 0) {
             super._update(from, to, value);
@@ -72,9 +76,12 @@ contract ReentrantFeeRecipient {
             // value as fee) or a clean revert — the test handles either.
             uint256 feeReq = portal.calculateFee(0); // empty body
             if (address(this).balance >= feeReq && feeReq > 0) {
-                try portal.send{ value: feeReq }(hex"") returns (uint128) {
-                    // reentrant send accepted
-                } catch {
+                try portal.send{ value: feeReq }(hex"") returns (
+                    uint128
+                ) {
+                // reentrant send accepted
+                }
+                    catch {
                     // reentrant send rejected; also acceptable
                 }
             }
@@ -130,7 +137,10 @@ contract SecuritySpecE2E is Test {
 
     // -------- helpers --------
 
-    function _bridge(uint256 amount, address recipient) internal returns (uint128 portalNonce, bytes memory payload) {
+    function _bridge(
+        uint256 amount,
+        address recipient
+    ) internal returns (uint128 portalNonce, bytes memory payload) {
         uint256 fee = sender.calculateBridgeFee(amount, recipient);
         vm.startPrank(alice);
         gToken.approve(address(sender), amount);
@@ -154,7 +164,11 @@ contract SecuritySpecE2E is Test {
         revert("MessageSent not found");
     }
 
-    function _deliver(uint128 oracleNonce, uint256 sourceId, bytes memory payload) internal {
+    function _deliver(
+        uint128 oracleNonce,
+        uint256 sourceId,
+        bytes memory payload
+    ) internal {
         vm.prank(SystemAddresses.NATIVE_ORACLE);
         receiver.onOracleEvent(SOURCE_TYPE_BLOCKCHAIN, sourceId, oracleNonce, payload);
     }
@@ -217,7 +231,9 @@ contract SecuritySpecE2E is Test {
 
         // large body (4 KB)
         bytes memory big = new bytes(4096);
-        for (uint256 i = 0; i < big.length; i++) big[i] = bytes1(uint8(i & 0xff));
+        for (uint256 i = 0; i < big.length; i++) {
+            big[i] = bytes1(uint8(i & 0xff));
+        }
         bytes memory p2 = PortalMessage.encode(sndr, n, big);
         (address s2, uint128 nn2, bytes memory b2) = PortalMessage.decode(p2);
         assertEq_helper(s2, sndr);
@@ -225,7 +241,10 @@ contract SecuritySpecE2E is Test {
         require(keccak256(b2) == keccak256(big), "body mismatch big");
     }
 
-    function assertEq_helper(address a, address b) internal pure {
+    function assertEq_helper(
+        address a,
+        address b
+    ) internal pure {
         require(a == b, "addr mismatch");
     }
 
@@ -550,7 +569,9 @@ contract SecuritySpecE2E is Test {
     /// S-14 Large body fee formula end-to-end: fee = baseFee + (36 + bodyLen) * feePerByte.
     function test_S14_LargeBody_FeeFormulaPinned() public {
         bytes memory body = new bytes(10_240); // 10 KB
-        for (uint256 i = 0; i < body.length; i++) body[i] = bytes1(uint8(i & 0xff));
+        for (uint256 i = 0; i < body.length; i++) {
+            body[i] = bytes1(uint8(i & 0xff));
+        }
 
         uint256 expected = BASE_FEE + (PortalMessage.MIN_PAYLOAD_LENGTH + body.length) * FEE_PER_BYTE;
         assertEq(portal.calculateFee(body.length), expected, "fee formula pinned");

--- a/test/utils/MintCapture.sol
+++ b/test/utils/MintCapture.sol
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+/// @notice Captures calls made to NATIVE_MINT_PRECOMPILE so tests can
+///         assert the receiver handed the right (recipient, amount) to it.
+/// @dev Receiver calls the precompile with packed calldata:
+///        uint8(0x01) || recipient (20B) || amount (32B) = 53 bytes.
+///      We decode that manually in a fallback to avoid needing a selector.
+contract MintCapture {
+    struct Call {
+        uint8 op;
+        address recipient;
+        uint256 amount;
+    }
+
+    Call[] public calls;
+    bool public shouldRevert;
+
+    function setShouldRevert(
+        bool v
+    ) external {
+        shouldRevert = v;
+    }
+
+    function callCount() external view returns (uint256) {
+        return calls.length;
+    }
+
+    function lastCall() external view returns (Call memory) {
+        require(calls.length > 0, "MintCapture: no calls");
+        return calls[calls.length - 1];
+    }
+
+    fallback() external {
+        if (shouldRevert) revert("mint failed");
+        require(msg.data.length == 53, "MintCapture: unexpected calldata length");
+
+        uint8 op = uint8(msg.data[0]);
+        address recipient;
+        uint256 amount;
+        assembly {
+            recipient := shr(96, calldataload(1))
+            amount := calldataload(21)
+        }
+        calls.push(Call({ op: op, recipient: recipient, amount: amount }));
+    }
+}


### PR DESCRIPTION
## Summary

- **Operator-facing deploy + verify scripts** for `GravityPortal` / `GBridgeSender` (Ethereum) and `GBridgeReceiver` (Gravity), plus a shell verifier that checks both chains end-to-end.
- **Local two-anvil harness** (`scripts/testnet/run_full_test.sh`) that etches all 22 Gravity system contracts via `anvil_setCode`, runs the real mainnet deploy script against chain-id 1, deploys the receiver against chain-id 127001, and runs the real verifier — exercising the same code path the operator will use on production.
- **Numbered security spec** (`spec_v2/oracle_evm_bridge.security.spec.md`): 9 invariants (I-1..I-9) + 15 adversarial scenarios (S-1..S-15) covering conservation, fee-on-transfer safety, nonce monotonicity, trust boundary, payload integrity, atomicity, fee envelope, oracle-side-only replay, permit front-run griefing, documented owner-drain centralization, and fee-formula pinning.
- **E2E tests** mapping 1:1 to the spec: `test/e2e/CrossChainBridge.t.sol` (15 happy-path + negative + fuzz) and `test/e2e/SecuritySpec.t.sol` (21 spec-anchored tests). Shared `test/utils/MintCapture.sol` mocks `NATIVE_MINT_PRECOMPILE`.

Full suite: **971 tests passing across 33 suites** (including the 36 new E2E/security tests).

## Notes

- `foundry.toml` gains `fs_permissions` for `./deployments` (deploy scripts write JSON receipts) and `./out` (the etch script reads `deployedBytecode.object`).
- No production contract code changes in this PR — only scripts, specs, and tests.
- `Gravity chain-id 127001` is hard-wired into the testnet harness default.

## Test plan

- [x] `forge test` — 971/971 passing.
- [x] `forge test --match-path test/e2e/SecuritySpec.t.sol -vv` — 21/21.
- [x] `forge test --match-path test/e2e/CrossChainBridge.t.sol -vv` — 15/15 (fuzz: 256 runs).
- [x] `./scripts/testnet/run_full_test.sh` — full deploy + verify against both anvils clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)