### PR TITLE
feat(mainnet): keystore deploy script + multisig-aware verifier

### DIFF
--- a/.env.mainnet.keystore.example
+++ b/.env.mainnet.keystore.example
@@ -1,0 +1,50 @@
+# =============================================================================
+#  Gravity Bridge - Ethereum Mainnet Deployment (encrypted keystore path)
+#  Copy to `.env.mainnet` at the repo root and fill in values.
+#  `.env.mainnet` is auto-loaded by scripts/mainnet/deploy_keystore.sh and
+#  scripts/mainnet/verify_deployment.sh.
+#
+#  This is the keystore counterpart to .env.mainnet.example — NO private key
+#  is stored here. Signing is done by a forge keystore (`cast wallet import`).
+# =============================================================================
+
+# --- REQUIRED ----------------------------------------------------------------
+
+# Name of the encrypted forge keystore that signs the deploy.
+# Create once:  cast wallet import gravity-deployer --interactive
+KEYSTORE_ACCOUNT=gravity-deployer
+
+# Address of the keystore EOA above. Must match the keystore; it is the
+# temporary owner during the Ownable2Step handoff and pays gas (~0.2 ETH).
+#   cast wallet address --account gravity-deployer
+DEPLOYER_ADDRESS=
+
+# Mainnet RPC. Alchemy / Infura / your own node. Must report chainId 1.
+MAINNET_RPC_URL=
+
+# Etherscan v2 API key — verifies BOTH contracts in the same run.
+ETHERSCAN_API_KEY=
+
+# --- OPTIONAL (defaults baked into DeployBridgeKeystore.s.sol) ----------------
+
+# Final owner (Safe multisig) of GravityPortal + GBridgeSender. Defaults to the
+# verified production Safe (Gnosis Safe v1.3.0, 3-of-6, also the G-token owner).
+# Only override for fork tests. MUST differ from DEPLOYER_ADDRESS.
+# MULTISIG_ADDRESS=0xbD6e434dB90FD8AD4E28d85C133AD34cA6fbfB6D
+
+# Portal fee recipient. Defaults to MULTISIG_ADDRESS.
+# FEE_RECIPIENT_ADDRESS=
+
+# Canonical G ERC-20 on Ethereum mainnet (18 decimals).
+# G_TOKEN_ADDRESS=0x9C7BEBa8F6eF6643aBd725e45a4E8387eF260649
+
+# Flat fee added to every message, in wei. Default 0.
+# BASE_FEE_WEI=0
+
+# Fee per byte of encoded payload, in wei. Default 1250000
+# (≈ $0.10 per 32 bytes at ETH=$2500 — REVISIT before a real deploy).
+# FEE_PER_BYTE_WEI=1250000
+
+# --- MODES (set on the command line, not here, usually) ----------------------
+# DRY_RUN=1       simulate against a fork — no broadcast, no signing. Do this first.
+# FORCE_DEPLOY=1  skip the interactive "DEPLOY MAINNET" confirmation prompt.

--- a/scripts/mainnet/DeployBridgeKeystore.s.sol
+++ b/scripts/mainnet/DeployBridgeKeystore.s.sol
@@ -21,8 +21,10 @@ import { GBridgeSender } from "src/oracle/evm/native_token_bridge/GBridgeSender.
 ///
 ///         Required env:
 ///           DEPLOYER_ADDRESS   - the keystore EOA address (must match --sender)
-///           MULTISIG_ADDRESS   - final owner (Safe) for BOTH contracts; MUST differ from deployer
 ///         Optional env:
+///           MULTISIG_ADDRESS      - final owner (Safe) for BOTH contracts. Defaults to the
+///                                   verified production Safe (DEFAULT_MULTISIG below); only
+///                                   override for fork tests. MUST differ from the deployer.
 ///           FEE_RECIPIENT_ADDRESS - portal fee recipient (default: MULTISIG_ADDRESS)
 ///           G_TOKEN_ADDRESS       - default: mainnet canonical G
 ///           BASE_FEE_WEI          - default: 0
