### PR TITLE
fix(deploy): hoist mkdir so DRY_RUN can write the artifact

### DIFF
--- a/scripts/mainnet/deploy_keystore.sh
+++ b/scripts/mainnet/deploy_keystore.sh
@@ -72,6 +72,11 @@ fi
 
 DRY_RUN="${DRY_RUN:-0}"
 
+# Deployments dir must exist before either the dry-run or the live broadcast — the
+# .s.sol script writes deployments/mainnet.json via vm.writeJson, which does NOT
+# create parent directories.
+mkdir -p "${REPO_ROOT}/deployments"
+
 # -- validate -----------------------------------------------------------------
 require_var DEPLOYER_ADDRESS
 require_var MAINNET_RPC_URL
@@ -135,8 +140,6 @@ if [[ "${FORCE_DEPLOY:-0}" != "1" ]]; then
         die "aborted by user"
     fi
 fi
-
-mkdir -p "${REPO_ROOT}/deployments"
 
 green "Running forge script (broadcast + verify)..."
 # --account decrypts the keystore in-process (you will be prompted for the


### PR DESCRIPTION
**Tiny one-line fix found while running the live-deploy dry-run.**

`DeployBridgeKeystore.s.sol` always writes `deployments/mainnet.json` via `vm.writeJson` — including under `DRY_RUN` (good: it lets the operator inspect the predicted addresses + salts). But the wrapper's \`mkdir -p deployments\` lived inside the live-broadcast branch, *after* the `DRY_RUN` early-exit. `vm.writeJson` does not create parent directories, so the dry-run reverted at the very end with:

\`\`\`
vm.writeJson: failed to open file ".../deployments/mainnet.json": No such file or directory (os error 2)
\`\`\`

— even though every contract-side step (deploy → transferOwnership → all post-deploy invariants) succeeded.

Fix: hoist `mkdir -p deployments` next to the env-load section so it runs in both DRY_RUN and live paths. Drop the now-redundant duplicate from the live branch.

Verified from a clean state (`rm -rf deployments`): `DRY_RUN=1 ./scripts/mainnet/deploy_keystore.sh` finishes cleanly and writes the artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)