### PR TITLE
fix(genesis-tool): make genesis JSON output byte-deterministic

### DIFF
--- a/genesis-tool/src/execute.rs
+++ b/genesis-tool/src/execute.rs
@@ -2,7 +2,7 @@ use crate::{
     genesis::{GenesisConfig, call_genesis_initialize, calculate_total_stake},
     utils::{
         CONTRACTS, GENESIS_ADDR, SYSTEM_ACCOUNT_INFO, SYSTEM_CALLER, analyze_txn_result,
-        execute_revm_sequential, read_hex_from_file,
+        execute_revm_sequential, read_hex_from_file, write_json_deterministic,
     },
 };
 
@@ -12,7 +12,7 @@ use revm::{
     primitives::{AccountInfo, Env, SpecId, U256},
 };
 use revm_primitives::{Bytecode, Bytes, TxEnv, hex};
-use std::{collections::HashMap, fs::File, io::BufWriter};
+use std::collections::BTreeMap;
 use tracing::{debug, error, info, warn};
 
 /// Deploy contracts using BSC-style direct bytecode deployment
@@ -205,8 +205,11 @@ pub fn genesis_generate(
         result.len()
     );
 
-    // Add deployed contracts to the final state
-    let mut genesis_state = HashMap::new();
+    // Add deployed contracts to the final state.
+    // BTreeMap keeps the top-level address ordering stable; the per-account
+    // storage HashMaps and the bundle_state's internal HashMaps are sorted at
+    // serialization time by `write_json_deterministic`.
+    let mut genesis_state: BTreeMap<_, PlainAccount> = BTreeMap::new();
 
     for (contract_name, contract_address) in CONTRACTS {
         let hex_path = format!("{}/{}.hex", byte_code_dir, contract_name);
@@ -266,11 +269,7 @@ pub fn genesis_generate(
     }
 
     // write bundle state into one json file named bundle_state.json
-    serde_json::to_writer_pretty(
-        BufWriter::new(File::create(format!("{output_dir}/bundle_state.json")).unwrap()),
-        &bundle_state,
-    )
-    .unwrap();
+    write_json_deterministic(format!("{output_dir}/bundle_state.json"), &bundle_state).unwrap();
 
     info!(
         "bundle state size is {:?}, contracts size {:?}",
@@ -296,14 +295,14 @@ pub fn genesis_generate(
         }
     }
 
-    serde_json::to_writer_pretty(
-        BufWriter::new(File::create(format!("{output_dir}/genesis_accounts.json")).unwrap()),
+    write_json_deterministic(
+        format!("{output_dir}/genesis_accounts.json"),
         &genesis_state,
     )
     .unwrap();
 
     // Create contracts JSON with bytecode
-    let contracts_json: HashMap<_, _> = genesis_state
+    let contracts_json: BTreeMap<_, _> = genesis_state
         .iter()
         .filter_map(|(addr, account)| {
             account
@@ -314,8 +313,8 @@ pub fn genesis_generate(
         })
         .collect();
 
-    serde_json::to_writer_pretty(
-        BufWriter::new(File::create(format!("{output_dir}/genesis_contracts.json")).unwrap()),
+    write_json_deterministic(
+        format!("{output_dir}/genesis_contracts.json"),
         &contracts_json,
     )
     .unwrap();

--- a/genesis-tool/src/utils.rs
+++ b/genesis-tool/src/utils.rs
@@ -8,7 +8,14 @@ use revm::{
     primitives::{Address, EVMError, Env, ExecutionResult, SpecId, TxEnv, U256},
 };
 use revm_primitives::{AccountInfo, Bytes, KECCAK_EMPTY, TxKind, hex, uint};
-use std::u64;
+use serde::Serialize;
+use serde_json::{Map, Value};
+use std::{
+    fs::File,
+    io::{BufWriter, Result as IoResult},
+    path::Path,
+    u64,
+};
 use tracing::info;
 
 pub const DEAD_ADDRESS: Address = address!("000000000000000000000000000000000000dEaD");
@@ -291,4 +298,66 @@ pub fn new_system_create_txn(hex_code: &str, args: Bytes) -> TxEnv {
 
 pub fn read_hex_from_file(path: &str) -> String {
     std::fs::read_to_string(path).expect(&format!("Failed to open {}", path))
+}
+
+/// Recursively normalize a `serde_json::Value` for deterministic output:
+///   - object keys sorted lexicographically
+///   - arrays whose every element is a 2-element `[string, _]` pair are
+///     sorted by that string. This handles `Vec<(StringLike, V)>` shapes
+///     that Rust produces when a `HashMap` is serialized as a sequence of
+///     pairs (e.g. `revm::db::Reverts` → `Vec<Vec<(Address, AccountRevert)>>`).
+///
+/// `serde_json` is compiled with the `preserve_order` feature transitively
+/// (via reqwest → ethers), so `serde_json::Map` is backed by `IndexMap` and
+/// keeps insertion order — we must rebuild every object by inserting entries
+/// in sorted-key order to get reproducible output.
+fn normalize_value(value: Value) -> Value {
+    match value {
+        Value::Object(map) => {
+            let mut entries: Vec<(String, Value)> = map.into_iter().collect();
+            entries.sort_by(|a, b| a.0.cmp(&b.0));
+            let mut sorted = Map::with_capacity(entries.len());
+            for (k, v) in entries {
+                sorted.insert(k, normalize_value(v));
+            }
+            Value::Object(sorted)
+        }
+        Value::Array(items) => {
+            let mut items: Vec<Value> = items.into_iter().map(normalize_value).collect();
+            // If this looks like a serialized map (`Vec<(string, V)>`), sort by key.
+            // Empty arrays and arrays of non-pair elements are left untouched so we
+            // don't reorder semantically-ordered sequences like the validators list.
+            let is_pair_array = !items.is_empty()
+                && items.iter().all(|el| {
+                    el.as_array()
+                        .map(|a| a.len() == 2 && a[0].is_string())
+                        .unwrap_or(false)
+                });
+            if is_pair_array {
+                items.sort_by(|a, b| {
+                    let ka = a[0].as_str().unwrap_or("");
+                    let kb = b[0].as_str().unwrap_or("");
+                    ka.cmp(kb)
+                });
+            }
+            Value::Array(items)
+        }
+        other => other,
+    }
+}
+
+/// Serialize `value` to `path` as pretty JSON with deterministic ordering of
+/// object keys and `Vec<(string, _)>`-shaped arrays. Guarantees byte-identical
+/// output for byte-identical input, independent of `HashMap` iteration order
+/// in the source data.
+pub fn write_json_deterministic<T, P>(path: P, value: &T) -> IoResult<()>
+where
+    T: Serialize,
+    P: AsRef<Path>,
+{
+    let raw = serde_json::to_value(value).expect("failed to convert value to serde_json::Value");
+    let normalized = normalize_value(raw);
+    let writer = BufWriter::new(File::create(path)?);
+    serde_json::to_writer_pretty(writer, &normalized)?;
+    Ok(())
 }


### PR DESCRIPTION
## Summary

- `bundle_state.json`, `genesis_accounts.json`, `genesis_contracts.json` serialize `HashMap`s (ours and revm's) whose iteration order is non-deterministic, so identical configs produced diff-noisy output and the multi-operator genesis ceremony's byte-reproducibility guarantee was not actually held.
- Added `utils::write_json_deterministic` that serializes via `serde_json::Value`, recursively sorts object keys, and sorts `[[string, _], ...]` pair-arrays by the first element (needed for `revm::db::Reverts = Vec<Vec<(Address, AccountRevert)>>`, which is built from a HashMap). The sort step is necessary because `serde_json` is compiled with `preserve_order` transitively via reqwest, so its `Map` is `IndexMap`-backed and won't sort on its own.
- Replaced the three `to_writer_pretty` calls in `execute.rs` with the helper and switched the top-level `genesis_state` / `contracts_json` containers to `BTreeMap`.

## Test plan

- [x] `cargo build` clean (no new warnings from touched files)
- [x] Ran `genesis-tool generate` twice against the same config; `diff -q` reports all three output files byte-identical
- [x] Spot-checked output: top-level keys alphabetical, `state` map keyed-sorted by address, `reverts[0]` inner array sorted by address
- [x] Validators array in input config is an `Object`-element array (not a pair-array), so the pair-sort heuristic leaves it untouched — no semantic reordering risk

🤖 Generated with [Claude Code](https://claude.com/claude-code)