### PR TITLE
fix(reconfiguration): apply ValidatorConfig before DKG snapshot to prevent target set divergence (#112)

### DIFF
--- a/src/blocker/Reconfiguration.sol
+++ b/src/blocker/Reconfiguration.sol
@@ -107,6 +107,13 @@ contract Reconfiguration is IReconfiguration {
             // Simple reconfiguration: DKG disabled, do immediate epoch transition
             _doImmediateReconfigure();
         } else {
+            // Apply ValidatorConfig before DKG starts so that the target validator set
+            // snapshot uses the same config values that onNewEpoch() will read later.
+            // Without this, pending changes to minimumBond/maximumBond/votingPowerIncreaseLimitPct
+            // cause the DKG target set to diverge from the actual epoch set.
+            // See: docs/dkg-config-divergence-analysis.md, gravity-audit#112
+            ValidatorConfig(SystemAddresses.VALIDATOR_CONFIG).applyPendingConfig();
+
             // Async reconfiguration with DKG: start DKG session
             _startDkgSession(config);
         }
@@ -160,6 +167,11 @@ contract Reconfiguration is IReconfiguration {
             // DKG disabled: perform immediate reconfigure
             _doImmediateReconfigure();
         } else {
+            // Apply ValidatorConfig before DKG starts so that the target validator set
+            // snapshot uses the same config values that onNewEpoch() will read later.
+            // See: docs/dkg-config-divergence-analysis.md, gravity-audit#112
+            ValidatorConfig(SystemAddresses.VALIDATOR_CONFIG).applyPendingConfig();
+
             // DKG enabled: start DKG session
             _startDkgSession(config);
         }
@@ -267,6 +279,7 @@ contract Reconfiguration is IReconfiguration {
         IRandomnessConfig(SystemAddresses.RANDOMNESS_CONFIG).applyPendingConfig();
         ConsensusConfig(SystemAddresses.CONSENSUS_CONFIG).applyPendingConfig();
         ExecutionConfig(SystemAddresses.EXECUTION_CONFIG).applyPendingConfig();
+        // NOTE: ValidatorConfig may already be applied (by _startDkgSession path); this is a safe no-op.
         ValidatorConfig(SystemAddresses.VALIDATOR_CONFIG).applyPendingConfig();
         VersionConfig(SystemAddresses.VERSION_CONFIG).applyPendingConfig();
         GovernanceConfig(SystemAddresses.GOVERNANCE_CONFIG).applyPendingConfig();

--- a/test/unit/blocker/Reconfiguration.t.sol
+++ b/test/unit/blocker/Reconfiguration.t.sol
@@ -777,5 +777,143 @@ contract ReconfigurationTest is Test {
         // Verify: targets array has 2 elements (indices 0 and 1 implicitly)
         // The DKG module will use these for the next epoch's key distribution
     }
+
+    // ========================================================================
+    // DKG CONFIG DIVERGENCE FIX TESTS (gravity-audit#112)
+    // ========================================================================
+
+    /// @notice Verify that checkAndStartTransition applies pending ValidatorConfig
+    ///         before starting DKG, so the target set snapshot uses the new config.
+    function test_checkAndStartTransition_appliesValidatorConfigBeforeDkg() public {
+        _initializeReconfiguration();
+
+        // Queue a pending ValidatorConfig change (raise minimumBond)
+        vm.prank(SystemAddresses.GOVERNANCE);
+        ValidatorConfig(SystemAddresses.VALIDATOR_CONFIG).setForNextEpoch(
+            50 ether, // minimumBond: 10 → 50
+            1000 ether,
+            7 days * 1_000_000,
+            true,
+            20,
+            100,
+            false,
+            0
+        );
+        assertTrue(ValidatorConfig(SystemAddresses.VALIDATOR_CONFIG).hasPendingConfig());
+
+        // Start transition (DKG path since RandomnessConfig is V2)
+        _advanceTime(TWO_HOURS + 1);
+        _startTransition();
+
+        // After checkAndStartTransition, pending ValidatorConfig should already be applied
+        assertFalse(
+            ValidatorConfig(SystemAddresses.VALIDATOR_CONFIG).hasPendingConfig(),
+            "ValidatorConfig pending should be cleared before DKG starts"
+        );
+        assertEq(
+            ValidatorConfig(SystemAddresses.VALIDATOR_CONFIG).minimumBond(),
+            50 ether,
+            "minimumBond should reflect the new value before DKG snapshot"
+        );
+    }
+
+    /// @notice Verify that governanceReconfigure also applies pending ValidatorConfig
+    ///         before starting DKG.
+    function test_governanceReconfigure_appliesValidatorConfigBeforeDkg() public {
+        _initializeReconfiguration();
+
+        // Queue a pending ValidatorConfig change (lower maximumBond)
+        vm.prank(SystemAddresses.GOVERNANCE);
+        ValidatorConfig(SystemAddresses.VALIDATOR_CONFIG).setForNextEpoch(
+            10 ether,
+            100 ether, // maximumBond: 1000 → 100
+            7 days * 1_000_000,
+            true,
+            20,
+            100,
+            false,
+            0
+        );
+        assertTrue(ValidatorConfig(SystemAddresses.VALIDATOR_CONFIG).hasPendingConfig());
+
+        // Governance triggers reconfigure (DKG path since RandomnessConfig is V2)
+        vm.prank(SystemAddresses.GOVERNANCE);
+        Reconfiguration(SystemAddresses.RECONFIGURATION).governanceReconfigure();
+
+        // After governanceReconfigure, pending ValidatorConfig should already be applied
+        assertFalse(
+            ValidatorConfig(SystemAddresses.VALIDATOR_CONFIG).hasPendingConfig(),
+            "ValidatorConfig pending should be cleared before DKG starts"
+        );
+        assertEq(
+            ValidatorConfig(SystemAddresses.VALIDATOR_CONFIG).maximumBond(),
+            100 ether,
+            "maximumBond should reflect the new value before DKG snapshot"
+        );
+    }
+
+    /// @notice Verify that the ValidatorConfig.applyPendingConfig() call in
+    ///         _applyReconfiguration() is a safe no-op when already applied.
+    function test_finishTransition_validatorConfigApplyIsNoopAfterEarlyApply() public {
+        _initializeReconfiguration();
+
+        // Queue pending config
+        vm.prank(SystemAddresses.GOVERNANCE);
+        ValidatorConfig(SystemAddresses.VALIDATOR_CONFIG).setForNextEpoch(
+            50 ether, 1000 ether, 7 days * 1_000_000, true, 20, 100, false, 0
+        );
+
+        // Start transition (applies ValidatorConfig early)
+        _advanceTime(TWO_HOURS + 1);
+        _startTransition();
+
+        // Verify config is already applied
+        assertEq(ValidatorConfig(SystemAddresses.VALIDATOR_CONFIG).minimumBond(), 50 ether);
+        assertFalse(ValidatorConfig(SystemAddresses.VALIDATOR_CONFIG).hasPendingConfig());
+
+        // Finish transition — _applyReconfiguration calls applyPendingConfig again (no-op)
+        _finishTransition(SAMPLE_TRANSCRIPT);
+
+        // Config should still be the new value (not reverted or double-applied)
+        assertEq(
+            ValidatorConfig(SystemAddresses.VALIDATOR_CONFIG).minimumBond(),
+            50 ether,
+            "Config value should survive the no-op re-apply in finishTransition"
+        );
+        assertEq(Reconfiguration(SystemAddresses.RECONFIGURATION).currentEpoch(), 2);
+    }
+
+    /// @notice When DKG is off (immediate reconfigure), ValidatorConfig is NOT applied early.
+    ///         It's applied normally in _applyReconfiguration(). This is correct because
+    ///         there's no DKG snapshot to diverge from.
+    function test_immediateReconfigure_appliesValidatorConfigNormally() public {
+        // Re-initialize RandomnessConfig as Off (DKG disabled)
+        vm.prank(SystemAddresses.GOVERNANCE);
+        RandomnessConfig(SystemAddresses.RANDOMNESS_CONFIG).setForNextEpoch(
+            RandomnessConfig.RandomnessConfigData({
+                variant: RandomnessConfig.ConfigVariant.Off,
+                configV2: RandomnessConfig.ConfigV2Data(0, 0, 0)
+            })
+        );
+        vm.prank(SystemAddresses.RECONFIGURATION);
+        RandomnessConfig(SystemAddresses.RANDOMNESS_CONFIG).applyPendingConfig();
+
+        _initializeReconfiguration();
+
+        // Queue pending ValidatorConfig
+        vm.prank(SystemAddresses.GOVERNANCE);
+        ValidatorConfig(SystemAddresses.VALIDATOR_CONFIG).setForNextEpoch(
+            50 ether, 1000 ether, 7 days * 1_000_000, true, 20, 100, false, 0
+        );
+
+        // Trigger immediate reconfigure (DKG off)
+        _advanceTime(TWO_HOURS + 1);
+        _startTransition();
+
+        // Config is applied in _applyReconfiguration (immediate path)
+        assertEq(ValidatorConfig(SystemAddresses.VALIDATOR_CONFIG).minimumBond(), 50 ether);
+        assertFalse(ValidatorConfig(SystemAddresses.VALIDATOR_CONFIG).hasPendingConfig());
+        assertEq(Reconfiguration(SystemAddresses.RECONFIGURATION).currentEpoch(), 2);
+    }
 }
 

--- a/test/unit/blocker/Reconfiguration.t.sol
+++ b/test/unit/blocker/Reconfiguration.t.sol
@@ -789,16 +789,17 @@ contract ReconfigurationTest is Test {
 
         // Queue a pending ValidatorConfig change (raise minimumBond)
         vm.prank(SystemAddresses.GOVERNANCE);
-        ValidatorConfig(SystemAddresses.VALIDATOR_CONFIG).setForNextEpoch(
-            50 ether, // minimumBond: 10 → 50
-            1000 ether,
-            7 days * 1_000_000,
-            true,
-            20,
-            100,
-            false,
-            0
-        );
+        ValidatorConfig(SystemAddresses.VALIDATOR_CONFIG)
+            .setForNextEpoch(
+                50 ether, // minimumBond: 10 → 50
+                1000 ether,
+                7 days * 1_000_000,
+                true,
+                20,
+                100,
+                false,
+                0
+            );
         assertTrue(ValidatorConfig(SystemAddresses.VALIDATOR_CONFIG).hasPendingConfig());
 
         // Start transition (DKG path since RandomnessConfig is V2)
@@ -824,16 +825,17 @@ contract ReconfigurationTest is Test {
 
         // Queue a pending ValidatorConfig change (lower maximumBond)
         vm.prank(SystemAddresses.GOVERNANCE);
-        ValidatorConfig(SystemAddresses.VALIDATOR_CONFIG).setForNextEpoch(
-            10 ether,
-            100 ether, // maximumBond: 1000 → 100
-            7 days * 1_000_000,
-            true,
-            20,
-            100,
-            false,
-            0
-        );
+        ValidatorConfig(SystemAddresses.VALIDATOR_CONFIG)
+            .setForNextEpoch(
+                10 ether,
+                100 ether, // maximumBond: 1000 → 100
+                7 days * 1_000_000,
+                true,
+                20,
+                100,
+                false,
+                0
+            );
         assertTrue(ValidatorConfig(SystemAddresses.VALIDATOR_CONFIG).hasPendingConfig());
 
         // Governance triggers reconfigure (DKG path since RandomnessConfig is V2)
@@ -859,9 +861,8 @@ contract ReconfigurationTest is Test {
 
         // Queue pending config
         vm.prank(SystemAddresses.GOVERNANCE);
-        ValidatorConfig(SystemAddresses.VALIDATOR_CONFIG).setForNextEpoch(
-            50 ether, 1000 ether, 7 days * 1_000_000, true, 20, 100, false, 0
-        );
+        ValidatorConfig(SystemAddresses.VALIDATOR_CONFIG)
+            .setForNextEpoch(50 ether, 1000 ether, 7 days * 1_000_000, true, 20, 100, false, 0);
 
         // Start transition (applies ValidatorConfig early)
         _advanceTime(TWO_HOURS + 1);
@@ -889,12 +890,12 @@ contract ReconfigurationTest is Test {
     function test_immediateReconfigure_appliesValidatorConfigNormally() public {
         // Re-initialize RandomnessConfig as Off (DKG disabled)
         vm.prank(SystemAddresses.GOVERNANCE);
-        RandomnessConfig(SystemAddresses.RANDOMNESS_CONFIG).setForNextEpoch(
-            RandomnessConfig.RandomnessConfigData({
-                variant: RandomnessConfig.ConfigVariant.Off,
-                configV2: RandomnessConfig.ConfigV2Data(0, 0, 0)
-            })
-        );
+        RandomnessConfig(SystemAddresses.RANDOMNESS_CONFIG)
+            .setForNextEpoch(
+                RandomnessConfig.RandomnessConfigData({
+                    variant: RandomnessConfig.ConfigVariant.Off, configV2: RandomnessConfig.ConfigV2Data(0, 0, 0)
+                })
+            );
         vm.prank(SystemAddresses.RECONFIGURATION);
         RandomnessConfig(SystemAddresses.RANDOMNESS_CONFIG).applyPendingConfig();
 
@@ -902,9 +903,8 @@ contract ReconfigurationTest is Test {
 
         // Queue pending ValidatorConfig
         vm.prank(SystemAddresses.GOVERNANCE);
-        ValidatorConfig(SystemAddresses.VALIDATOR_CONFIG).setForNextEpoch(
-            50 ether, 1000 ether, 7 days * 1_000_000, true, 20, 100, false, 0
-        );
+        ValidatorConfig(SystemAddresses.VALIDATOR_CONFIG)
+            .setForNextEpoch(50 ether, 1000 ether, 7 days * 1_000_000, true, 20, 100, false, 0);
 
         // Trigger immediate reconfigure (DKG off)
         _advanceTime(TWO_HOURS + 1);


### PR DESCRIPTION
When DKG is enabled, the target validator set snapshot was computed using current ValidatorConfig values, but onNewEpoch() read the config after applyPendingConfig() — causing minimumBond/maximumBond/votingPowerIncreaseLimitPct changes to produce a different validator set than what DKG key shares were generated for. Fix: apply ValidatorConfig.applyPendingConfig() before _startDkgSession() in both checkAndStartTransition() and governanceReconfigure().
