### PR TITLE
fix(verify): differentiate revert types in check_exists; route JWKManager checks to 0x…4001

### DIFF
--- a/scripts/verify_hardfork/hardforks/zeta.sh
+++ b/scripts/verify_hardfork/hardforks/zeta.sh
@@ -138,8 +138,11 @@ run_smoke_tests() {
     # Validation tightening is only observable via setPatches() with an empty
     # field in one of the JWKs — that entrypoint is onlyGenesis and calldata-heavy,
     # so we only assert selector presence on the already-exposed views.
-    check_exists  "getProviderCount()"                    "$NATIVE_ORACLE" "getProviderCount()(uint256)"
-    check_exists  "getPatches()"                          "$NATIVE_ORACLE" "getPatches()"
+    # JWKManager lives at its own system address (0x…4001), distinct from
+    # NativeOracle (0x…4000); the two contracts share lineage but expose
+    # different selectors.
+    check_exists  "getProviderCount()"                    "$JWK_MANAGER" "getProviderCount()(uint256)"
+    check_exists  "getPatches()"                          "$JWK_MANAGER" "getPatches()"
     echo ""
 
     # ── ReentrancyGuard persistence check (inherited from Delta) ──────

--- a/scripts/verify_hardfork/lib/addresses.sh
+++ b/scripts/verify_hardfork/lib/addresses.sh
@@ -27,6 +27,7 @@ GOVERNANCE=$(_addr 0x1625F3000)
 
 # ── Oracle (0x1625F4xxx) ─────────────────────────────────────────────
 NATIVE_ORACLE=$(_addr 0x1625F4000)
+JWK_MANAGER=$(_addr 0x1625F4001)
 ORACLE_REQUEST_QUEUE=$(_addr 0x1625F4002)
 
 # ── Genesis (0x1625F0xxx) ────────────────────────────────────────────

--- a/scripts/verify_hardfork/lib/helpers.sh
+++ b/scripts/verify_hardfork/lib/helpers.sh
@@ -80,6 +80,12 @@ check_reverts() {
 
 # check_exists: Verify that a function call does NOT revert (function exists).
 #   check_exists "label" "address" "sig()(returnType)" [args...]
+#
+# Distinguishes two revert flavors:
+#   - Empty revert (no data) ⇒ selector not in dispatcher ⇒ FAIL
+#   - Revert with 4-byte error selector ⇒ function ran, hit require/CustomError ⇒ PASS
+#     (e.g. OwnableUnauthorizedAccount when caller lacks --from, or InvalidMinimumStake
+#      when input fails validation; the dispatcher reaching the body proves existence)
 check_exists() {
     local label="$1"
     local addr="$2"
@@ -87,12 +93,18 @@ check_exists() {
     shift 3
     local args=("$@")
 
-    result=$(cast call "$addr" "$sig" ${args[@]+"${args[@]}"} --rpc-url "$RPC_URL" 2>/dev/null || echo "REVERT")
-
-    if [ "$result" = "REVERT" ]; then
-        fail "${label}: call reverted (function may not exist)"
-    else
+    local output
+    if output=$(cast call "$addr" "$sig" ${args[@]+"${args[@]}"} --rpc-url "$RPC_URL" 2>&1); then
         pass "${label}: OK"
+        return
+    fi
+
+    if echo "$output" | grep -qE 'data: "0x[0-9a-fA-F]{8}'; then
+        local sel
+        sel=$(echo "$output" | grep -oE 'data: "0x[0-9a-fA-F]{8}' | head -1 | sed 's/data: "//')
+        pass "${label}: OK (function exists; reverted with ${sel})"
+    else
+        fail "${label}: call reverted with no data (function may not exist)"
     fi
 }
 


### PR DESCRIPTION
Closes the verify.sh script bugs documented in #88 (sections 2 and 3). The remaining gravity-reth–side hardcoded StakePool address issue is out of scope for this PR.

## Summary

Two fixes to the Zeta hardfork verification flow:

1. **`check_exists` distinguishes revert flavors.** Previously every cast revert was reported as `function may not exist`. EVM distinguishes:
   - **Empty revert (no data)** ⇒ selector not in dispatcher ⇒ true negative.
   - **Revert with 4-byte error selector** ⇒ function ran and hit a `require` / CustomError ⇒ function exists.

   Inspecting the cast error payload for a 4-byte selector lets us pass calls that revert from access control (`OwnableUnauthorizedAccount` when the test omits `--from`) or input validation (`InvalidMinimumStake` when a zero arg is passed), while still failing on a true selector-not-found.

2. **JWKManager smoke tests query the right address.** `hardforks/zeta.sh` queried `getProviderCount` / `getPatches` on `NATIVE_ORACLE` (`0x…4000`); those methods live on **JWKManager** (`0x…4001`). `forge inspect NativeOracle methodIdentifiers` confirms NativeOracle does not expose them. Adds the missing `JWK_MANAGER` constant in `lib/addresses.sh` and updates the two `check_exists` calls.

## Impact

On a 6-node devnet that completed a `gravity-testnet-v1.4.0 → main` rolling upgrade with `zetaBlock = 10000`:

| | Before | After |
|---|---:|---:|
| Passed | 31 | **41** |
| Failed | 12 | 2 |

The 10 newly-passing checks (functions that existed all along but were misreported) are now visible with their revert selector for traceability:

```
✅ setMinimumStakeForNextEpoch() ABI: OK (function exists; reverted with 0x647c942e)
✅ proposeStaker() ABI: OK (function exists; reverted with 0x118cdaa7)
✅ acceptStaker() ABI: OK (function exists; reverted with 0x5f75abf7)
✅ getProviderCount(): OK
…
```

The remaining 2 failures are the gravity-reth hardcoded testnet StakePool address issue affecting StakePool #4 — out of scope for this PR.

## Files

- `scripts/verify_hardfork/lib/helpers.sh` — `check_exists` revert classification.
- `scripts/verify_hardfork/lib/addresses.sh` — add `JWK_MANAGER` constant.
- `scripts/verify_hardfork/hardforks/zeta.sh` — JWKManager calls now target `$JWK_MANAGER`.

## Test plan

- [x] Verified locally on a fresh devnet rolling-upgrade run: `bash scripts/verify_hardfork/verify.sh zeta http://localhost:8545` → `41 passed / 2 failed / 0 skipped`.
- [x] No regressions in the existing gamma verify path (`check_exists` semantics are a strict superset — all old PASSes remain PASS).
- [ ] Re-run on testnet post-Zeta if a maintainer wants additional confirmation.