### PR TITLE
feat(staking): gate createPool behind allowPoolCreation flag

### DIFF
--- a/genesis-tool/src/genesis.rs
+++ b/genesis-tool/src/genesis.rs
@@ -115,6 +115,9 @@ pub struct StakingConfigParams {
 
     #[serde(rename = "unbondingDelayMicros")]
     pub unbonding_delay_micros: u64,
+
+    #[serde(rename = "allowPoolCreation", default)]
+    pub allow_pool_creation: bool,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
@@ -260,6 +263,7 @@ sol! {
         uint256 minimumStake;
         uint64 lockupDurationMicros;
         uint64 unbondingDelayMicros;
+        bool allowPoolCreation;
     }
 
     struct SolGovernanceConfigParams {
@@ -396,6 +400,7 @@ pub fn convert_config_to_sol(config: &GenesisConfig) -> SolGenesisInitParams {
         minimumStake: parse_u256(&config.staking_config.minimum_stake),
         lockupDurationMicros: config.staking_config.lockup_duration_micros,
         unbondingDelayMicros: config.staking_config.unbonding_delay_micros,
+        allowPoolCreation: config.staking_config.allow_pool_creation,
     };
 
     // Convert GovernanceConfig

--- a/spec_v2/staking.spec.md
+++ b/spec_v2/staking.spec.md
@@ -500,23 +500,32 @@ Create a new StakePool with all parameters specified explicitly.
 
 **Behavior:**
 
-1. Revert if `msg.value < minimumStake` (prevents spam)
-2. Increment `poolNonce`
-3. Compute deterministic address via CREATE2 (salt = `poolNonce`)
-4. Deploy new StakePool contract with all parameters and initial stake (`msg.value`)
-5. Pool constructor validates `lockedUntil >= now + minLockupDuration`
-6. Add to `_allPools` array
-7. Set `_isPool[pool] = true` (registers as valid pool)
-8. Emit `PoolCreated` event
-9. Return pool address
+1. Revert if a reconfiguration transition is in progress
+2. Revert with `PoolCreationDisabled` if `StakingConfig.allowPoolCreation()` is
+   `false` and the caller is not the GENESIS system address
+3. Revert if `msg.value < minimumStake` (prevents spam)
+4. Increment `poolNonce`
+5. Compute deterministic address via CREATE2 (salt = `poolNonce`)
+6. Deploy new StakePool contract with all parameters and initial stake (`msg.value`)
+7. Pool constructor validates `lockedUntil >= now + minLockupDuration`
+8. Add to `_allPools` array
+9. Set `_isPool[pool] = true` (registers as valid pool)
+10. Emit `PoolCreated` event
+11. Return pool address
 
 **Notes:**
 
-- Anyone can call this function (no restriction on caller)
-- Anyone can create multiple pools (no limit per address)
+- Access: anyone may call when `StakingConfig.allowPoolCreation` is `true`;
+  GENESIS can always call (bypass). When the flag is `false`, only GENESIS
+  (i.e., during genesis bootstrap) may create pools.
+- Anyone can create multiple pools (no limit per address) once the gate is open
 - All parameters must be explicitly provided (no defaults)
 - `lockedUntil` must be valid: `>= now + minLockupDuration`
 - Initial stake (`msg.value`) becomes the pool's activeStake immediately
+- The `allowPoolCreation` flag is flipped by governance via the dedicated
+  `StakingConfig.setAllowPoolCreationForNextEpoch(bool)` setter (independent
+  from the atomic `setForNextEpoch` pathway) and takes effect at the next epoch
+  boundary (`applyPendingConfig`).
 
 #### Pool Status Query Functions
 
@@ -945,7 +954,7 @@ Lockup parameters are configured in `StakingConfig`:
 
 | Contract  | Function                                        | Allowed Callers         |
 | --------- | ----------------------------------------------- | ----------------------- |
-| Staking   | createPool                                      | Anyone (with min stake) |
+| Staking   | createPool                                      | GENESIS always; anyone (with min stake) when `StakingConfig.allowPoolCreation = true` |
 | Staking   | renewPoolLockup                                 | VALIDATOR_MANAGER only  |
 | Staking   | view functions                                  | Anyone                  |
 | StakePool | addStake/unstake/withdrawAvailable/unstakeAndWithdraw/renewLockUntil/withdrawRewards | Staker only (blocked during reconfiguration for mutating funcs) |
@@ -977,6 +986,7 @@ The following errors from `Errors.sol` are used:
 | Error                                                              | When                                   |
 | ------------------------------------------------------------------ | -------------------------------------- |
 | `InsufficientStakeForPoolCreation(uint256 sent, uint256 required)` | msg.value < minimumStake on createPool |
+| `PoolCreationDisabled()`                                           | createPool called by non-GENESIS while `allowPoolCreation = false` |
 | `PoolIndexOutOfBounds(uint256 index, uint256 total)`               | Querying pool at invalid index         |
 | `InvalidPool(address pool)`                                        | Pool status query on non-factory pool  |
 

--- a/src/Genesis.sol
+++ b/src/Genesis.sol
@@ -51,6 +51,7 @@ contract Genesis {
         uint256 minimumStake;
         uint64 lockupDurationMicros;
         uint64 unbondingDelayMicros;
+        bool allowPoolCreation;
     }
 
     struct GovernanceConfigParams {
@@ -196,7 +197,8 @@ contract Genesis {
             .initialize(
                 params.stakingConfig.minimumStake,
                 params.stakingConfig.lockupDurationMicros,
-                params.stakingConfig.unbondingDelayMicros
+                params.stakingConfig.unbondingDelayMicros,
+                params.stakingConfig.allowPoolCreation
             );
 
         EpochConfig(SystemAddresses.EPOCH_CONFIG).initialize(params.epochIntervalMicros);

--- a/src/foundation/Errors.sol
+++ b/src/foundation/Errors.sol
@@ -154,6 +154,9 @@ library Errors {
     /// @notice Validator set changes are disabled
     error ValidatorSetChangesDisabled();
 
+    /// @notice Permissionless pool creation is currently disabled
+    error PoolCreationDisabled();
+
     /// @notice Maximum validator set size reached
     /// @param maxSize The maximum allowed validator set size
     error MaxValidatorSetSizeReached(uint256 maxSize);

--- a/src/runtime/IStakingConfig.sol
+++ b/src/runtime/IStakingConfig.sol
@@ -14,5 +14,8 @@ interface IStakingConfig {
 
     /// @notice Unbonding delay in microseconds (additional wait after lockedUntil before withdrawal)
     function unbondingDelayMicros() external view returns (uint64);
+
+    /// @notice Whether permissionless pool creation via Staking.createPool is enabled
+    function allowPoolCreation() external view returns (bool);
 }
 

--- a/src/runtime/StakingConfig.sol
+++ b/src/runtime/StakingConfig.sol
@@ -61,6 +61,21 @@ contract StakingConfig {
     /// @notice Whether a pending configuration exists
     bool public hasPendingConfig;
 
+    /// @notice Whether permissionless pool creation via Staking.createPool is enabled.
+    /// @dev When false, only GENESIS may create pools (see Staking.createPool).
+    ///      Toggled via governance through setAllowPoolCreationForNextEpoch /
+    ///      applyPendingConfig. Packs with `hasPendingConfig` to preserve the
+    ///      storage layout of deployed contracts (append-only).
+    bool public allowPoolCreation;
+
+    /// @notice Pending value for `allowPoolCreation`, applied at the next epoch boundary.
+    bool private _pendingAllowPoolCreation;
+
+    /// @notice Whether a pending `allowPoolCreation` change exists.
+    /// @dev Independent from `hasPendingConfig` so the two governance paths
+    ///      (main staking config vs. pool-creation gate) don't interfere.
+    bool private _hasPendingAllowPoolCreation;
+
     // ========================================================================
     // EVENTS
     // ========================================================================
@@ -74,6 +89,12 @@ contract StakingConfig {
     /// @notice Emitted when pending configuration is cleared (applied or removed)
     event PendingStakingConfigCleared();
 
+    /// @notice Emitted when governance queues a change to `allowPoolCreation`
+    event PendingAllowPoolCreationSet(bool value);
+
+    /// @notice Emitted when `allowPoolCreation` is applied at an epoch boundary
+    event AllowPoolCreationUpdated(bool value);
+
     // ========================================================================
     // INITIALIZATION
     // ========================================================================
@@ -83,10 +104,12 @@ contract StakingConfig {
     /// @param _minimumStake Minimum stake for governance participation (must be > 0)
     /// @param _lockupDurationMicros Lockup duration in microseconds (must be > 0)
     /// @param _unbondingDelayMicros Unbonding delay in microseconds (must be > 0)
+    /// @param _allowPoolCreation Whether permissionless Staking.createPool is enabled
     function initialize(
         uint256 _minimumStake,
         uint64 _lockupDurationMicros,
-        uint64 _unbondingDelayMicros
+        uint64 _unbondingDelayMicros,
+        bool _allowPoolCreation
     ) external {
         requireAllowed(SystemAddresses.GENESIS);
         if (_initialized) revert Errors.AlreadyInitialized();
@@ -95,6 +118,7 @@ contract StakingConfig {
         minimumStake = _minimumStake;
         lockupDurationMicros = _lockupDurationMicros;
         unbondingDelayMicros = _unbondingDelayMicros;
+        allowPoolCreation = _allowPoolCreation;
         _initialized = true;
 
         emit StakingConfigUpdated();
@@ -146,28 +170,53 @@ contract StakingConfig {
         emit PendingStakingConfigSet();
     }
 
+    /// @notice Queue a change to `allowPoolCreation` for the next epoch
+    /// @dev Only callable by GOVERNANCE. Applied at the next epoch boundary
+    ///      by applyPendingConfig(). Independent from the atomic `setForNextEpoch`
+    ///      pathway so flipping this gate does not require re-specifying other fields.
+    /// @param _allowPoolCreation New value to apply next epoch
+    function setAllowPoolCreationForNextEpoch(
+        bool _allowPoolCreation
+    ) external {
+        requireAllowed(SystemAddresses.GOVERNANCE);
+        _requireInitialized();
+
+        _pendingAllowPoolCreation = _allowPoolCreation;
+        _hasPendingAllowPoolCreation = true;
+        emit PendingAllowPoolCreationSet(_allowPoolCreation);
+    }
+
     // ========================================================================
     // EPOCH TRANSITION (RECONFIGURATION only)
     // ========================================================================
 
     /// @notice Apply pending configuration at epoch boundary
     /// @dev Only callable by RECONFIGURATION during epoch transition.
-    ///      If no pending config exists, this is a no-op.
+    ///      Applies the atomic staking-config pending block AND the independent
+    ///      `allowPoolCreation` pending flip, if either is set. No-op if neither is set.
     function applyPendingConfig() external {
         requireAllowed(SystemAddresses.RECONFIGURATION);
         _requireInitialized();
-        if (!hasPendingConfig) return;
 
-        minimumStake = _pendingConfig.minimumStake;
-        lockupDurationMicros = _pendingConfig.lockupDurationMicros;
-        unbondingDelayMicros = _pendingConfig.unbondingDelayMicros;
-        hasPendingConfig = false;
+        if (hasPendingConfig) {
+            minimumStake = _pendingConfig.minimumStake;
+            lockupDurationMicros = _pendingConfig.lockupDurationMicros;
+            unbondingDelayMicros = _pendingConfig.unbondingDelayMicros;
+            hasPendingConfig = false;
 
-        // Clear pending config storage
-        delete _pendingConfig;
+            // Clear pending config storage
+            delete _pendingConfig;
 
-        emit StakingConfigUpdated();
-        emit PendingStakingConfigCleared();
+            emit StakingConfigUpdated();
+            emit PendingStakingConfigCleared();
+        }
+
+        if (_hasPendingAllowPoolCreation) {
+            allowPoolCreation = _pendingAllowPoolCreation;
+            _hasPendingAllowPoolCreation = false;
+            _pendingAllowPoolCreation = false;
+            emit AllowPoolCreationUpdated(allowPoolCreation);
+        }
     }
 
     // ========================================================================

--- a/src/staking/Staking.sol
+++ b/src/staking/Staking.sol
@@ -189,10 +189,8 @@ contract Staking is IStaking {
 
         // Gate permissionless pool creation; Genesis is always allowed so it can
         // bootstrap the founding validator pools even while the gate is closed.
-        if (
-            msg.sender != SystemAddresses.GENESIS
-                && !IStakingConfig(SystemAddresses.STAKE_CONFIG).allowPoolCreation()
-        ) {
+        if (msg.sender != SystemAddresses.GENESIS && !IStakingConfig(SystemAddresses.STAKE_CONFIG).allowPoolCreation())
+        {
             revert Errors.PoolCreationDisabled();
         }
 

--- a/src/staking/Staking.sol
+++ b/src/staking/Staking.sol
@@ -187,6 +187,15 @@ contract Staking is IStaking {
             revert Errors.ReconfigurationInProgress();
         }
 
+        // Gate permissionless pool creation; Genesis is always allowed so it can
+        // bootstrap the founding validator pools even while the gate is closed.
+        if (
+            msg.sender != SystemAddresses.GENESIS
+                && !IStakingConfig(SystemAddresses.STAKE_CONFIG).allowPoolCreation()
+        ) {
+            revert Errors.PoolCreationDisabled();
+        }
+
         // Validate critical addresses are not zero
         if (owner == address(0)) revert Errors.ZeroAddress();
         if (staker == address(0)) revert Errors.ZeroAddress();

--- a/test/unit/GenesisTest.t.sol
+++ b/test/unit/GenesisTest.t.sol
@@ -74,6 +74,7 @@ contract GenesisTest is Test {
         params.stakingConfig.minimumStake = 10 ether;
         params.stakingConfig.lockupDurationMicros = 14 days * 1_000_000;
         params.stakingConfig.unbondingDelayMicros = 7 days * 1_000_000;
+        params.stakingConfig.allowPoolCreation = false;
 
         // Epoch Config
         params.epochIntervalMicros = 1 hours * 1_000_000;

--- a/test/unit/blocker/Blocker.t.sol
+++ b/test/unit/blocker/Blocker.t.sol
@@ -181,7 +181,8 @@ contract BlockerTest is Test {
             .initialize(
                 1 ether, // minimumStake
                 30 days * 1_000_000, // lockupDurationMicros
-                7 days * 1_000_000 // unbondingDelayMicros
+                7 days * 1_000_000, // unbondingDelayMicros
+                true // allowPoolCreation
             );
 
         // Setup mock validators

--- a/test/unit/blocker/Reconfiguration.t.sol
+++ b/test/unit/blocker/Reconfiguration.t.sol
@@ -198,7 +198,8 @@ contract ReconfigurationTest is Test {
             .initialize(
                 1 ether, // minimumStake
                 30 days * 1_000_000, // lockupDurationMicros
-                7 days * 1_000_000 // unbondingDelayMicros
+                7 days * 1_000_000, // unbondingDelayMicros
+                true // allowPoolCreation
             );
 
         // Setup mock validators

--- a/test/unit/governance/Governance.t.sol
+++ b/test/unit/governance/Governance.t.sol
@@ -85,7 +85,7 @@ contract GovernanceTest is Test {
 
         // Initialize StakingConfig
         vm.prank(SystemAddresses.GENESIS);
-        stakingConfig.initialize(MIN_STAKE, LOCKUP_DURATION_MICROS, UNBONDING_DELAY_MICROS);
+        stakingConfig.initialize(MIN_STAKE, LOCKUP_DURATION_MICROS, UNBONDING_DELAY_MICROS, true);
 
         // Deploy Staking
         vm.etch(SystemAddresses.STAKING, address(new Staking()).code);

--- a/test/unit/integration/ConsensusEngineFlow.t.sol
+++ b/test/unit/integration/ConsensusEngineFlow.t.sol
@@ -142,7 +142,7 @@ contract ConsensusEngineFlowTest is Test {
 
         // Initialize configs
         vm.prank(SystemAddresses.GENESIS);
-        stakingConfig.initialize(MIN_STAKE, LOCKUP_DURATION, UNBONDING_DELAY);
+        stakingConfig.initialize(MIN_STAKE, LOCKUP_DURATION, UNBONDING_DELAY, true);
 
         vm.prank(SystemAddresses.GENESIS);
         validatorConfig.initialize(

--- a/test/unit/runtime/StakingConfig.t.sol
+++ b/test/unit/runtime/StakingConfig.t.sol
@@ -39,7 +39,7 @@ contract StakingConfigTest is Test {
 
     function test_Initialize() public {
         vm.prank(SystemAddresses.GENESIS);
-        config.initialize(MIN_STAKE, LOCKUP_DURATION, UNBONDING_DELAY);
+        config.initialize(MIN_STAKE, LOCKUP_DURATION, UNBONDING_DELAY, false);
 
         assertEq(config.minimumStake(), MIN_STAKE);
         assertEq(config.lockupDurationMicros(), LOCKUP_DURATION);
@@ -50,35 +50,35 @@ contract StakingConfigTest is Test {
     function test_RevertWhen_Initialize_ZeroMinimumStake() public {
         vm.prank(SystemAddresses.GENESIS);
         vm.expectRevert(Errors.InvalidMinimumStake.selector);
-        config.initialize(0, LOCKUP_DURATION, UNBONDING_DELAY);
+        config.initialize(0, LOCKUP_DURATION, UNBONDING_DELAY, false);
     }
 
     function test_RevertWhen_Initialize_ZeroLockupDuration() public {
         vm.prank(SystemAddresses.GENESIS);
         vm.expectRevert(Errors.InvalidLockupDuration.selector);
-        config.initialize(MIN_STAKE, 0, UNBONDING_DELAY);
+        config.initialize(MIN_STAKE, 0, UNBONDING_DELAY, false);
     }
 
     function test_RevertWhen_Initialize_ZeroUnbondingDelay() public {
         vm.prank(SystemAddresses.GENESIS);
         vm.expectRevert(Errors.InvalidUnbondingDelay.selector);
-        config.initialize(MIN_STAKE, LOCKUP_DURATION, 0);
+        config.initialize(MIN_STAKE, LOCKUP_DURATION, 0, false);
     }
 
     function test_RevertWhen_Initialize_AlreadyInitialized() public {
         vm.prank(SystemAddresses.GENESIS);
-        config.initialize(MIN_STAKE, LOCKUP_DURATION, UNBONDING_DELAY);
+        config.initialize(MIN_STAKE, LOCKUP_DURATION, UNBONDING_DELAY, false);
 
         vm.prank(SystemAddresses.GENESIS);
         vm.expectRevert(Errors.AlreadyInitialized.selector);
-        config.initialize(MIN_STAKE * 2, LOCKUP_DURATION, UNBONDING_DELAY);
+        config.initialize(MIN_STAKE * 2, LOCKUP_DURATION, UNBONDING_DELAY, false);
     }
 
     function test_RevertWhen_Initialize_NotGenesis() public {
         address notGenesis = address(0x1234);
         vm.prank(notGenesis);
         vm.expectRevert(abi.encodeWithSelector(NotAllowed.selector, notGenesis, SystemAddresses.GENESIS));
-        config.initialize(MIN_STAKE, LOCKUP_DURATION, UNBONDING_DELAY);
+        config.initialize(MIN_STAKE, LOCKUP_DURATION, UNBONDING_DELAY, false);
     }
 
     // ========================================================================
@@ -286,7 +286,7 @@ contract StakingConfigTest is Test {
         vm.assume(unbondingDelay > 0 && unbondingDelay <= config.MAX_UNBONDING_DELAY());
 
         vm.prank(SystemAddresses.GENESIS);
-        config.initialize(minStake, lockupDuration, unbondingDelay);
+        config.initialize(minStake, lockupDuration, unbondingDelay, false);
 
         assertEq(config.minimumStake(), minStake);
         assertEq(config.lockupDurationMicros(), lockupDuration);
@@ -319,7 +319,7 @@ contract StakingConfigTest is Test {
         uint64 excessiveLockup = maxLockup + 1;
         vm.prank(SystemAddresses.GENESIS);
         vm.expectRevert(abi.encodeWithSelector(Errors.ExcessiveDuration.selector, excessiveLockup, maxLockup));
-        config.initialize(MIN_STAKE, excessiveLockup, UNBONDING_DELAY);
+        config.initialize(MIN_STAKE, excessiveLockup, UNBONDING_DELAY, false);
     }
 
     function test_RevertWhen_Initialize_ExcessiveUnbondingDelay() public {
@@ -327,7 +327,7 @@ contract StakingConfigTest is Test {
         uint64 excessiveUnbonding = maxUnbonding + 1;
         vm.prank(SystemAddresses.GENESIS);
         vm.expectRevert(abi.encodeWithSelector(Errors.ExcessiveDuration.selector, excessiveUnbonding, maxUnbonding));
-        config.initialize(MIN_STAKE, LOCKUP_DURATION, excessiveUnbonding);
+        config.initialize(MIN_STAKE, LOCKUP_DURATION, excessiveUnbonding, false);
     }
 
     // ========================================================================
@@ -336,6 +336,6 @@ contract StakingConfigTest is Test {
 
     function _initializeConfig() internal {
         vm.prank(SystemAddresses.GENESIS);
-        config.initialize(MIN_STAKE, LOCKUP_DURATION, UNBONDING_DELAY);
+        config.initialize(MIN_STAKE, LOCKUP_DURATION, UNBONDING_DELAY, false);
     }
 }

--- a/test/unit/staking/StakerSeparation.t.sol
+++ b/test/unit/staking/StakerSeparation.t.sol
@@ -66,7 +66,7 @@ contract StakerSeparationTest is Test {
         vm.etch(SystemAddresses.RECONFIGURATION, address(new MockReconfiguration2()).code);
 
         vm.prank(SystemAddresses.GENESIS);
-        stakingConfig.initialize(MIN_STAKE, LOCKUP_DURATION, UNBONDING_DELAY);
+        stakingConfig.initialize(MIN_STAKE, LOCKUP_DURATION, UNBONDING_DELAY, true);
 
         vm.prank(SystemAddresses.BLOCK);
         timestamp.updateGlobalTime(ownerAddr, INITIAL_TIMESTAMP);

--- a/test/unit/staking/Staking.t.sol
+++ b/test/unit/staking/Staking.t.sol
@@ -74,7 +74,7 @@ contract StakingTest is Test {
 
         // Initialize StakingConfig with unbonding delay
         vm.prank(SystemAddresses.GENESIS);
-        stakingConfig.initialize(MIN_STAKE, LOCKUP_DURATION, UNBONDING_DELAY);
+        stakingConfig.initialize(MIN_STAKE, LOCKUP_DURATION, UNBONDING_DELAY, true);
 
         // Set initial timestamp
         vm.prank(SystemAddresses.BLOCK);

--- a/test/unit/staking/StakingPoolCreationGate.t.sol
+++ b/test/unit/staking/StakingPoolCreationGate.t.sol
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import { Test } from "forge-std/Test.sol";
+import { Staking } from "../../../src/staking/Staking.sol";
+import { StakingConfig } from "../../../src/runtime/StakingConfig.sol";
+import { Timestamp } from "../../../src/runtime/Timestamp.sol";
+import { SystemAddresses } from "../../../src/foundation/SystemAddresses.sol";
+import { Errors } from "../../../src/foundation/Errors.sol";
+import { ValidatorStatus } from "../../../src/foundation/Types.sol";
+
+contract MockValidatorManagementGate {
+    function isValidator(
+        address
+    ) external pure returns (bool) {
+        return false;
+    }
+
+    function getValidatorStatus(
+        address
+    ) external pure returns (ValidatorStatus) {
+        return ValidatorStatus.INACTIVE;
+    }
+}
+
+contract MockReconfigurationGate {
+    function isTransitionInProgress() external pure returns (bool) {
+        return false;
+    }
+}
+
+/// @title StakingPoolCreationGateTest
+/// @notice Tests for the `allowPoolCreation` gate on Staking.createPool, including
+///         the GENESIS bypass and governance flip via the pending-config pathway.
+contract StakingPoolCreationGateTest is Test {
+    Staking public staking;
+    StakingConfig public stakingConfig;
+    Timestamp public timestamp;
+
+    address public alice = makeAddr("alice");
+
+    uint256 constant MIN_STAKE = 1 ether;
+    uint64 constant LOCKUP_DURATION = 14 days * 1_000_000;
+    uint64 constant UNBONDING_DELAY = 7 days * 1_000_000;
+    uint64 constant INITIAL_TIMESTAMP = 1_000_000_000_000_000;
+
+    function setUp() public {
+        vm.etch(SystemAddresses.STAKE_CONFIG, address(new StakingConfig()).code);
+        stakingConfig = StakingConfig(SystemAddresses.STAKE_CONFIG);
+
+        vm.etch(SystemAddresses.TIMESTAMP, address(new Timestamp()).code);
+        timestamp = Timestamp(SystemAddresses.TIMESTAMP);
+
+        vm.etch(SystemAddresses.STAKING, address(new Staking()).code);
+        staking = Staking(SystemAddresses.STAKING);
+
+        vm.etch(SystemAddresses.VALIDATOR_MANAGER, address(new MockValidatorManagementGate()).code);
+        vm.etch(SystemAddresses.RECONFIGURATION, address(new MockReconfigurationGate()).code);
+
+        // Initialize with allowPoolCreation = false (mainnet-launch default)
+        vm.prank(SystemAddresses.GENESIS);
+        stakingConfig.initialize(MIN_STAKE, LOCKUP_DURATION, UNBONDING_DELAY, false);
+
+        vm.prank(SystemAddresses.BLOCK);
+        timestamp.updateGlobalTime(alice, INITIAL_TIMESTAMP);
+
+        vm.deal(alice, 100 ether);
+        vm.deal(SystemAddresses.GENESIS, 100 ether);
+    }
+
+    function _createPoolAs(
+        address caller
+    ) internal returns (address) {
+        uint64 lockedUntil = INITIAL_TIMESTAMP + LOCKUP_DURATION;
+        vm.prank(caller);
+        return staking.createPool{ value: MIN_STAKE }(alice, alice, alice, alice, lockedUntil);
+    }
+
+    // --------------------------------------------------------------------
+    // Gate blocks permissionless creation when allowPoolCreation is false
+    // --------------------------------------------------------------------
+
+    function test_createPool_RevertsWhenDisabled_ForExternalCaller() public {
+        uint64 lockedUntil = INITIAL_TIMESTAMP + LOCKUP_DURATION;
+
+        vm.prank(alice);
+        vm.expectRevert(Errors.PoolCreationDisabled.selector);
+        staking.createPool{ value: MIN_STAKE }(alice, alice, alice, alice, lockedUntil);
+    }
+
+    // --------------------------------------------------------------------
+    // GENESIS bypass works regardless of flag state
+    // --------------------------------------------------------------------
+
+    function test_createPool_GenesisCanBypassWhenDisabled() public {
+        address pool = _createPoolAs(SystemAddresses.GENESIS);
+        assertTrue(staking.isPool(pool), "Genesis-created pool should be registered");
+        assertEq(staking.getPoolCount(), 1, "Pool count should be 1");
+    }
+
+    // --------------------------------------------------------------------
+    // Governance flip takes effect at epoch boundary
+    // --------------------------------------------------------------------
+
+    function test_createPool_GovernanceFlip_TakesEffectAfterApply() public {
+        uint64 lockedUntil = INITIAL_TIMESTAMP + LOCKUP_DURATION;
+
+        // Queue the flip via governance (dedicated setter — independent of the
+        // atomic setForNextEpoch path)
+        vm.prank(SystemAddresses.GOVERNANCE);
+        stakingConfig.setAllowPoolCreationForNextEpoch(true);
+
+        // Before apply: gate is still closed for external callers
+        vm.prank(alice);
+        vm.expectRevert(Errors.PoolCreationDisabled.selector);
+        staking.createPool{ value: MIN_STAKE }(alice, alice, alice, alice, lockedUntil);
+
+        // Apply at epoch boundary
+        vm.prank(SystemAddresses.RECONFIGURATION);
+        stakingConfig.applyPendingConfig();
+
+        assertTrue(stakingConfig.allowPoolCreation(), "Flag should be true after apply");
+
+        // After apply: external caller can create
+        address pool = _createPoolAs(alice);
+        assertTrue(staking.isPool(pool), "External caller should succeed after flip");
+    }
+
+    // --------------------------------------------------------------------
+    // Governance can flip back to closed
+    // --------------------------------------------------------------------
+
+    function test_createPool_GovernanceFlipBack_RecloseGate() public {
+        uint64 lockedUntil = INITIAL_TIMESTAMP + LOCKUP_DURATION;
+
+        // Open the gate
+        vm.prank(SystemAddresses.GOVERNANCE);
+        stakingConfig.setAllowPoolCreationForNextEpoch(true);
+        vm.prank(SystemAddresses.RECONFIGURATION);
+        stakingConfig.applyPendingConfig();
+
+        // External caller can create while open
+        address pool = _createPoolAs(alice);
+        assertTrue(staking.isPool(pool), "External caller should succeed while open");
+
+        // Close it again
+        vm.prank(SystemAddresses.GOVERNANCE);
+        stakingConfig.setAllowPoolCreationForNextEpoch(false);
+        vm.prank(SystemAddresses.RECONFIGURATION);
+        stakingConfig.applyPendingConfig();
+
+        assertFalse(stakingConfig.allowPoolCreation(), "Flag should be false after re-close");
+
+        // External caller blocked again
+        vm.prank(alice);
+        vm.expectRevert(Errors.PoolCreationDisabled.selector);
+        staking.createPool{ value: MIN_STAKE }(alice, alice, alice, alice, lockedUntil);
+
+        // GENESIS still bypasses
+        address genesisPool = _createPoolAs(SystemAddresses.GENESIS);
+        assertTrue(staking.isPool(genesisPool), "Genesis should still bypass after re-close");
+    }
+}

--- a/test/unit/staking/ValidatorManagement.t.sol
+++ b/test/unit/staking/ValidatorManagement.t.sol
@@ -99,7 +99,7 @@ contract ValidatorManagementTest is Test {
 
         // Initialize StakingConfig (with unbonding delay)
         vm.prank(SystemAddresses.GENESIS);
-        stakingConfig.initialize(MIN_STAKE, LOCKUP_DURATION, UNBONDING_DELAY);
+        stakingConfig.initialize(MIN_STAKE, LOCKUP_DURATION, UNBONDING_DELAY, true);
 
         // Initialize ValidatorConfig
         vm.prank(SystemAddresses.GENESIS);


### PR DESCRIPTION
## Summary
- Add `allowPoolCreation: bool` to `StakingConfig`; default `false`; Genesis bypass in `Staking.createPool`
- Dedicated governance setter `setAllowPoolCreationForNextEpoch(bool)` with independent pending state — flip takes effect at the next epoch boundary via `applyPendingConfig`
- `Genesis.initialize` signature extended; `genesis-tool` JSON makes the field optional via `#[serde(default)]` so unchanged configs behave as before (closed)

## Why
For mainnet bootstrap we want only the 7 genesis validators' pools to exist. The existing `allowValidatorSetChange` gates validator registration only, not pool creation — external parties could still deploy empty StakePool contracts and clutter state. This adds an independent gate at the factory.

## Storage layout
The flag and its pending state are implemented as **append-only** `bool` fields that pack into slot 7 offsets 1-3, alongside the existing `hasPendingConfig` at slot 7 offset 0. **The `PendingConfig` struct is NOT modified**, so `hasPendingConfig` stays at its original slot and no downstream slots shift. This is safe for in-place upgrades of already-deployed `StakingConfig` instances on testnet/mainnet — existing state reads from the same slots, the three new bytes default to zero (= closed gate).

`forge inspect StakingConfig storageLayout` confirms no shift:
- slots 0-6: unchanged
- slot 7 offset 0: `hasPendingConfig` (unchanged)
- slot 7 offsets 1-3: `allowPoolCreation`, `_pendingAllowPoolCreation`, `_hasPendingAllowPoolCreation` (new, previously unused bytes)

## Test plan
- [x] `forge test` — 939 tests pass (includes 4 new gate tests in `test/unit/staking/StakingPoolCreationGate.t.sol`)
- [x] `cd genesis-tool && cargo build` passes
- [x] `forge inspect StakingConfig storageLayout` confirms upgrade-safe append-only layout
- [x] New tests cover: default-false blocks non-GENESIS caller; GENESIS bypass works; governance flip via `setAllowPoolCreationForNextEpoch` + `applyPendingConfig` opens the gate at epoch boundary; flip back re-closes the gate; GENESIS still bypasses after re-close
- [x] Existing `StakingConfig.t.sol` (atomic `setForNextEpoch` path) unchanged — confirms dedicated flag path doesn't interfere

## Deployment notes
- **Fresh chains** (mainnet genesis): pass `allowPoolCreation: false` (or omit from JSON — defaults to false). Genesis bypasses and creates the 7 founding pools; no external pool creation post-genesis until governance flips.
- **Existing testnets with deployed `StakingConfig`**: `initialize(4 args)` cannot be called again (guarded by `_initialized`), so the contract upgrade reads `allowPoolCreation = 0 (false)` from the previously-unused byte. Governance can immediately use `setAllowPoolCreationForNextEpoch(true)` to reopen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)