### PR TITLE
fix(staking): honor allowValidatorSetChange freeze during activation (#447)

### DIFF
--- a/src/staking/ValidatorManagement.sol
+++ b/src/staking/ValidatorManagement.sol
@@ -1093,8 +1093,19 @@ contract ValidatorManagement is IValidatorManagement {
         uint256 addedPower = 0;
 
         uint256 minimumBond = IValidatorConfig(SystemAddresses.VALIDATOR_CONFIG).minimumBond();
+        // Audit #447: mirror evictUnderperformingValidators — no validator-set churn under freeze.
+        // joinValidatorSet already rejects new joins once the storage flag flips to false, but
+        // `_pendingActive` may still hold (a) race-window joins from the same epoch as the
+        // setForNextEpoch call and (b) carry-overs deferred by votingPowerIncreaseLimitPct.
+        // Defer the whole queue so the freeze invariant holds.
+        bool freeze = !IValidatorConfig(SystemAddresses.VALIDATOR_CONFIG).allowValidatorSetChange();
         for (uint256 i = 0; i < pendingActiveLen; i++) {
             address pool = _pendingActive[i];
+            if (freeze) {
+                result.toKeepPending[result.keepPendingCount] = pool;
+                result.keepPendingCount++;
+                continue;
+            }
             uint256 power = _getValidatorVotingPower(pool);
 
             // Check minimum bond requirement

--- a/test/unit/staking/ValidatorManagement.t.sol
+++ b/test/unit/staking/ValidatorManagement.t.sol
@@ -423,6 +423,92 @@ contract ValidatorManagementTest is Test {
         assertEq(stillActive, 1, "Without freeze, eviction must run and leave exactly 1 validator");
     }
 
+    /// @notice Audit #447: a join landed in the race window between
+    ///         setForNextEpoch(allowValidatorSetChange=false) and the epoch boundary must
+    ///         NOT be promoted to ACTIVE at the boundary on which the freeze takes effect.
+    ///         Before the fix, `_computeNextEpochValidatorSet` did not read the freeze flag,
+    ///         so any pool already in `_pendingActive` was promoted regardless — silently
+    ///         defeating governance's incident-response freeze.
+    function test_audit447_freezeBlocksPendingActiveActivation() public {
+        // Seed the active set so currentTotal > 0 (otherwise the increase-limit branch
+        // is a no-op and the test would still pass without the fix).
+        address seedPool = _createRegisterAndJoin(alice, MIN_BOND * 10, "alice");
+        _processEpoch(); // seed becomes ACTIVE
+        assertEq(
+            uint8(validatorManager.getValidator(seedPool).status),
+            uint8(ValidatorStatus.ACTIVE),
+            "seed must be ACTIVE before the race"
+        );
+
+        // The attacker registers and joins while the flag is still TRUE (race window).
+        address attackerPool = _createRegisterAndJoin(bob, MIN_BOND, "bob");
+        assertEq(
+            uint8(validatorManager.getValidator(attackerPool).status),
+            uint8(ValidatorStatus.PENDING_ACTIVE),
+            "attacker landed in _pendingActive during the race window"
+        );
+
+        // Governance applies the freeze (mirrors the apply step that
+        // Reconfiguration._applyReconfiguration runs before onNewEpoch).
+        vm.prank(SystemAddresses.GOVERNANCE);
+        validatorConfig.setForNextEpoch(
+            MIN_BOND,
+            MAX_BOND,
+            UNBONDING_DELAY,
+            false, // allowValidatorSetChange = false  (FREEZE takes effect now)
+            VOTING_POWER_INCREASE_LIMIT,
+            MAX_VALIDATOR_SET_SIZE,
+            false,
+            0
+        );
+        vm.prank(SystemAddresses.RECONFIGURATION);
+        validatorConfig.applyPendingConfig();
+
+        // Process the boundary on which the freeze first applies. The attacker MUST stay
+        // in PENDING_ACTIVE — promotion would defeat the freeze.
+        _processEpoch();
+
+        assertEq(
+            uint8(validatorManager.getValidator(attackerPool).status),
+            uint8(ValidatorStatus.PENDING_ACTIVE),
+            "attacker must remain PENDING_ACTIVE under freeze"
+        );
+        assertEq(validatorManager.getActiveValidatorCount(), 1, "active set must not grow under freeze");
+
+        // The freeze must hold across subsequent boundaries too — the queue is not drained
+        // by repeated reconfiguration while the flag is false.
+        _processEpoch();
+        _processEpoch();
+        assertEq(
+            uint8(validatorManager.getValidator(attackerPool).status),
+            uint8(ValidatorStatus.PENDING_ACTIVE),
+            "attacker must still be PENDING_ACTIVE after additional frozen boundaries"
+        );
+
+        // Un-freeze and process one more boundary — now the queue drains.
+        vm.prank(SystemAddresses.GOVERNANCE);
+        validatorConfig.setForNextEpoch(
+            MIN_BOND,
+            MAX_BOND,
+            UNBONDING_DELAY,
+            true, // un-freeze
+            VOTING_POWER_INCREASE_LIMIT,
+            MAX_VALIDATOR_SET_SIZE,
+            false,
+            0
+        );
+        vm.prank(SystemAddresses.RECONFIGURATION);
+        validatorConfig.applyPendingConfig();
+
+        _processEpoch();
+        assertEq(
+            uint8(validatorManager.getValidator(attackerPool).status),
+            uint8(ValidatorStatus.ACTIVE),
+            "attacker activates normally once freeze is lifted"
+        );
+        assertEq(validatorManager.getActiveValidatorCount(), 2, "active set grows after un-freeze");
+    }
+
     /// @notice Audit #187: registerValidator must be blocked during reconfiguration
     ///         to prevent consensus pubkey writes from interleaving with a live DKG session,
     ///         which would produce nondeterministic DKG reads across validators.


### PR DESCRIPTION
## Summary

`_computeNextEpochValidatorSet` previously promoted every entry in `_pendingActive` regardless of the live `allowValidatorSetChange` flag. Because `Reconfiguration._applyReconfiguration` writes the new flag value via `ValidatorConfig.applyPendingConfig()` **before** calling `onNewEpoch()`, the very boundary on which a freeze takes effect would still activate any pending join that landed in the race window — silently defeating governance's incident-response freeze.

This PR mirrors the existing `evictUnderperformingValidators` freeze handling (see `Audit #154`): when the flag is false, defer every entry in `_pendingActive` to `toKeepPending` so the queue waits until governance unfreezes.

Closes Galxe/gravity-audit#447.

## The bug, in one diagram

```
T0  governance setForNextEpoch(allowSet=false)        flag(live)=TRUE, pending=FALSE
T1  attacker joinValidatorSet(attackerPool)           ── joinValidatorSet reads TRUE ✓
                                                          attackerPool → _pendingActive
T2  epoch boundary
    step 1: applyPendingConfig()                      ── flag(live) = FALSE
    step 2: onNewEpoch()
              └─ _computeNextEpochValidatorSet()      ── did NOT read flag ✗
                   └─ attackerPool promoted to ACTIVE   freeze defeated
```

Two queueing paths feed this exposure:
- **Race window**: any join in the current epoch between `setForNextEpoch(...false)` and the epoch boundary (the storage flag flips only at the boundary, so the live check at `joinValidatorSet` still reads TRUE).
- **Carry-over**: entries deferred to `toKeepPending` by `votingPowerIncreaseLimitPct` in earlier epochs that have not yet drained.

## Fix

`src/staking/ValidatorManagement.sol` — at the top of step 3 of `_computeNextEpochValidatorSet`, branch on `allowValidatorSetChange()`. If false, every `_pendingActive` entry goes to `toKeepPending` instead of being processed for activation. The activation loop (minimumBond / votingPowerIncreaseLimitPct) runs unchanged when the flag is true.

This is the same shape as `evictUnderperformingValidators` (`ValidatorManagement.sol:696-698`), keeping the contract internally consistent on the meaning of "freeze".

## What this PR does NOT change (intentional)

- **`_pendingInactive`**: leaves queued before the freeze still complete at the boundary. Locking deactivation is a separate semantic decision (\"freeze = lock membership\" vs \"freeze = stop new churn\"). The minimal fix for #447 is activation-side only.
- **`joinValidatorSet` / `leaveValidatorSet`**: already gate on the live flag — no change needed.
- **`forceLeaveValidatorSet`**: governance retains the ability to pull entries out of `_pendingActive` during a freeze (it doesn't check the flag), preserved as the incident-response escape hatch.

## Tests

`test/unit/staking/ValidatorManagement.t.sol::test_audit447_freezeBlocksPendingActiveActivation` exercises the full race scenario end-to-end:

1. Seed an ACTIVE validator so `currentTotal > 0` (otherwise the increase-limit branch would no-op and the test would pass without the fix).
2. Attacker joins → lands in `_pendingActive` while flag is still TRUE.
3. Governance sets the freeze, `applyPendingConfig()` runs.
4. Boundary on which freeze takes effect — assert attacker stays `PENDING_ACTIVE`, `getActiveValidatorCount()` unchanged.
5. Two more frozen boundaries — assert still `PENDING_ACTIVE` (no per-epoch drain).
6. Un-freeze, one more boundary — assert promotion to `ACTIVE`.

## Test plan

- [x] `forge build` (clean, only pre-existing lint notes)
- [x] `FOUNDRY_TEST=test/unit forge test` — **1011 passed, 0 failed**
- [x] `forge fmt` on both changed files
- [ ] CI green
- [ ] Reviewer to weigh in on whether the symmetric `_pendingInactive` lock should also land (separate PR if so)

🤖 Generated with [Claude Code](https://claude.com/claude-code)