### PR TITLE
fix(staking): disable StakePool.renounceOwnership

### DIFF
--- a/src/staking/StakePool.sol
+++ b/src/staking/StakePool.sol
@@ -365,6 +365,18 @@ contract StakePool is IStakePool, Ownable2Step, ReentrancyGuard {
         emit RoleChangeCancelled(address(this), Role.Voter);
     }
 
+    // ── Ownership overrides ─────────────────────────────────────────────
+
+    /// @notice Disable ownership renunciation.
+    /// @dev OZ `Ownable.renounceOwnership()` is public by default; if the owner
+    ///      ever called it, every `onlyOwner` path (propose/cancel role changes,
+    ///      role-change delay setters) would be permanently dead and the pool
+    ///      would be frozen at whichever staker/operator/voter is current —
+    ///      including a malicious one. No governance recovery exists.
+    function renounceOwnership() public pure override {
+        revert Errors.OperationNotSupported();
+    }
+
     // ── Role change delay configuration ─────────────────────────────────
 
     /// @inheritdoc IStakePool

--- a/test/unit/staking/StakerSeparation.t.sol
+++ b/test/unit/staking/StakerSeparation.t.sol
@@ -158,4 +158,16 @@ contract StakerSeparationTest is Test {
         IStakePool(pool).acceptOperator();
         assertEq(IStakePool(pool).getOperator(), newOperator, "proposeOperator did not apply");
     }
+
+    function test_renounceOwnership_Reverts() public {
+        address pool = _createDistinctPool();
+
+        // Owner cannot brick the pool by renouncing — would otherwise permanently
+        // disable proposeStaker/proposeOperator/proposeVoter and their cancel/delay setters.
+        vm.prank(ownerAddr);
+        vm.expectRevert(Errors.OperationNotSupported.selector);
+        Ownable(pool).renounceOwnership();
+
+        assertEq(Ownable(pool).owner(), ownerAddr, "owner should be unchanged after revert");
+    }
 }


### PR DESCRIPTION
## Description

`StakePool` inherits OpenZeppelin's `Ownable2Step`, which exposes a public `renounceOwnership()`. If a pool owner ever invoked it — by mistake, by social engineering, or by a buggy script — the pool would become permanently locked:

- `proposeStaker`, `proposeOperator`, `proposeVoter` and their cancel counterparts are all `onlyOwner`.
- `setStakerChangeDelay`, `setOperatorChangeDelay`, `setVoterChangeDelay` are also `onlyOwner`.

With ownership renounced (to `address(0)`), every role-rotation and delay-tuning path is permanently unreachable. The pool would be frozen at whichever staker/operator/voter is current — including a malicious one — with no governance recovery path. Stake would remain bonded under the current role configuration until lockup matures and the staker (possibly the attacker) drains it.

This change overrides `renounceOwnership()` on `StakePool` to revert with `Errors.OperationNotSupported()`, matching the precedent already established for the same reason in `src/governance/Governance.sol`.

Adds `test_renounceOwnership_Reverts` in `test/unit/staking/StakerSeparation.t.sol` covering:
- `vm.expectRevert(Errors.OperationNotSupported.selector)` from the owner
- post-call assertion that `owner()` is unchanged

## Type of Change

- [ ] 📚 Documentation
- [ ] 🔧 Bug fix
- [ ] 🥂 Improvement
- [ ] 🚀 New feature
- [x] 🔐 Security fix
- [ ] 💥 Breaking change

🤖 Generated with [Claude Code](https://claude.com/claude-code)