### PR TITLE
chore: port recent foundry-template fixes (#4, #5)

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -34,9 +34,9 @@ jobs:
           submodules: recursive
 
       - name: Setup Python for security tools
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12'
 
       - name: Run ${{ matrix.tool }} Analysis
         run: make ${{ matrix.tool }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,16 +23,16 @@ jobs:
           submodules: recursive
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: '20'
 
       - name: Install dependencies
         run: yarn install
 
       # Restore Forge cache
       - name: Cache Forge Build
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             cache/

--- a/.github/workflows/typo-check.yml
+++ b/.github/workflows/typo-check.yml
@@ -17,6 +17,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: crate-ci/typos@v1.29.7
+      - uses: crate-ci/typos@v1.46.1
         with:
           config: .github/configs/typos-cli.toml

--- a/.solhint.json
+++ b/.solhint.json
@@ -3,11 +3,11 @@
   "plugins": [],
   "rules": {
     "no-console": "off",
-    "no-global-import": ["off"],
+    "no-global-import": "off",
     "import-path-check": "off",
     "code-complexity": ["warn", 7],
-    "function-max-lines": ["off", 50],
-    "max-line-length": ["off", 120],
+    "function-max-lines": "off",
+    "max-line-length": "off",
     "max-states-count": ["warn", 15],
     "no-empty-blocks": "off",
     "no-unused-vars": "warn",
@@ -43,12 +43,7 @@
         "ignoreConstructors": true
       }
     ],
-    "private-vars-leading-underscore": [
-      "off",
-      {
-        "strict": false
-      }
-    ],
+    "private-vars-leading-underscore": "off",
     "const-name-snakecase": "warn",
     "func-name-mixedcase": "off",
     "use-forbidden-name": "warn",

--- a/foundry.toml
+++ b/foundry.toml
@@ -8,7 +8,6 @@ libs = ["lib"]
 solc = "0.8.30"
 cache = true
 cache_path = 'cache'
-auto_detect_solc = true
 optimizer = true
 optimizer_runs = 200
 via_ir = true

--- a/script/cleanup-demo.sh
+++ b/script/cleanup-demo.sh
@@ -1,59 +1,49 @@
 #!/bin/bash
 
-# Cleanup script to remove demo files from specific directories
-# This script cleans up demo files while preserving folder structure
+# Cleanup script to remove the demo files shipped with the template.
+# Only the specific files added by the template are removed -- any
+# contracts / tests you have written are left alone.
 
 set -e  # Exit on any error
 
 echo "Starting cleanup process..."
 
-# Function to check if directory exists before cleaning
-cleanup_directory() {
-    local dir="$1"
-    local preserve_folders="$2"
-    
-    if [ -d "$dir" ]; then
-        echo "  Cleaning: $dir"
-        if [ "$preserve_folders" = "true" ]; then
-            # Remove files and symbolic links but preserve folders
-            find "$dir" -type f -delete
-            find "$dir" -type l -delete
-        else
-            # Remove everything
-            rm -rf "$dir"/*
-        fi
-    else
-        echo "  Directory $dir does not exist, skipping..."
+# Demo files written by the template:
+DEMO_SRC_FILES=(
+    "src/Counter.sol"
+    "src/CounterV2.sol"
+    "src/VulnerableLendingPool.sol"
+)
+
+DEMO_TEST_FILES=(
+    "test/unit/VulnerableLendingPool.unit.t.sol"
+    "test/fuzz/VulnerableLendingPool.fuzz.t.sol"
+    "test/invariant/VulnerableLendingPool.invariant.t.sol"
+)
+
+remove_if_exists() {
+    local f="$1"
+    if [ -f "$f" ]; then
+        echo "  Removing: $f"
+        rm -f "$f"
     fi
 }
 
-echo "Cleaning src/ directory..."
-cleanup_directory "src" "false"
+echo "Removing demo source files..."
+for f in "${DEMO_SRC_FILES[@]}"; do
+    remove_if_exists "$f"
+done
 
-echo "Cleaning test directories..."
-cleanup_directory "test/unit" "true"
-cleanup_directory "test/fuzz" "true"
-cleanup_directory "test/invariant" "true"
+echo "Removing demo test files..."
+for f in "${DEMO_TEST_FILES[@]}"; do
+    remove_if_exists "$f"
+done
 
-echo "Cleaning audit/ directory..."
-cleanup_directory "audit" "true"
-
-echo "Cleaning script/releases/ directory (preserving README.md)..."
-if [ -d "script/releases" ]; then
-    echo "  Cleaning: script/releases"
-    # Create a temporary directory to store README.md
-    if [ -f "script/releases/README.md" ]; then
-        cp "script/releases/README.md" "/tmp/releases_readme_backup.md"
-    fi
-    # Remove everything in releases
-    rm -rf script/releases/*
-    # Restore README.md if it existed
-    if [ -f "/tmp/releases_readme_backup.md" ]; then
-        cp "/tmp/releases_readme_backup.md" "script/releases/README.md"
-        rm "/tmp/releases_readme_backup.md"
-    fi
-else
-    echo "  Directory script/releases does not exist, skipping..."
+# audit/ is a generated artifact directory -- safe to clear contents.
+if [ -d "audit" ]; then
+    echo "Clearing audit/ directory..."
+    find "audit" -type f -delete
+    find "audit" -type l -delete
 fi
 
 echo "Cleanup completed successfully!"

--- a/script/generate_mythril_report.sh
+++ b/script/generate_mythril_report.sh
@@ -33,24 +33,33 @@ fi
 
 # Check if Mythril is installed
 if ! command -v myth &> /dev/null; then
-  echo -e "${YELLOW}Mythril not found. Attempting to install via pip...${NC}"
-  
-  # Try to install Mythril
-  if command -v pip3 &> /dev/null; then
-    pip3 install mythril
-  elif command -v pip &> /dev/null; then
-    pip install mythril
+  echo -e "${YELLOW}Mythril not found. Attempting to install...${NC}"
+
+  if command -v pipx &> /dev/null; then
+    echo -e "${YELLOW}Installing mythril via pipx...${NC}"
+    pipx install mythril || true
+  elif command -v pip3 &> /dev/null && pip3 install --user --dry-run mythril &> /dev/null; then
+    echo -e "${YELLOW}Installing mythril via pip3 --user...${NC}"
+    pip3 install --user mythril
+  elif command -v pip &> /dev/null && pip install --user --dry-run mythril &> /dev/null; then
+    echo -e "${YELLOW}Installing mythril via pip --user...${NC}"
+    pip install --user mythril
   else
-    echo -e "${RED}Error: pip not found. Please install Python and pip first.${NC}"
-    echo -e "${YELLOW}Installation instructions:${NC}"
-    echo -e "${YELLOW}  pip3 install mythril${NC}"
-    echo -e "${YELLOW}  or use Docker: docker pull mythril/myth${NC}"
+    echo -e "${RED}Error: cannot auto-install mythril.${NC}"
+    echo -e "${YELLOW}Modern Python distributions (PEP 668) block pip from writing to system or user site-packages.${NC}"
+    echo -e "${YELLOW}Install manually with one of:${NC}"
+    echo -e "${YELLOW}  pipx install mythril                     # recommended${NC}"
+    echo -e "${YELLOW}  python3 -m venv .venv && source .venv/bin/activate && pip install mythril${NC}"
+    echo -e "${YELLOW}  docker pull mythril/myth                 # alternative${NC}"
+    echo -e "${YELLOW}Project page: https://github.com/ConsenSys/mythril${NC}"
     exit 1
   fi
-  
+
   # Verify installation
   if ! command -v myth &> /dev/null; then
-    echo -e "${RED}Error: Mythril installation failed.${NC}"
+    echo -e "${RED}Error: myth was installed but is not on PATH.${NC}"
+    echo -e "${YELLOW}For pipx installs, run 'pipx ensurepath' once and restart your shell.${NC}"
+    echo -e "${YELLOW}For pip --user installs, ensure ~/.local/bin (or your user base) is on PATH.${NC}"
     exit 1
   fi
 fi

--- a/script/generate_slither_report.sh
+++ b/script/generate_slither_report.sh
@@ -34,31 +34,33 @@ fi
 
 # Check if Slither is installed
 if ! command -v slither &> /dev/null; then
-  echo -e "${YELLOW}Slither not found. Attempting to install via pip...${NC}"
-  
-  # Try to install Slither
-  if command -v pip3 &> /dev/null; then
-    echo -e "${YELLOW}Installing slither-analyzer...${NC}"
-    pip3 install slither-analyzer
-  elif command -v pip &> /dev/null; then
-    echo -e "${YELLOW}Installing slither-analyzer...${NC}"
-    pip install slither-analyzer
-  elif command -v pipx &> /dev/null; then
-    echo -e "${YELLOW}Installing slither-analyzer...${NC}"
-    pipx install slither-analyzer
+  echo -e "${YELLOW}Slither not found. Attempting to install...${NC}"
+
+  if command -v pipx &> /dev/null; then
+    echo -e "${YELLOW}Installing slither-analyzer via pipx...${NC}"
+    pipx install slither-analyzer || true
+  elif command -v pip3 &> /dev/null && pip3 install --user --dry-run slither-analyzer &> /dev/null; then
+    echo -e "${YELLOW}Installing slither-analyzer via pip3 --user...${NC}"
+    pip3 install --user slither-analyzer
+  elif command -v pip &> /dev/null && pip install --user --dry-run slither-analyzer &> /dev/null; then
+    echo -e "${YELLOW}Installing slither-analyzer via pip --user...${NC}"
+    pip install --user slither-analyzer
   else
-    echo -e "${RED}Error: pip not found. Please install Python and pip first.${NC}"
-    echo -e "${YELLOW}Installation instructions:${NC}"
-    echo -e "${YELLOW}  pip3 install slither-analyzer${NC}"
-    echo -e "${YELLOW}  or visit: https://github.com/crytic/slither${NC}"
+    echo -e "${RED}Error: cannot auto-install slither-analyzer.${NC}"
+    echo -e "${YELLOW}Modern Python distributions (PEP 668) block pip from writing to system or user site-packages.${NC}"
+    echo -e "${YELLOW}Install manually with one of:${NC}"
+    echo -e "${YELLOW}  pipx install slither-analyzer            # recommended${NC}"
+    echo -e "${YELLOW}  python3 -m venv .venv && source .venv/bin/activate && pip install slither-analyzer${NC}"
+    echo -e "${YELLOW}  pip install --user --break-system-packages slither-analyzer  # last resort${NC}"
+    echo -e "${YELLOW}Project page: https://github.com/crytic/slither${NC}"
     exit 1
   fi
-  
+
   # Verify installation
   if ! command -v slither &> /dev/null; then
-    echo -e "${RED}Error: Slither installation failed.${NC}"
-    echo -e "${YELLOW}Please try manual installation:${NC}"
-    echo -e "${YELLOW}  pip3 install slither-analyzer${NC}"
+    echo -e "${RED}Error: slither was installed but is not on PATH.${NC}"
+    echo -e "${YELLOW}For pipx installs, run 'pipx ensurepath' once and restart your shell.${NC}"
+    echo -e "${YELLOW}For pip --user installs, ensure ~/.local/bin (or your user base) is on PATH.${NC}"
     exit 1
   fi
 fi

--- a/script/utils/ProxyHelper.sol
+++ b/script/utils/ProxyHelper.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.30;
 
-import "forge-std/Vm.sol";
+import { Vm } from "forge-std/Vm.sol";
 
 /**
  * @title ProxyHelper
@@ -16,7 +16,7 @@ library ProxyHelper {
     bytes32 internal constant ADMIN_SLOT = 0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103;
 
     // Vm instance
-    Vm constant vm = Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
+    Vm constant VM = Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
 
     /**
      * @notice Get proxy contract implementation address (read directly from storage slot)
@@ -27,7 +27,7 @@ library ProxyHelper {
         address proxy
     ) internal view returns (address implementationAddress) {
         // Use vm.load to read directly from proxy contract storage slot
-        bytes32 value = vm.load(proxy, IMPLEMENTATION_SLOT);
+        bytes32 value = VM.load(proxy, IMPLEMENTATION_SLOT);
         implementationAddress = address(uint160(uint256(value)));
     }
 
@@ -40,7 +40,7 @@ library ProxyHelper {
         address proxy
     ) internal view returns (address adminAddress) {
         // Use vm.load to read directly from proxy contract storage slot
-        bytes32 value = vm.load(proxy, ADMIN_SLOT);
+        bytes32 value = VM.load(proxy, ADMIN_SLOT);
         adminAddress = address(uint160(uint256(value)));
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -74,7 +74,7 @@ ajv-errors@^1.0.1:
   resolved "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz"
   integrity sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==
 
-ajv@^6.12.6, ajv@>=5.0.0, "ajv@4.11.8 - 8":
+ajv@^6.12.6:
   version "6.12.6"
   resolved "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz"
   integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
@@ -111,14 +111,7 @@ ansi-regex@^6.0.1:
   resolved "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz"
   integrity sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==
 
-ansi-styles@^4.0.0:
-  version "4.3.0"
-  resolved "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz"
-  integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
-  dependencies:
-    color-convert "^2.0.1"
-
-ansi-styles@^4.1.0:
+ansi-styles@^4.0.0, ansi-styles@^4.1.0:
   version "4.3.0"
   resolved "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz"
   integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==


### PR DESCRIPTION
Cherry-picks the portable fixes from `foundry-template` commits `7742c65` (#4) and `d9d3237` (#5), which landed after this repo's cruft pin (`b813717`). No template-infra or dependency-version churn — only the changes that apply to a generated project.

## Changes

| File | Change |
|------|--------|
| `script/cleanup-demo.sh` | Only delete the named demo files instead of `rm -rf src/*`. **The old version would wipe the entire real `src/` tree** if `make cleanup-demo` were ever run here. |
| `script/generate_slither_report.sh` | PEP-668-aware installer (`pipx` → `pip3 --user` → `pip --user`). Supersedes the repo's old 3-line pipx patch. |
| `script/generate_mythril_report.sh` | Same PEP-668-aware installer — so `make slither` / `make mythril` work on modern Debian/Ubuntu instead of failing on `externally-managed-environment`. |
| `.solhint.json` | Bare severity strings for disabled rules to clear solhint schema warnings. Repo-local `no-console: off` override kept. |
| `foundry.toml` | Drop `auto_detect_solc` — explicit `solc = "0.8.30"` already pins the compiler. |
| `.github/workflows/test.yml` | `actions/setup-node` v3→v4 (node 18→20), `actions/cache` v3→v4. |
| `.github/workflows/security-audit.yml` | `actions/setup-python` v4→v5 (3.11→3.12). |
| `.github/workflows/typo-check.yml` | `crate-ci/typos` v1.29.7→v1.46.1. |
| `script/utils/ProxyHelper.sol` | Named `Vm` import + `VM` constant rename (forge-lint). |

## Deliberately *not* ported

- **`package.json` dep bumps / Zeus removal** — the template bumps its own pinned OZ/forge-std commits; this repo has its own versioning and bumping OZ could break the contracts. This repo never had Zeus.
- **`remappings.txt`** — the `@zeus-templates` line removed upstream was never present here.

## Verification

- `forge build` → exit 0, 0 errors.
- `.solhint.json` parses as valid JSON; `npx solhint` runs clean with no schema warnings.
- `forge fmt --check` passes on `ProxyHelper.sol`.

## Note

`yarn.lock` picked up a cosmetic normalization from `yarn install` (two identical dependency ranges merged — no version/URL/integrity-hash changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)