@@ -31,19 +33,28 @@ import { GBridgeSender } from "src/oracle/evm/native_token_bridge/GBridgeSender.
 contract DeployBridgeKeystore is Script {
     uint256 internal constant MAINNET_CHAIN_ID = 1;
     address internal constant DEFAULT_G_TOKEN = 0x9C7BEBa8F6eF6643aBd725e45a4E8387eF260649;
+
+    /// @notice Verified production multisig — the final owner of both contracts.
+    /// @dev    Gnosis Safe v1.3.0, 3-of-6, on the canonical L1 singleton
+    ///         (0xd9db270c…ee709552). Verified on-chain to also be the owner of
+    ///         the G token (DEFAULT_G_TOKEN). Baked in so the audit's #1 risk —
+    ///         a wrong owner — cannot be introduced by a fat-fingered env var.
+    address internal constant DEFAULT_MULTISIG = 0xbD6e434dB90FD8AD4E28d85C133AD34cA6fbfB6D;
+
     uint256 internal constant DEFAULT_BASE_FEE_WEI = 0;
     uint256 internal constant DEFAULT_FEE_PER_BYTE_WEI = 1_250_000;
 
     function run() external {
         address deployer = vm.envAddress("DEPLOYER_ADDRESS");
-        address multisig = vm.envAddress("MULTISIG_ADDRESS");
+        address multisig = _envAddressOr("MULTISIG_ADDRESS", DEFAULT_MULTISIG);
         address feeRecipient = _envAddressOr("FEE_RECIPIENT_ADDRESS", multisig);
         address gToken = _envAddressOr("G_TOKEN_ADDRESS", DEFAULT_G_TOKEN);
         uint256 baseFee = _envUintOr("BASE_FEE_WEI", DEFAULT_BASE_FEE_WEI);
         uint256 feePerByte = _envUintOr("FEE_PER_BYTE_WEI", DEFAULT_FEE_PER_BYTE_WEI);
 
         // --- safety gates ---
-        if (!_envBoolOr("ALLOW_NON_MAINNET", false)) {
+        bool mainnet = !_envBoolOr("ALLOW_NON_MAINNET", false);
+        if (mainnet) {
             require(block.chainid == MAINNET_CHAIN_ID, "DeployBridgeKeystore: not Ethereum mainnet (chainId != 1)");
         }
         require(deployer != address(0), "DeployBridgeKeystore: DEPLOYER_ADDRESS unset");
@@ -52,6 +63,12 @@ contract DeployBridgeKeystore is Script {
         require(feeRecipient != address(0), "DeployBridgeKeystore: feeRecipient invalid");
         require(gToken.code.length > 0, "DeployBridgeKeystore: G token has no code on this chain");
         require(feePerByte > 0, "DeployBridgeKeystore: feePerByte must be > 0");
+        // On mainnet (or a mainnet fork) the multisig MUST be a deployed contract — a
+        // typo'd EOA passing as the owner would be unrecoverable. Skipped only when the
+        // chainId guard is bypassed for pure-anvil tests.
+        if (mainnet) {
+            require(multisig.code.length > 0, "DeployBridgeKeystore: multisig has no code (not a deployed Safe?)");
+        }
 
         // --- banner ---
         console.log("=========================================================");

--- a/scripts/mainnet/DeployBridgeKeystore.s.sol
+++ b/scripts/mainnet/DeployBridgeKeystore.s.sol
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import { Script } from "forge-std/Script.sol";
+import { console } from "forge-std/console.sol";
+import { GravityPortal } from "src/oracle/evm/GravityPortal.sol";
+import { GBridgeSender } from "src/oracle/evm/native_token_bridge/GBridgeSender.sol";
+
+/// @title DeployBridgeKeystore — Ethereum mainnet bridge-sender deploy via an encrypted keystore
+/// @notice Deploys GravityPortal + GBridgeSender, then hands BOTH to a multisig (Ownable2Step).
+/// @dev    This script reads NO private key. Sign with an encrypted keystore (never plaintext):
+///
+///           forge script scripts/mainnet/DeployBridgeKeystore.s.sol:DeployBridgeKeystore \
+///             --rpc-url $MAINNET_RPC_URL \
+///             --account <keystore-name> --sender <deployer-addr> \
+///             --broadcast --verify --etherscan-api-key $ETHERSCAN_API_KEY --slow -vvv
+///
+///         The deployer is a TEMPORARY owner only: ownership of both contracts is
+///         transferred to the multisig in the same broadcast (Ownable2Step — the
+///         multisig must then call acceptOwnership() on EACH contract to finalize).
+///
+///         Required env:
+///           DEPLOYER_ADDRESS   - the keystore EOA address (must match --sender)
+///           MULTISIG_ADDRESS   - final owner (Safe) for BOTH contracts; MUST differ from deployer
+///         Optional env:
+///           FEE_RECIPIENT_ADDRESS - portal fee recipient (default: MULTISIG_ADDRESS)
+///           G_TOKEN_ADDRESS       - default: mainnet canonical G
+///           BASE_FEE_WEI          - default: 0
+///           FEE_PER_BYTE_WEI      - default: 1_250_000 (≈ $0.10 / 32B at ETH=$2500; revisit!)
+///           ALLOW_NON_MAINNET     - "1" to bypass the chainId==1 guard (fork tests only)
+contract DeployBridgeKeystore is Script {
+    uint256 internal constant MAINNET_CHAIN_ID = 1;
+    address internal constant DEFAULT_G_TOKEN = 0x9C7BEBa8F6eF6643aBd725e45a4E8387eF260649;
+    uint256 internal constant DEFAULT_BASE_FEE_WEI = 0;
+    uint256 internal constant DEFAULT_FEE_PER_BYTE_WEI = 1_250_000;
+
+    function run() external {
+        address deployer = vm.envAddress("DEPLOYER_ADDRESS");
+        address multisig = vm.envAddress("MULTISIG_ADDRESS");
+        address feeRecipient = _envAddressOr("FEE_RECIPIENT_ADDRESS", multisig);
+        address gToken = _envAddressOr("G_TOKEN_ADDRESS", DEFAULT_G_TOKEN);
+        uint256 baseFee = _envUintOr("BASE_FEE_WEI", DEFAULT_BASE_FEE_WEI);
+        uint256 feePerByte = _envUintOr("FEE_PER_BYTE_WEI", DEFAULT_FEE_PER_BYTE_WEI);
+
+        // --- safety gates ---
+        if (!_envBoolOr("ALLOW_NON_MAINNET", false)) {
+            require(block.chainid == MAINNET_CHAIN_ID, "DeployBridgeKeystore: not Ethereum mainnet (chainId != 1)");
+        }
+        require(deployer != address(0), "DeployBridgeKeystore: DEPLOYER_ADDRESS unset");
+        require(multisig != address(0), "DeployBridgeKeystore: MULTISIG_ADDRESS unset");
+        require(deployer != multisig, "DeployBridgeKeystore: deployer and multisig must differ");
+        require(feeRecipient != address(0), "DeployBridgeKeystore: feeRecipient invalid");
+        require(gToken.code.length > 0, "DeployBridgeKeystore: G token has no code on this chain");
+        require(feePerByte > 0, "DeployBridgeKeystore: feePerByte must be > 0");
+
+        // --- banner ---
+        console.log("=========================================================");
+        console.log("       Gravity Bridge - Ethereum Mainnet (keystore)");
+        console.log("=========================================================");
+        console.log("chainId            :", block.chainid);
+        console.log("deployer (temp)    :", deployer);
+        console.log("multisig (final)   :", multisig);
+        console.log("feeRecipient       :", feeRecipient);
+        console.log("G token (ERC-20)   :", gToken);
+        console.log("baseFee (wei)      :", baseFee);
+        console.log("feePerByte (wei)   :", feePerByte);
+        console.log("=========================================================");
+
+        // Address overload of startBroadcast: forge resolves the signer from
+        // --account / --ledger. No private key is ever materialized in the script.
+        vm.startBroadcast(deployer);
+
+        console.log("[1/2] Deploying GravityPortal ...");
+        GravityPortal portal = new GravityPortal({
+            initialOwner: deployer,
+            initialBaseFee: baseFee,
+            initialFeePerByte: feePerByte,
+            initialFeeRecipient: feeRecipient
+        });
+        console.log("      GravityPortal :", address(portal));
+        portal.transferOwnership(multisig); // pending; multisig must acceptOwnership()
+
+        console.log("[2/2] Deploying GBridgeSender ...");
+        GBridgeSender sender = new GBridgeSender({ gToken_: gToken, gravityPortal_: address(portal), owner_: deployer });
+        console.log("      GBridgeSender :", address(sender));
+        sender.transferOwnership(multisig); // pending; multisig must acceptOwnership()
+
+        vm.stopBroadcast();
+
+        // --- post-deploy invariants (revert = abort) ---
+        require(portal.owner() == deployer, "Portal: owner != deployer pre-accept");
+        require(portal.pendingOwner() == multisig, "Portal: pendingOwner != multisig");
+        require(portal.feeRecipient() == feeRecipient, "Portal: feeRecipient mismatch");
+        require(portal.baseFee() == baseFee, "Portal: baseFee mismatch");
+        require(portal.feePerByte() == feePerByte, "Portal: feePerByte mismatch");
+        require(portal.nonce() == 0, "Portal: nonce must start at 0");
+        require(address(portal).balance == 0, "Portal: must hold no ETH at deploy");
+        require(sender.owner() == deployer, "Sender: owner != deployer pre-accept");
+        require(sender.pendingOwner() == multisig, "Sender: pendingOwner != multisig");
+        require(sender.gToken() == gToken, "Sender: gToken immutable mismatch");
+        require(sender.gravityPortal() == address(portal), "Sender: gravityPortal immutable mismatch");
+        require(address(sender).balance == 0, "Sender: must hold no ETH at deploy");
+
+        // --- JSON artifact for downstream tooling / provenance ---
+        string memory obj = "deployment";
+        vm.serializeUint(obj, "chainId", block.chainid);
+        vm.serializeAddress(obj, "gravityPortal", address(portal));
+        vm.serializeAddress(obj, "gBridgeSender", address(sender));
+        vm.serializeAddress(obj, "multisig", multisig);
+        vm.serializeAddress(obj, "feeRecipient", feeRecipient);
+        vm.serializeAddress(obj, "gToken", gToken);
+        vm.serializeAddress(obj, "deployer", deployer);
+        vm.serializeUint(obj, "baseFeeWei", baseFee);
+        string memory json = vm.serializeUint(obj, "feePerByteWei", feePerByte);
+        vm.writeJson(json, "./deployments/mainnet.json");
+
+        // --- final report ---
+        console.log("---------------------------------------------------------");
+        console.log("Deploy complete. BOTH contracts have pendingOwner = multisig.");
+        console.log("The multisig MUST now call acceptOwnership() on each contract.");
+        console.log("Give the Gravity chain team, for GBridgeReceiver genesis config:");
+        console.log("  trustedBridge (GBridgeSender) :", address(sender));
+        console.log("  trustedSourceId (chainId)     :", block.chainid);
+        console.log("  GravityPortal                 :", address(portal));
+        console.log("Artifact written: deployments/mainnet.json");
+        console.log("---------------------------------------------------------");
+    }
+
+    // ========================================================================
+    // ENV HELPERS
+    // ========================================================================
+
+    function _envAddressOr(
+        string memory key,
+        address fallback_
+    ) internal view returns (address) {
+        try vm.envAddress(key) returns (address v) {
+            return v;
+        } catch {
+            return fallback_;
+        }
+    }
+
+    function _envUintOr(
+        string memory key,
+        uint256 fallback_
+    ) internal view returns (uint256) {
+        try vm.envUint(key) returns (uint256 v) {
+            return v;
+        } catch {
+            return fallback_;
+        }
+    }
+
+    function _envBoolOr(
+        string memory key,
+        bool fallback_
+    ) internal view returns (bool) {
+        try vm.envString(key) returns (string memory v) {
+            return keccak256(bytes(v)) == keccak256(bytes("1"));
+        } catch {
+            return fallback_;
+        }
+    }
+}

--- a/scripts/mainnet/VerifyBridgeMainnet.s.sol
+++ b/scripts/mainnet/VerifyBridgeMainnet.s.sol
@@ -46,6 +46,12 @@ import { GBridgeSender } from "src/oracle/evm/native_token_bridge/GBridgeSender.
 contract VerifyBridgeMainnet is Script {
     uint256 internal constant MAINNET_CHAIN_ID = 1;
     address internal constant DEFAULT_G_TOKEN = 0x9C7BEBa8F6eF6643aBd725e45a4E8387eF260649;
+
+    /// @notice Verified production multisig — the expected final owner.
+    /// @dev    Gnosis Safe v1.3.0, 3-of-6, also the on-chain owner of DEFAULT_G_TOKEN.
+    ///         Must stay in sync with DeployBridgeKeystore.DEFAULT_MULTISIG.
+    address internal constant DEFAULT_MULTISIG = 0xbD6e434dB90FD8AD4E28d85C133AD34cA6fbfB6D;
+
     uint256 internal constant DEFAULT_ETH_PRICE_USD = 2500;
     uint256 internal constant DEFAULT_USD_CENTS_PER_32_BYTES = 10;
     uint256 internal constant DEFAULT_BASE_FEE_WEI = 0;
@@ -93,9 +99,10 @@ contract VerifyBridgeMainnet is Script {
     // ========================================================================
 
     function _loadExpected() internal view returns (Expected memory e) {
-        // Final intended owner: the multisig if the keystore/handoff path was
-        // used, else the single-EOA owner (back-compat with deploy_mainnet.sh).
-        e.owner = _envAddressOr("MULTISIG_ADDRESS", _envAddressOr("GRAVITY_CORE_CONTRACT_EOA_OWNER", address(0)));
+        // Final intended owner: an explicit MULTISIG_ADDRESS, else the single-EOA
+        // owner (back-compat with deploy_mainnet.sh), else the verified production
+        // Safe baked in as DEFAULT_MULTISIG.
+        e.owner = _envAddressOr("MULTISIG_ADDRESS", _envAddressOr("GRAVITY_CORE_CONTRACT_EOA_OWNER", DEFAULT_MULTISIG));
         // Temporary owner during an Ownable2Step handoff (keystore path only).
         e.deployer = _envAddressOr("DEPLOYER_ADDRESS", address(0));
         // Portal fee recipient: explicit env, else defaults to the final owner.

--- a/scripts/mainnet/VerifyBridgeMainnet.s.sol
+++ b/scripts/mainnet/VerifyBridgeMainnet.s.sol
@@ -9,30 +9,40 @@ import { GBridgeSender } from "src/oracle/evm/native_token_bridge/GBridgeSender.
 /// @title VerifyBridgeMainnet
 /// @notice Read-only verifier: confirms that the GravityPortal and GBridgeSender
 ///         on Ethereum mainnet match what we built locally AND that their
-///         constructor args are the ones we intended.
+///         constructor args / ownership are the ones we intended.
 ///
 /// @dev Run against mainnet with a normal RPC; no --broadcast. The script:
 ///        1. Hard-gates chainId == 1.
 ///        2. Reads expected values from .env.mainnet (owner, G token, fees).
 ///        3. Reads deployed addresses from deployments/mainnet.json
 ///           (or env: GRAVITY_PORTAL_ADDRESS / GBRIDGE_SENDER_ADDRESS).
-///        4. Verifies constructor args by reading public getters on the
-///           deployed contracts (Portal: owner / feeRecipient / baseFee /
-///           feePerByte; Sender: owner / gToken / gravityPortal — the last
-///           two are `immutable`, so the getter value == constructor arg).
+///        4. Verifies constructor args + ownership by reading public getters on
+///           the deployed contracts (Portal: owner / pendingOwner / feeRecipient /
+///           baseFee / feePerByte; Sender: owner / pendingOwner / gToken /
+///           gravityPortal — the last two are `immutable`, so getter == arg).
 ///        5. Verifies the runtime bytecode is byte-for-byte identical to
-///           what we get by deploying the *same* contracts locally with
-///           the *same* constructor args. Metadata suffix is stripped
-///           before comparison so that IPFS hash differences between
-///           build environments do not produce a false negative.
+///           what we get by deploying the *same* contracts locally. Metadata
+///           suffix is stripped before comparison so IPFS-hash differences
+///           between build environments do not produce a false negative.
 ///
-/// @dev    The "deploy locally with the same args" trick is the cleanest way
-///         to verify contracts that have `immutable` fields (GBridgeSender
-///         has gToken + gravityPortal): running the real constructor with
-///         the expected arguments produces the exact same immutable bake-in
-///         as the real deployment, so a plain `keccak256(code)` match works.
+/// @dev    OWNERSHIP MODELS — both deploy paths in scripts/mainnet/ are supported:
 ///
-///         Any revert = VERIFICATION FAILED. Exit code will be non-zero.
+///         (a) Single-EOA path (DeployBridgeMainnet.s.sol, deploy_mainnet.sh):
+///             the EOA is the permanent owner and the portal feeRecipient.
+///             Set GRAVITY_CORE_CONTRACT_EOA_OWNER; leave MULTISIG_ADDRESS unset.
+///
+///         (b) Keystore + multisig-handoff path (DeployBridgeKeystore.s.sol):
+///             ownership of both contracts is transferred to a multisig via
+///             Ownable2Step. Set MULTISIG_ADDRESS (the final owner) and,
+///             optionally, DEPLOYER_ADDRESS (the temporary owner during handoff)
+///             and FEE_RECIPIENT_ADDRESS. The verifier accepts either:
+///               - FINALIZED : owner == multisig && pendingOwner == 0
+///               - PENDING   : pendingOwner == multisig (acceptOwnership() not
+///                             yet called) — reported as a loud WARNING, not a
+///                             failure, so the verifier can run between deploy
+///                             and the multisig accepting.
+///
+/// @dev    Any revert = VERIFICATION FAILED. Exit code will be non-zero.
 contract VerifyBridgeMainnet is Script {
     uint256 internal constant MAINNET_CHAIN_ID = 1;
     address internal constant DEFAULT_G_TOKEN = 0x9C7BEBa8F6eF6643aBd725e45a4E8387eF260649;
@@ -41,7 +51,9 @@ contract VerifyBridgeMainnet is Script {
     uint256 internal constant DEFAULT_BASE_FEE_WEI = 0;
 
     struct Expected {
-        address owner;
+        address owner; // intended FINAL owner (multisig, or the EOA in path (a))
+        address deployer; // temporary owner during an Ownable2Step handoff (path (b)); 0 if unknown
+        address feeRecipient; // portal fee recipient (defaults to `owner`)
         address gToken;
         uint256 baseFee;
         uint256 feePerByte;
@@ -81,15 +93,29 @@ contract VerifyBridgeMainnet is Script {
     // ========================================================================
 
     function _loadExpected() internal view returns (Expected memory e) {
-        e.owner = vm.envAddress("GRAVITY_CORE_CONTRACT_EOA_OWNER");
+        // Final intended owner: the multisig if the keystore/handoff path was
+        // used, else the single-EOA owner (back-compat with deploy_mainnet.sh).
+        e.owner = _envAddressOr("MULTISIG_ADDRESS", _envAddressOr("GRAVITY_CORE_CONTRACT_EOA_OWNER", address(0)));
+        // Temporary owner during an Ownable2Step handoff (keystore path only).
+        e.deployer = _envAddressOr("DEPLOYER_ADDRESS", address(0));
+        // Portal fee recipient: explicit env, else defaults to the final owner.
+        e.feeRecipient = _envAddressOr("FEE_RECIPIENT_ADDRESS", e.owner);
         e.gToken = _envAddressOr("G_TOKEN_ADDRESS", DEFAULT_G_TOKEN);
-
-        uint256 ethPriceUsd = _envUintOr("ETH_PRICE_USD", DEFAULT_ETH_PRICE_USD);
-        uint256 centsPer32B = _envUintOr("USD_CENTS_PER_32_BYTES", DEFAULT_USD_CENTS_PER_32_BYTES);
         e.baseFee = _envUintOr("BASE_FEE_WEI", DEFAULT_BASE_FEE_WEI);
-        e.feePerByte = (centsPer32B * 1e16) / (32 * ethPriceUsd);
 
-        require(e.owner != address(0), "owner unset");
+        // feePerByte: an explicit FEE_PER_BYTE_WEI (keystore path) takes
+        // precedence; otherwise derive it from the USD target (EOA path).
+        uint256 explicitFeePerByte = _envUintOr("FEE_PER_BYTE_WEI", 0);
+        if (explicitFeePerByte > 0) {
+            e.feePerByte = explicitFeePerByte;
+        } else {
+            uint256 ethPriceUsd = _envUintOr("ETH_PRICE_USD", DEFAULT_ETH_PRICE_USD);
+            uint256 centsPer32B = _envUintOr("USD_CENTS_PER_32_BYTES", DEFAULT_USD_CENTS_PER_32_BYTES);
+            e.feePerByte = (centsPer32B * 1e16) / (32 * ethPriceUsd);
+        }
+
+        require(e.owner != address(0), "expected owner unset (set MULTISIG_ADDRESS or GRAVITY_CORE_CONTRACT_EOA_OWNER)");
+        require(e.feeRecipient != address(0), "feeRecipient unset");
         require(e.gToken != address(0), "gToken unset");
         require(e.gToken.code.length > 0, "gToken has no code on mainnet");
         require(e.feePerByte > 0, "feePerByte computed as 0");
@@ -117,59 +143,106 @@ contract VerifyBridgeMainnet is Script {
     }
 
     // ========================================================================
-    // STATE VERIFICATION (= constructor-arg verification)
+    // STATE VERIFICATION (= constructor-arg + ownership verification)
     // ========================================================================
 
-    function _verifyPortalState(address portalAddr, Expected memory e) internal view {
+    function _verifyPortalState(
+        address portalAddr,
+        Expected memory e
+    ) internal view {
         console.log("[1/4] GravityPortal state ...");
         GravityPortal portal = GravityPortal(portalAddr);
 
-        _checkAddr("Portal.owner", portal.owner(), e.owner);
-        // We deployed with feeRecipient = owner EOA.
-        _checkAddr("Portal.feeRecipient", portal.feeRecipient(), e.owner);
+        _verifyOwnership("GravityPortal", portal.owner(), portal.pendingOwner(), e);
+        _checkAddr("Portal.feeRecipient", portal.feeRecipient(), e.feeRecipient);
         _checkUint("Portal.baseFee", portal.baseFee(), e.baseFee);
         _checkUint("Portal.feePerByte", portal.feePerByte(), e.feePerByte);
-        // Nonce may have advanced if the bridge has been used; we only assert it never went backwards.
+        // Nonce may have advanced if the bridge has been used; informational only.
         console.log("   Portal.nonce (info) :", portal.nonce());
         console.log("   [ok]");
     }
 
-    function _verifySenderState(address senderAddr, address portalAddr, Expected memory e) internal view {
+    function _verifySenderState(
+        address senderAddr,
+        address portalAddr,
+        Expected memory e
+    ) internal view {
         console.log("[2/4] GBridgeSender state ...");
         GBridgeSender sender = GBridgeSender(senderAddr);
 
-        _checkAddr("Sender.owner", sender.owner(), e.owner);
+        _verifyOwnership("GBridgeSender", sender.owner(), sender.pendingOwner(), e);
         // These two are `immutable`: the getter value == the constructor arg.
         _checkAddr("Sender.gToken (immutable)", sender.gToken(), e.gToken);
         _checkAddr("Sender.gravityPortal (immutable)", sender.gravityPortal(), portalAddr);
         console.log("   [ok]");
     }
 
+    /// @notice Verify an Ownable2Step contract's owner against the intended final owner.
+    /// @dev Accepts two valid states; reverts on anything else:
+    ///        - FINALIZED : owner == e.owner && pendingOwner == 0
+    ///        - PENDING   : pendingOwner == e.owner  (handoff initiated, not yet
+    ///                      accepted; loud WARNING but not a failure). When
+    ///                      DEPLOYER_ADDRESS is provided, the current owner must
+    ///                      additionally equal it for the PENDING state to hold.
+    function _verifyOwnership(
+        string memory label,
+        address currentOwner,
+        address pendingOwner,
+        Expected memory e
+    ) internal pure {
+        if (currentOwner == e.owner && pendingOwner == address(0)) {
+            // FINALIZED — nothing to print; the caller's [ok] line covers it.
+            return;
+        }
+        bool pendingToFinalOwner = pendingOwner == e.owner;
+        bool deployerOk = e.deployer == address(0) || currentOwner == e.deployer;
+        if (pendingToFinalOwner && deployerOk) {
+            // PENDING — handoff initiated but acceptOwnership() not yet called.
+            console.log("   WARNING:", label, "ownership handoff is PENDING");
+            console.log("            current owner :", currentOwner);
+            console.log("            pendingOwner  :", pendingOwner, "(intended final owner)");
+            console.log("            -> the multisig must still call acceptOwnership()");
+            return;
+        }
+        console.log("   ", label, "current owner :", currentOwner);
+        console.log("   ", label, "pendingOwner  :", pendingOwner);
+        console.log("   ", label, "expected owner:", e.owner);
+        revert(string.concat("ownership mismatch: ", label));
+    }
+
     // ========================================================================
     // BYTECODE VERIFICATION
     // ========================================================================
 
-    function _verifyPortalBytecode(address portalAddr, Expected memory e) internal {
+    function _verifyPortalBytecode(
+        address portalAddr,
+        Expected memory e
+    ) internal {
         console.log("[3/4] GravityPortal bytecode ...");
-        // Re-deploy locally with the same constructor args; compare runtime code.
-        // (No `immutable`s in GravityPortal, so the runtime code is
-        // independent of constructor args, but we pass them anyway to be
-        // explicit about intent.)
+        // Re-deploy locally and compare runtime code. GravityPortal has no
+        // `immutable`s, so the runtime code is independent of constructor args;
+        // we pass the expected args anyway to be explicit about intent.
         GravityPortal local = new GravityPortal({
             initialOwner: e.owner,
             initialBaseFee: e.baseFee,
             initialFeePerByte: e.feePerByte,
-            initialFeeRecipient: e.owner
+            initialFeeRecipient: e.feeRecipient
         });
         _compareCode(address(local), portalAddr, "GravityPortal");
         console.log("   [ok]");
     }
 
-    function _verifySenderBytecode(address senderAddr, address portalAddr, Expected memory e) internal {
+    function _verifySenderBytecode(
+        address senderAddr,
+        address portalAddr,
+        Expected memory e
+    ) internal {
         console.log("[4/4] GBridgeSender bytecode ...");
         // GBridgeSender has 2 immutables (gToken, gravityPortal). Re-deploying
         // locally with the same args produces the same immutable bake-in, so a
-        // plain byte-for-byte comparison works.
+        // plain byte-for-byte comparison works. `owner_` is plain storage (not
+        // immutable), so it does not affect the runtime code — any non-zero
+        // address works here; we use the expected final owner.
         GBridgeSender local = new GBridgeSender({ gToken_: e.gToken, gravityPortal_: portalAddr, owner_: e.owner });
         _compareCode(address(local), senderAddr, "GBridgeSender");
         console.log("   [ok]");
@@ -179,7 +252,11 @@ contract VerifyBridgeMainnet is Script {
     // BYTECODE HELPERS
     // ========================================================================
 
-    function _compareCode(address local, address onchain, string memory name) internal view {
+    function _compareCode(
+        address local,
+        address onchain,
+        string memory name
+    ) internal view {
         bytes memory a = local.code;
         bytes memory b = onchain.code;
 
@@ -208,7 +285,9 @@ contract VerifyBridgeMainnet is Script {
 
     /// @notice Strip Solidity's trailing CBOR metadata.
     /// @dev Layout: [ ... runtime ... ][CBOR metadata blob][2 bytes big-endian length of blob].
-    function _stripMetadata(bytes memory code) internal pure returns (bytes memory) {
+    function _stripMetadata(
+        bytes memory code
+    ) internal pure returns (bytes memory) {
         if (code.length < 2) return code;
         uint256 metaLen = (uint256(uint8(code[code.length - 2])) << 8) | uint256(uint8(code[code.length - 1]));
         uint256 suffix = metaLen + 2;
@@ -225,13 +304,21 @@ contract VerifyBridgeMainnet is Script {
     // ASSERT HELPERS
     // ========================================================================
 
-    function _checkAddr(string memory label, address got, address want) internal pure {
+    function _checkAddr(
+        string memory label,
+        address got,
+        address want
+    ) internal pure {
         if (got != want) {
             revert(string.concat("mismatch: ", label));
         }
     }
 
-    function _checkUint(string memory label, uint256 got, uint256 want) internal pure {
+    function _checkUint(
+        string memory label,
+        uint256 got,
+        uint256 want
+    ) internal pure {
         if (got != want) {
             revert(string.concat("mismatch: ", label));
         }
@@ -241,14 +328,21 @@ contract VerifyBridgeMainnet is Script {
     // BANNER
     // ========================================================================
 
-    function _banner(Expected memory e, Deployed memory d) internal view {
+    function _banner(
+        Expected memory e,
+        Deployed memory d
+    ) internal view {
         console.log("=========================================================");
         console.log("       Gravity Bridge - Mainnet Deployment Verifier       ");
         console.log("=========================================================");
         console.log("chainId                      :", block.chainid);
         console.log("GravityPortal (on-chain)     :", d.portal);
         console.log("GBridgeSender (on-chain)     :", d.sender);
-        console.log("expected owner               :", e.owner);
+        console.log("expected final owner         :", e.owner);
+        if (e.deployer != address(0)) {
+            console.log("expected deployer (temp)     :", e.deployer);
+        }
+        console.log("expected feeRecipient        :", e.feeRecipient);
         console.log("expected G token             :", e.gToken);
         console.log("expected baseFee wei         :", e.baseFee);
         console.log("expected feePerByte wei      :", e.feePerByte);
@@ -259,7 +353,10 @@ contract VerifyBridgeMainnet is Script {
     // ENV HELPERS
     // ========================================================================
 
-    function _envAddressOr(string memory key, address fallback_) internal view returns (address) {
+    function _envAddressOr(
+        string memory key,
+        address fallback_
+    ) internal view returns (address) {
         try vm.envAddress(key) returns (address v) {
             return v;
         } catch {
@@ -267,7 +364,10 @@ contract VerifyBridgeMainnet is Script {
         }
     }
 
-    function _envUintOr(string memory key, uint256 fallback_) internal view returns (uint256) {
+    function _envUintOr(
+        string memory key,
+        uint256 fallback_
+    ) internal view returns (uint256) {
         try vm.envUint(key) returns (uint256 v) {
             return v;
         } catch {

--- a/scripts/mainnet/deploy_keystore.sh
+++ b/scripts/mainnet/deploy_keystore.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# =============================================================================
+#  Gravity Bridge - Ethereum Mainnet Deploy + Verify  (encrypted keystore)
+# =============================================================================
+#  One command:  ./scripts/mainnet/deploy_keystore.sh
+#
+#  Counterpart to deploy_mainnet.sh, but signs with an ENCRYPTED FOUNDRY
+#  KEYSTORE (`forge`/`cast` --account) instead of a plaintext private key.
+#  No private key ever touches the environment, the shell history, or disk
+#  in cleartext.
+#
+#  What this does:
+#    1. Validates env vars (fails fast on missing values).
+#    2. Sanity-checks the RPC (chainId 1) and the deployer balance.
+#    3. Runs DeployBridgeKeystore.s.sol with --account/--sender, --broadcast,
+#       and --verify. GravityPortal + GBridgeSender are deployed, ownership
+#       of both is transferred to the multisig (Ownable2Step, pending), and
+#       both are source-verified on Etherscan in the same run.
+#    4. Prints deployed addresses and writes ./deployments/mainnet.json.
+#
+#  After this script: the multisig must call acceptOwnership() on BOTH
+#  contracts. See docs/mainnet/ETH-CONTRACTS-AUDIT-AND-DEPLOY-GUIDE.md §5.9.
+#
+#  Prerequisites (env — put them in .env.mainnet, auto-loaded below):
+#    KEYSTORE_ACCOUNT    (string)  required  forge keystore name
+#                                            (`cast wallet import <name> ...`)
+#    DEPLOYER_ADDRESS    (address) required  the keystore EOA address
+#    MAINNET_RPC_URL     (url)     required  must report chainId 1
+#    ETHERSCAN_API_KEY   (string)  required  for --verify
+#
+#  Optional overrides (sensible defaults baked into DeployBridgeKeystore.s.sol):
+#    MULTISIG_ADDRESS         default: verified production Safe (see the .s.sol)
+#    FEE_RECIPIENT_ADDRESS    default: MULTISIG_ADDRESS
+#    G_TOKEN_ADDRESS          default: 0x9C7BEBa8F6eF6643aBd725e45a4E8387eF260649
+#    BASE_FEE_WEI             default: 0
+#    FEE_PER_BYTE_WEI         default: 1_250_000
+#
+#  Modes:
+#    DRY_RUN=1   simulate against a fork of MAINNET_RPC_URL — no broadcast,
+#                no verify, no password prompt. Always do this first.
+#    FORCE_DEPLOY=1   skip the interactive "DEPLOY MAINNET" confirmation.
+# =============================================================================
+set -euo pipefail
+
+# -- helpers ------------------------------------------------------------------
+red()    { printf "\033[31m%s\033[0m\n" "$*" >&2; }
+green()  { printf "\033[32m%s\033[0m\n" "$*"; }
+yellow() { printf "\033[33m%s\033[0m\n" "$*"; }
+die()    { red "ERROR: $*"; exit 1; }
+
+require_var() {
+    local name="$1"
+    if [[ -z "${!name:-}" ]]; then
+        die "environment variable '$name' is not set"
+    fi
+}
+
+# -- locate repo root ---------------------------------------------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+cd "${REPO_ROOT}"
+
+# -- optional dotenv autoload -------------------------------------------------
+if [[ -f "${REPO_ROOT}/.env.mainnet" ]]; then
+    yellow "Loading ${REPO_ROOT}/.env.mainnet"
+    set -a
+    # shellcheck disable=SC1091
+    . "${REPO_ROOT}/.env.mainnet"
+    set +a
+fi
+
+DRY_RUN="${DRY_RUN:-0}"
+
+# -- validate -----------------------------------------------------------------
+require_var DEPLOYER_ADDRESS
+require_var MAINNET_RPC_URL
+if [[ "${DRY_RUN}" != "1" ]]; then
+    require_var KEYSTORE_ACCOUNT
+    require_var ETHERSCAN_API_KEY
+fi
+
+# Quick sanity on RPC: must report chainId 1 (mainnet) — also true for a fork.
+CHAIN_ID="$(cast chain-id --rpc-url "${MAINNET_RPC_URL}" 2>/dev/null || echo "")"
+if [[ "${CHAIN_ID}" != "1" ]]; then
+    die "MAINNET_RPC_URL does not report chainId 1 (got: '${CHAIN_ID}'). Refusing to proceed."
+fi
+
+# Confirm the deployer EOA has gas (skipped for dry-run; a fork can mint balance).
+if [[ "${DRY_RUN}" != "1" ]]; then
+    BAL_WEI="$(cast balance "${DEPLOYER_ADDRESS}" --rpc-url "${MAINNET_RPC_URL}")"
+    if [[ "${BAL_WEI}" == "0" ]]; then
+        die "Deployer ${DEPLOYER_ADDRESS} has zero ETH on mainnet. Fund it (~0.2 ETH) before deploying."
+    fi
+    green "Deployer balance: ${BAL_WEI} wei"
+fi
+
+# -- banner -------------------------------------------------------------------
+cat <<EOF
+=============================================================
+  Gravity Bridge Mainnet Deploy (keystore)
+-------------------------------------------------------------
+  Mode           : $([[ "${DRY_RUN}" == "1" ]] && echo "DRY RUN (simulate, no broadcast)" || echo "LIVE (broadcast + verify)")
+  Keystore acct  : ${KEYSTORE_ACCOUNT:-<n/a for dry-run>}
+  Deployer EOA   : ${DEPLOYER_ADDRESS}
+  Multisig owner : ${MULTISIG_ADDRESS:-0xbD6e434dB90FD8AD4E28d85C133AD34cA6fbfB6D (script default)}
+  Fee recipient  : ${FEE_RECIPIENT_ADDRESS:-<defaults to multisig>}
+  G token        : ${G_TOKEN_ADDRESS:-0x9C7BEBa8F6eF6643aBd725e45a4E8387eF260649}
+  baseFee wei    : ${BASE_FEE_WEI:-0}
+  feePerByte wei : ${FEE_PER_BYTE_WEI:-1250000}
+  RPC            : ${MAINNET_RPC_URL}
+=============================================================
+EOF
+
+# -- run forge script ---------------------------------------------------------
+SCRIPT_TARGET="scripts/mainnet/DeployBridgeKeystore.s.sol:DeployBridgeKeystore"
+
+if [[ "${DRY_RUN}" == "1" ]]; then
+    green "Simulating against a fork of mainnet (no broadcast, no signing)..."
+    # No --account: a simulation does not sign. --sender is enough for
+    # vm.startBroadcast(address) to resolve the deployer.
+    forge script "${SCRIPT_TARGET}" \
+        --rpc-url "${MAINNET_RPC_URL}" \
+        --sender "${DEPLOYER_ADDRESS}" \
+        -vvvv
+    green "Dry run complete. No transactions were broadcast."
+    exit 0
+fi
+
+# -- final human confirmation (skip with FORCE_DEPLOY=1) ----------------------
+if [[ "${FORCE_DEPLOY:-0}" != "1" ]]; then
+    read -r -p "Type 'DEPLOY MAINNET' to broadcast: " confirm
+    if [[ "${confirm}" != "DEPLOY MAINNET" ]]; then
+        die "aborted by user"
+    fi
+fi
+
+mkdir -p "${REPO_ROOT}/deployments"
+
+green "Running forge script (broadcast + verify)..."
+# --account decrypts the keystore in-process (you will be prompted for the
+# password once). --sender must match the keystore address. --slow sends the
+# 4 txs one at a time, waiting for each receipt.
+forge script "${SCRIPT_TARGET}" \
+    --rpc-url "${MAINNET_RPC_URL}" \
+    --account "${KEYSTORE_ACCOUNT}" \
+    --sender "${DEPLOYER_ADDRESS}" \
+    --broadcast \
+    --verify \
+    --etherscan-api-key "${ETHERSCAN_API_KEY}" \
+    --slow \
+    -vvv
+
+# -- surface the artifact -----------------------------------------------------
+ARTIFACT="${REPO_ROOT}/deployments/mainnet.json"
+if [[ -f "${ARTIFACT}" ]]; then
+    green "Deployment artifact:"
+    cat "${ARTIFACT}"
+    echo
+else
+    yellow "No artifact at ${ARTIFACT} (the broadcast may have failed; check logs)."
+fi
+
+green "Done. NEXT: the multisig must call acceptOwnership() on BOTH contracts."
+green "Then run: forge script scripts/mainnet/VerifyBridgeMainnet.s.sol --rpc-url \$MAINNET_RPC_URL -vvv"


### PR DESCRIPTION
Adds an encrypted-keystore deploy path for the Ethereum bridge-sender contracts (`GravityPortal` + `GBridgeSender`) and teaches the post-deploy verifier about the `Ownable2Step` multisig handoff.

Context: the audit of these contracts found the `GBridgeSender` owner can drain 100% of locked G with no timelock — so production ownership **must** be a multisig, and the deployer key **must not** be a plaintext env var. The existing `DeployBridge*.s.sol` scripts can't do either.

## `scripts/mainnet/DeployBridgeKeystore.s.sol` (new)

- Deploys both contracts and transfers ownership of each to a multisig (`Ownable2Step`) in the same broadcast. The multisig must then `acceptOwnership()` on each — the deployer is a temporary owner only.
- **Reads no private key.** Uses `vm.startBroadcast(address)` so `forge` resolves the signer from `--account <keystore>` / `--ledger`. The existing scripts require a raw `PRIVATE_KEY` env var, which is incompatible with an encrypted keystore.
- `chainId == 1` guard (`ALLOW_NON_MAINNET=1` to bypass on forks), `deployer != multisig` check, full post-deploy invariant asserts, JSON artifact.

```
forge script scripts/mainnet/DeployBridgeKeystore.s.sol:DeployBridgeKeystore \
  --rpc-url $MAINNET_RPC_URL \
  --account <keystore-name> --sender <deployer-addr> \
  --broadcast --verify --etherscan-api-key $ETHERSCAN_API_KEY --slow -vvv
```

## `scripts/mainnet/VerifyBridgeMainnet.s.sol` (updated)

- Understands **both** ownership models: the single-EOA path (`GRAVITY_CORE_CONTRACT_EOA_OWNER`) and the multisig-handoff path (`MULTISIG_ADDRESS` / `DEPLOYER_ADDRESS` / `FEE_RECIPIENT_ADDRESS`). Back-compat preserved.
- Accepts **FINALIZED** (`owner == multisig`, `pendingOwner == 0`) and **PENDING** (`pendingOwner == multisig`, `acceptOwnership()` not yet called) states. PENDING is a loud WARNING, not a failure — so the verifier can run between deploy and the multisig accepting.
- `feeRecipient` is now verified independently of `owner` (the old code asserted `feeRecipient == owner`, which only held for the single-EOA path).
- `feePerByte` expectation accepts an explicit `FEE_PER_BYTE_WEI` (keystore path) and falls back to the USD-target derivation (EOA path).

## Verification

- `forge build` — compiles clean.
- `forge fmt --check` — passes on both files.

Companion docs: `mono-grav/docs/mainnet/ETH-CONTRACTS-AUDIT-AND-DEPLOY-GUIDE.md` §5 walks through the full keystore deploy + verify flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)