### PR TITLE
fix(staking): revert when performance tracker length drifts

### DIFF
--- a/spec_v2/validator_management.spec.md
+++ b/spec_v2/validator_management.spec.md
@@ -340,7 +340,6 @@ interface IValidatorManagement {
     event ValidatorAutoEvicted(address indexed stakePool, uint256 successfulProposals);
     event ValidatorUnderbondedEvicted(address indexed stakePool, uint256 votingPower, uint256 minimumBond);
     event ValidatorRevertedInactive(address indexed stakePool);
-    event PerformanceLengthMismatch(uint256 activeCount, uint256 perfCount);
     event ConsensusKeyRotated(address indexed stakePool, bytes newPubkey);
     event FeeRecipientUpdated(address indexed stakePool, address newRecipient);
     event FeeRecipientApplied(address indexed stakePool, address oldRecipient, address newRecipient);
@@ -577,8 +576,11 @@ auto-eviction is disabled, to enforce the minimum-bond invariant at epoch bounda
 Runs only when `autoEvictEnabled == true`. Reads per-validator success counts from the
 `ValidatorPerformanceTracker`. For each still-ACTIVE validator:
 
-- If the active-set count vs. performance-array length disagrees, emit `PerformanceLengthMismatch`
-  and skip Phase 2 (defensive).
+- If the active-set count vs. performance-array length disagrees, revert with
+  `PerformanceTrackerMisaligned(activeCount, perfCount)`. Silent skipping would let
+  underperforming validators ride epoch after epoch whenever the upstream tracker drifts.
+  Governance can bypass Phase 2 entirely by setting `autoEvictEnabled = false`, which
+  short-circuits this code path before the length check.
 - Compute `successPct = successfulProposals * 100 / totalProposals` (0 if `totalProposals == 0`).
   When `successPct < autoEvictThresholdPct` (0-100), mark the validator PENDING_INACTIVE and emit
   `ValidatorAutoEvicted(pool, successfulProposals)`.

--- a/src/foundation/Errors.sol
+++ b/src/foundation/Errors.sol
@@ -163,6 +163,13 @@ library Errors {
     /// @param actual Actual increase amount
     error VotingPowerIncreaseLimitExceeded(uint256 limit, uint256 actual);
 
+    /// @notice Performance tracker returned an array whose length does not match the
+    ///         active validator count. Indicates upstream state drift; auto-eviction
+    ///         cannot be evaluated safely.
+    /// @param activeCount Active validator count seen by ValidatorManagement
+    /// @param perfCount Length of the performance array returned by the tracker
+    error PerformanceTrackerMisaligned(uint256 activeCount, uint256 perfCount);
+
     /// @notice Moniker exceeds maximum length
     /// @param maxLength Maximum allowed length
     /// @param actualLength Actual moniker length

--- a/src/staking/IValidatorManagement.sol
+++ b/src/staking/IValidatorManagement.sol
@@ -73,9 +73,6 @@ interface IValidatorManagement {
     /// @param minimumBond The expected minimum bond threshold
     event ValidatorUnderbondedEvicted(address indexed stakePool, uint256 votingPower, uint256 minimumBond);
 
-    /// @notice Emitted when performance data array length doesn't match active validator count
-    event PerformanceLengthMismatch(uint256 activeCount, uint256 perfCount);
-
     /// @notice Emitted when a validator's consensus key is rotated
     /// @param stakePool Address of the validator's stake pool
     /// @param newPubkey New BLS public key

--- a/src/staking/ValidatorManagement.sol
+++ b/src/staking/ValidatorManagement.sol
@@ -743,9 +743,12 @@ contract ValidatorManagement is IValidatorManagement {
         uint256 perfLen = perfs.length;
 
         // Strict equality check: perf array length must match active validator count.
+        // Silently skipping would let underperforming validators ride epoch after epoch
+        // whenever the upstream tracker drifts. Reverting forces governance to
+        // investigate (and disable autoEvictEnabled if they need to bypass eviction
+        // while the tracker is fixed — that switch short-circuits Phase 2 above).
         if (activeLen != perfLen) {
-            emit PerformanceLengthMismatch(activeLen, perfLen);
-            return;
+            revert Errors.PerformanceTrackerMisaligned(activeLen, perfLen);
         }
 
         // Note: remainingActive counter is shared and correctly reflects remaining ACTIVE validators after Phase 1

--- a/test/unit/staking/ValidatorManagement.t.sol
+++ b/test/unit/staking/ValidatorManagement.t.sol
@@ -2751,5 +2751,76 @@ contract ValidatorManagementTest is Test {
         assertEq(uint8(validatorManager.getValidatorStatus(bobPool)), uint8(ValidatorStatus.INACTIVE));
         assertEq(uint8(validatorManager.getValidatorStatus(charliePool)), uint8(ValidatorStatus.ACTIVE));
     }
+
+    /// @notice Performance-tracker length drift must revert, not silently skip Phase 2.
+    /// Silent skip would let underperforming validators ride epoch after epoch if the
+    /// tracker ever desynchronises with ValidatorManagement's active set.
+    function test_evictUnderperforming_revertsOnPerfLengthMismatch() public {
+        _createRegisterAndJoin(alice, 50 ether, "alice");
+        _createRegisterAndJoin(bob, 50 ether, "bob");
+        _createRegisterAndJoin(charlie, 50 ether, "charlie");
+        _processEpoch();
+        _processEpoch(); // Advance past epoch 1 (eviction skipped before)
+
+        // Enable auto-evict so Phase 2 (the length check) is reached.
+        vm.prank(SystemAddresses.GOVERNANCE);
+        validatorConfig.setForNextEpoch(
+            MIN_BOND, MAX_BOND, UNBONDING_DELAY, true, VOTING_POWER_INCREASE_LIMIT, MAX_VALIDATOR_SET_SIZE, true, 10
+        );
+        vm.prank(SystemAddresses.RECONFIGURATION);
+        validatorConfig.applyPendingConfig();
+
+        uint256 activeLen = validatorManager.getActiveValidatorCount();
+        assertEq(activeLen, 3, "expected 3 active validators");
+
+        // Return a deliberately short perf array — wrong length triggers the check.
+        IValidatorPerformanceTracker.IndividualPerformance[] memory shortPerfs =
+            new IValidatorPerformanceTracker.IndividualPerformance[](activeLen - 1);
+        for (uint256 i = 0; i < shortPerfs.length; i++) {
+            shortPerfs[i] = IValidatorPerformanceTracker.IndividualPerformance(10, 0);
+        }
+        vm.mockCall(
+            SystemAddresses.PERFORMANCE_TRACKER,
+            abi.encodeWithSelector(IValidatorPerformanceTracker.getAllPerformances.selector),
+            abi.encode(shortPerfs)
+        );
+
+        vm.prank(SystemAddresses.RECONFIGURATION);
+        vm.expectRevert(
+            abi.encodeWithSelector(Errors.PerformanceTrackerMisaligned.selector, activeLen, shortPerfs.length)
+        );
+        validatorManager.evictUnderperformingValidators();
+    }
+
+    /// @notice Sanity: governance can bypass the strict length check by disabling
+    /// autoEvictEnabled, which short-circuits Phase 2 before the length comparison.
+    /// This is the documented recovery path if the perf tracker drifts.
+    function test_evictUnderperforming_autoEvictDisabledBypassesPerfCheck() public {
+        _createRegisterAndJoin(alice, 50 ether, "alice");
+        _createRegisterAndJoin(bob, 50 ether, "bob");
+        _processEpoch();
+        _processEpoch();
+
+        // Auto-evict disabled (last arg false).
+        vm.prank(SystemAddresses.GOVERNANCE);
+        validatorConfig.setForNextEpoch(
+            MIN_BOND, MAX_BOND, UNBONDING_DELAY, true, VOTING_POWER_INCREASE_LIMIT, MAX_VALIDATOR_SET_SIZE, false, 10
+        );
+        vm.prank(SystemAddresses.RECONFIGURATION);
+        validatorConfig.applyPendingConfig();
+
+        // Even with a wrong-length perf array, Phase 2 is short-circuited at the
+        // enabled check above the length comparison, so this must NOT revert.
+        IValidatorPerformanceTracker.IndividualPerformance[] memory shortPerfs =
+            new IValidatorPerformanceTracker.IndividualPerformance[](0);
+        vm.mockCall(
+            SystemAddresses.PERFORMANCE_TRACKER,
+            abi.encodeWithSelector(IValidatorPerformanceTracker.getAllPerformances.selector),
+            abi.encode(shortPerfs)
+        );
+
+        vm.prank(SystemAddresses.RECONFIGURATION);
+        validatorManager.evictUnderperformingValidators();
+    }
 }
 


### PR DESCRIPTION
## Description

`evictUnderperformingValidators` runs in two phases:

1. **Underbonded eviction** — always runs, regardless of perf data.
2. **Performance-based eviction** — only when `autoEvictEnabled == true`, reads from `ValidatorPerformanceTracker`.

Before this PR, Phase 2 emitted a `PerformanceLengthMismatch` event and silently `return`ed when the perf array length did not match the active validator count. That silent skip is dangerous: if the tracker ever drifts (operational bug, mis-ordered reset in `Reconfiguration`, hostile tracker upgrade), underperforming validators continue to earn rewards epoch after epoch, weakening BFT liveness. The event is the only signal, easy to miss without active monitoring.

### Change

Replace the silent return with:

```solidity
if (activeLen != perfLen) {
    revert Errors.PerformanceTrackerMisaligned(activeLen, perfLen);
}
```

This forces governance/operator investigation. Recovery path already exists in the contract: governance can flip `autoEvictEnabled` to `false`, which short-circuits Phase 2 at the `enabled` check above the length comparison. Once the tracker is fixed, re-enable.

Phase 1 (underbonded) is unaffected; it does not depend on the perf tracker and continues to run unconditionally — even if Phase 2 reverts.

### Files

- `src/foundation/Errors.sol` — new `PerformanceTrackerMisaligned(uint256 activeCount, uint256 perfCount)` error
- `src/staking/ValidatorManagement.sol` — silent return → revert
- `src/staking/IValidatorManagement.sol` — remove the now-unused `PerformanceLengthMismatch` event
- `spec_v2/validator_management.spec.md` — update spec to match new behavior
- `test/unit/staking/ValidatorManagement.t.sol` — two new tests

### Tests

- `test_evictUnderperforming_revertsOnPerfLengthMismatch` — sets up 3 active validators, mocks perf-tracker to return a 2-element array, asserts `PerformanceTrackerMisaligned(3, 2)` revert.
- `test_evictUnderperforming_autoEvictDisabledBypassesPerfCheck` — same setup with `autoEvictEnabled = false`, asserts no revert (governance bypass works as documented).

Full ValidatorManagement suite: 120 passed / 0 failed.

## Type of Change

- [ ] 📚 Documentation
- [ ] 🔧 Bug fix
- [ ] 🥂 Improvement
- [ ] 🚀 New feature
- [x] 🔐 Security fix
- [ ] 💥 Breaking change

🤖 Generated with [Claude Code](https://claude.com/claude-code)