### PR TITLE
fix(staking): tolerate pool revert in _getValidatorVotingPower

### DIFF
--- a/src/staking/ValidatorManagement.sol
+++ b/src/staking/ValidatorManagement.sol
@@ -996,15 +996,25 @@ contract ValidatorManagement is IValidatorManagement {
 
     /// @notice Get validator's voting power (capped at maximumBond)
     /// @dev The call chain (Staking.getPoolVotingPower → StakePool.getVotingPower → _getEffectiveStakeAt)
-    ///      is entirely pure view functions with safe arithmetic. For factory-created StakePools,
-    ///      this call cannot revert. No try/catch is needed.
+    ///      is entirely pure view over factory-created storage with checked arithmetic,
+    ///      so the call SHOULD not revert today. The try/catch is defense-in-depth: this
+    ///      function is invoked inside unbounded loops during epoch transition (eviction,
+    ///      bond sync, next-set computation). If any future regression — corrupted bucket
+    ///      array, division-by-zero in a config tweak, panic in a binary-search update —
+    ///      introduces a revert path, the chain would halt at every epoch boundary until a
+    ///      contract upgrade ships. Returning 0 instead drops that one validator out of
+    ///      the set on the next pass, which is the correct disposition for a pool whose
+    ///      bookkeeping is broken.
     function _getValidatorVotingPower(
         address stakePool
     ) internal view returns (uint256) {
         uint64 now_ = ITimestamp(SystemAddresses.TIMESTAMP).nowMicroseconds();
-        uint256 power = IStaking(SystemAddresses.STAKING).getPoolVotingPower(stakePool, now_);
         uint256 maxBond = IValidatorConfig(SystemAddresses.VALIDATOR_CONFIG).maximumBond();
-        return power > maxBond ? maxBond : power;
+        try IStaking(SystemAddresses.STAKING).getPoolVotingPower(stakePool, now_) returns (uint256 power) {
+            return power > maxBond ? maxBond : power;
+        } catch {
+            return 0;
+        }
     }
 
     /// @notice Compute the complete next epoch validator set

--- a/test/unit/staking/ValidatorManagement.t.sol
+++ b/test/unit/staking/ValidatorManagement.t.sol
@@ -2700,6 +2700,50 @@ contract ValidatorManagementTest is Test {
         assertEq(uint8(validatorManager.getValidatorStatus(bobPool)), uint8(ValidatorStatus.ACTIVE));
     }
 
+    /// @notice A single pool whose getVotingPower reverts must NOT halt the eviction
+    /// loop (which would halt epoch transitions and the whole chain). The reverting
+    /// pool should be treated as having zero voting power — evicted by Phase 1's
+    /// underbonded check — while the other validators continue normally.
+    function test_eviction_toleratesPoolRevert() public {
+        // Three validators so the last-validator liveness guard doesn't fire when
+        // Alice gets evicted.
+        address alicePool = _createRegisterAndJoin(alice, MIN_BOND, "alice");
+        address bobPool = _createRegisterAndJoin(bob, MIN_BOND * 2, "bob");
+        address charliePool = _createRegisterAndJoin(charlie, MIN_BOND * 2, "charlie");
+        _processEpoch();
+        _processEpoch(); // advance past epoch 1 (eviction is skipped on epoch <= 1)
+
+        // Simulate a malfunctioning pool: every getPoolVotingPower(alicePool, *)
+        // call reverts. Partial-match means any timestamp arg matches.
+        vm.mockCallRevert(
+            SystemAddresses.STAKING,
+            abi.encodeWithSelector(IStaking.getPoolVotingPower.selector, alicePool),
+            bytes("pool storage corrupted")
+        );
+
+        // Phase 1 reads voting power for every active validator. Without the
+        // try/catch in _getValidatorVotingPower, Alice's revert would propagate
+        // out of evictUnderperformingValidators and halt the epoch transition.
+        vm.prank(SystemAddresses.RECONFIGURATION);
+        validatorManager.evictUnderperformingValidators();
+
+        // Alice's pool reported 0 voting power (via catch), so the underbonded
+        // check evicted her into PENDING_INACTIVE.
+        assertEq(
+            uint8(validatorManager.getValidatorStatus(alicePool)),
+            uint8(ValidatorStatus.PENDING_INACTIVE),
+            "reverting pool should be evicted as underbonded"
+        );
+
+        // Bob and Charlie are untouched.
+        assertEq(uint8(validatorManager.getValidatorStatus(bobPool)), uint8(ValidatorStatus.ACTIVE), "bob still ACTIVE");
+        assertEq(
+            uint8(validatorManager.getValidatorStatus(charliePool)),
+            uint8(ValidatorStatus.ACTIVE),
+            "charlie still ACTIVE"
+        );
+    }
+
     /// @notice Test that both underbonded and underperforming validators are evicted
     function test_d3_2_underbondedAndUnderperforming_bothEvicted() public {
         address alicePool = _createRegisterAndJoin(alice, 20 ether, "alice");


### PR DESCRIPTION
## Description

`_getValidatorVotingPower` is invoked inside unbounded loops during epoch transitions:

- `evictUnderperformingValidators` (Phase 1 — every active validator)
- `_syncBondsAndCalculateTotalVotingPower` (every active validator)
- `_calculateStayingVotingPower` (every active validator that isn't leaving)
- `_computeNextEpochValidatorSet` (every active and pending-active validator)

Today the call chain through `Staking.getPoolVotingPower` and `StakePool.getVotingPower` is pure view over factory-created storage with checked arithmetic, so the call SHOULD not revert in practice. The existing comment on the function notes this and explicitly says "no try/catch is needed."

The chain's liveness should not depend on that invariant being preserved forever, however. A future regression — a corrupted bucket array, division-by-zero introduced by a config tweak, a panic in a binary-search update, a new code path with an unguarded require — would propagate the revert out of `evictUnderperformingValidators` or `onNewEpoch` and halt every epoch boundary until a contract upgrade shipped. The attack surface reduces to: "any one validator's pool starts reverting on a voting-power query."

### Change

Wrap the external `IStaking.getPoolVotingPower` call in `try/catch`. On revert, return 0. The behavioral effects:

- **Eviction Phase 1**: The misbehaving pool is treated as 0 power, fails the `power < minimumBond` check, gets evicted into `PENDING_INACTIVE`. Correct disposition for a malfunctioning pool.
- **Bond sync and totals**: The misbehaving pool contributes 0 to the next-epoch total. Correct disposition for an excluded pool.
- **Registration / join paths**: still produce informative errors. A pool returning 0 fails the downstream `InsufficientBond` check loudly — the operator gets `InsufficientBond(minBond, 0)` instead of a low-level revert.

The cost is one try/catch wrapper. The benefit is permanent immunity to a class of "one-pool-halts-the-chain" regressions.

### Test

`test_eviction_toleratesPoolRevert` in `ValidatorManagement.t.sol`:

1. Three validators registered and active (Alice, Bob, Charlie) — three so the last-validator liveness guard does not fire when Alice is evicted.
2. `vm.mockCallRevert(STAKING, IStaking.getPoolVotingPower.selector | alicePool, "pool storage corrupted")` — every voting-power query for Alice's pool reverts.
3. Trigger `evictUnderperformingValidators`. Without this PR the call would propagate the revert and the test would fail with the mock error. With the PR it completes.
4. Asserts Alice is `PENDING_INACTIVE` (caught revert → 0 power → underbonded → evicted) and Bob/Charlie remain `ACTIVE`.

Full ValidatorManagement suite: 119 passed / 0 failed.

## Type of Change

- [ ] 📚 Documentation
- [ ] 🔧 Bug fix
- [ ] 🥂 Improvement
- [ ] 🚀 New feature
- [x] 🔐 Security fix
- [ ] 💥 Breaking change

🤖 Generated with [Claude Code](https://claude.com/claude-code)