### PR TITLE
feat(genesis-tool): verify Governance owner + isInitialized post-genesis

### DIFF
--- a/genesis-tool/src/main.rs
+++ b/genesis-tool/src/main.rs
@@ -72,6 +72,13 @@ enum Commands {
         /// Path to the genesis.json file to verify
         #[arg(short, long)]
         genesis_file: String,
+
+        /// Optional path to the genesis config used to produce the artifact.
+        /// When provided, `Governance.owner()` must equal the config's
+        /// `governanceOwner`. Without it we only check the on-chain owner is
+        /// non-zero and `isInitialized()` is true.
+        #[arg(short, long)]
+        config_file: Option<String>,
     },
 }
 
@@ -132,8 +139,8 @@ async fn main() -> Result<()> {
         Commands::Generate { byte_code_dir, config_file, output } => {
             run_generate(byte_code_dir, config_file, output).await
         }
-        Commands::Verify { genesis_file } => {
-            run_verify(genesis_file)
+        Commands::Verify { genesis_file, config_file } => {
+            run_verify(genesis_file, config_file.as_deref())
         }
     };
 
@@ -184,10 +191,10 @@ async fn run_generate(byte_code_dir: &str, config_file: &str, output: &str) -> R
     Ok(())
 }
 
-fn run_verify(genesis_file: &str) -> Result<()> {
+fn run_verify(genesis_file: &str, config_file: Option<&str>) -> Result<()> {
     info!("Starting Gravity Genesis Verify");
-    
-    let result = verify::verify_genesis_file(genesis_file)?;
+
+    let result = verify::verify_genesis_file(genesis_file, config_file)?;
     verify::print_verify_summary(&result);
     
     if result.success {

--- a/genesis-tool/src/post_genesis.rs
+++ b/genesis-tool/src/post_genesis.rs
@@ -1,5 +1,7 @@
+use alloy_sol_macro::sol;
+use alloy_sol_types::SolCall;
 use revm::{DatabaseRef, InMemoryDB, db::BundleState};
-use revm_primitives::{ExecutionResult, SpecId, TxEnv, hex};
+use revm_primitives::{Address, ExecutionResult, SpecId, TxEnv, hex};
 use tracing::{error, info};
 
 use crate::{
@@ -7,8 +9,15 @@ use crate::{
     genesis::{
         GenesisConfig, call_get_active_validators, print_active_validators_result,
     },
-    utils::execute_revm_sequential,
+    utils::{GOVERNANCE_ADDR, execute_revm_sequential, new_system_call_txn},
 };
+
+sol! {
+    interface IGovernance {
+        function owner() external view returns (address);
+        function isInitialized() external view returns (bool);
+    }
+}
 
 /// Generic template for handling execution results
 ///
@@ -97,16 +106,246 @@ fn verify_active_validators(db: impl DatabaseRef, bundle_state: BundleState, con
     )
 }
 
+/// Verify that `Governance.owner()` and `Governance.isInitialized()` reflect
+/// the values the config asked for. Without this, a typo or zero address in
+/// `governanceOwner` is silently baked into a sealed genesis artifact and
+/// only surfaces after launch — when `renounceOwnership` is already disabled
+/// and the executor set is unmanageable for the lifetime of the chain.
+fn verify_governance_owner(
+    db: impl DatabaseRef,
+    bundle_state: BundleState,
+    config: &GenesisConfig,
+) -> Result<(), String> {
+    let expected_owner: Address = config
+        .governance_owner
+        .parse()
+        .map_err(|e| format!("Invalid governanceOwner address in config {:?}: {}", config.governance_owner, e))?;
+    verify_governance_owner_at(
+        db,
+        bundle_state,
+        expected_owner,
+        config.chain_id,
+        resolve_block_timestamp(config),
+    )
+}
+
+/// Primitive-typed variant of `verify_governance_owner`. Exists so unit tests
+/// can drive the on-chain check without constructing a full `GenesisConfig`.
+fn verify_governance_owner_at(
+    db: impl DatabaseRef,
+    bundle_state: BundleState,
+    expected_owner: Address,
+    chain_id: u64,
+    block_timestamp_secs: u64,
+) -> Result<(), String> {
+    let owner_txn = new_system_call_txn(
+        GOVERNANCE_ADDR,
+        IGovernance::ownerCall {}.abi_encode().into(),
+    );
+
+    execute_verification(
+        db,
+        bundle_state,
+        owner_txn,
+        "governance owner",
+        chain_id,
+        block_timestamp_secs,
+        |result| {
+            handle_execution_result(result, "Governance.owner()", |output_bytes| {
+                let decoded = IGovernance::ownerCall::abi_decode_returns(output_bytes, false)
+                    .map_err(|e| format!("Failed to decode Governance.owner(): {:?}", e))?;
+                let actual_owner = decoded._0;
+                if actual_owner != expected_owner {
+                    let msg = format!(
+                        "Governance owner mismatch: config governanceOwner={:?}, on-chain owner()={:?}",
+                        expected_owner, actual_owner
+                    );
+                    error!("❌ {}", msg);
+                    return Err(msg);
+                }
+                info!("✅ Governance.owner() = {:?} matches config", actual_owner);
+                Ok(())
+            })
+        },
+    )
+}
+
+/// Verify `Governance.isInitialized() == true` so a missing/skipped Genesis
+/// initialize call cannot ship as a "valid" artifact.
+fn verify_governance_initialized(
+    db: impl DatabaseRef,
+    bundle_state: BundleState,
+    config: &GenesisConfig,
+) -> Result<(), String> {
+    verify_governance_initialized_at(
+        db,
+        bundle_state,
+        config.chain_id,
+        resolve_block_timestamp(config),
+    )
+}
+
+fn verify_governance_initialized_at(
+    db: impl DatabaseRef,
+    bundle_state: BundleState,
+    chain_id: u64,
+    block_timestamp_secs: u64,
+) -> Result<(), String> {
+    let txn = new_system_call_txn(
+        GOVERNANCE_ADDR,
+        IGovernance::isInitializedCall {}.abi_encode().into(),
+    );
+
+    execute_verification(
+        db,
+        bundle_state,
+        txn,
+        "governance isInitialized",
+        chain_id,
+        block_timestamp_secs,
+        |result| {
+            handle_execution_result(result, "Governance.isInitialized()", |output_bytes| {
+                let decoded = IGovernance::isInitializedCall::abi_decode_returns(output_bytes, false)
+                    .map_err(|e| format!("Failed to decode Governance.isInitialized(): {:?}", e))?;
+                if !decoded._0 {
+                    let msg = "Governance.isInitialized() returned false — Genesis.initialize did not run".to_string();
+                    error!("❌ {}", msg);
+                    return Err(msg);
+                }
+                info!("✅ Governance.isInitialized() = true");
+                Ok(())
+            })
+        },
+    )
+}
+
 pub fn verify_result(
     db: InMemoryDB,
     bundle_state: BundleState,
     config: &GenesisConfig,
 ) -> Result<(), String> {
     verify_active_validators(db.clone(), bundle_state.clone(), config)?;
+    verify_governance_initialized(db.clone(), bundle_state.clone(), config)?;
+    verify_governance_owner(db.clone(), bundle_state.clone(), config)?;
     // Add more verification steps as needed:
     // - verify_jwks()
     // - verify_epoch_config()
     // - verify_randomness_config()
     // etc.
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use revm_primitives::{AccountInfo, Bytecode, Bytes, U256};
+
+    // The verifier hits Governance via the SYSTEM_CALLER account. revm needs
+    // that caller to exist (with enough nonce headroom) before it will run
+    // the call; otherwise the txn aborts before our stub bytecode executes
+    // and we'd be testing the wrong thing.
+    fn plant_system_caller(db: &mut InMemoryDB) {
+        let info = AccountInfo {
+            balance: U256::from(1_000_000_000_000_000_000_u128),
+            nonce: 1,
+            code_hash: revm_primitives::KECCAK_EMPTY,
+            code: None,
+        };
+        db.insert_account_info(crate::utils::SYSTEM_CALLER, info);
+    }
+
+    /// Plant raw EVM bytecode at `addr`. The bytecode ignores calldata, so the
+    /// same stub works for any function selector — sufficient for tests that
+    /// only call one method per planted contract.
+    fn plant_code(db: &mut InMemoryDB, addr: Address, code: Vec<u8>) {
+        let bytecode = Bytecode::new_raw(Bytes::from(code));
+        let info = AccountInfo {
+            balance: U256::ZERO,
+            nonce: 1,
+            code_hash: bytecode.hash_slow(),
+            code: Some(bytecode),
+        };
+        db.insert_account_info(addr, info);
+    }
+
+    /// Stub bytecode that always ABI-returns `addr` as a 32-byte word.
+    /// PUSH20 addr; PUSH1 0; MSTORE; PUSH1 32; PUSH1 0; RETURN
+    fn stub_returning_address(addr: Address) -> Vec<u8> {
+        let mut code = Vec::with_capacity(29);
+        code.push(0x73);
+        code.extend_from_slice(addr.as_slice());
+        code.extend_from_slice(&[0x60, 0x00, 0x52, 0x60, 0x20, 0x60, 0x00, 0xf3]);
+        code
+    }
+
+    /// Stub bytecode that always ABI-returns a single uint256 word `value`.
+    fn stub_returning_uint(value: u8) -> Vec<u8> {
+        vec![0x60, value, 0x60, 0x00, 0x52, 0x60, 0x20, 0x60, 0x00, 0xf3]
+    }
+
+    #[test]
+    fn governance_owner_matches_passes() {
+        let owner: Address = "0x000000000000000000000000000000000000dEaD"
+            .parse()
+            .unwrap();
+        let mut db = InMemoryDB::default();
+        plant_system_caller(&mut db);
+        plant_code(&mut db, GOVERNANCE_ADDR, stub_returning_address(owner));
+
+        let result = verify_governance_owner_at(db, BundleState::default(), owner, 1337, 1_700_000_000);
+        assert!(result.is_ok(), "expected Ok, got {:?}", result);
+    }
+
+    #[test]
+    fn governance_owner_mismatch_fails() {
+        let on_chain: Address = "0x000000000000000000000000000000000000dEaD"
+            .parse()
+            .unwrap();
+        let expected: Address = "0x000000000000000000000000000000000000bEEf"
+            .parse()
+            .unwrap();
+        let mut db = InMemoryDB::default();
+        plant_system_caller(&mut db);
+        plant_code(&mut db, GOVERNANCE_ADDR, stub_returning_address(on_chain));
+
+        let result =
+            verify_governance_owner_at(db, BundleState::default(), expected, 1337, 1_700_000_000);
+        let err = result.expect_err("expected Err on owner mismatch");
+        assert!(
+            err.to_lowercase().contains("mismatch"),
+            "error should mention mismatch, got: {}",
+            err
+        );
+        // The error must surface BOTH addresses so a CI log makes the gap
+        // diagnosable without re-running the tool.
+        assert!(err.contains("dead"), "error should include on-chain owner, got: {}", err);
+        assert!(err.contains("beef"), "error should include expected owner, got: {}", err);
+    }
+
+    #[test]
+    fn governance_initialized_true_passes() {
+        let mut db = InMemoryDB::default();
+        plant_system_caller(&mut db);
+        plant_code(&mut db, GOVERNANCE_ADDR, stub_returning_uint(1));
+
+        let result =
+            verify_governance_initialized_at(db, BundleState::default(), 1337, 1_700_000_000);
+        assert!(result.is_ok(), "expected Ok, got {:?}", result);
+    }
+
+    #[test]
+    fn governance_initialized_false_fails() {
+        let mut db = InMemoryDB::default();
+        plant_system_caller(&mut db);
+        plant_code(&mut db, GOVERNANCE_ADDR, stub_returning_uint(0));
+
+        let result =
+            verify_governance_initialized_at(db, BundleState::default(), 1337, 1_700_000_000);
+        let err = result.expect_err("expected Err when isInitialized=false");
+        assert!(
+            err.contains("initialize did not run") || err.contains("returned false"),
+            "error should explain the missing initialize, got: {}",
+            err
+        );
+    }
 }

--- a/genesis-tool/src/verify.rs
+++ b/genesis-tool/src/verify.rs
@@ -16,8 +16,8 @@ use tracing::{error, info, warn};
 
 use crate::execute::prepare_env;
 use crate::utils::{
-    execute_revm_sequential, new_system_call_txn, EPOCH_CONFIG_ADDR, SYSTEM_CALLER,
-    VALIDATOR_MANAGER_ADDR,
+    execute_revm_sequential, new_system_call_txn, EPOCH_CONFIG_ADDR, GOVERNANCE_ADDR,
+    SYSTEM_CALLER, VALIDATOR_MANAGER_ADDR,
 };
 
 // ============================================================================
@@ -58,6 +58,11 @@ sol! {
 
     // EpochConfig.epochIntervalMicros()
     function epochIntervalMicros() external view returns (uint64);
+
+    interface IGovernance {
+        function owner() external view returns (address);
+        function isInitialized() external view returns (bool);
+    }
 }
 
 /// Result of genesis verification
@@ -79,10 +84,42 @@ pub struct ValidatorInfo {
     pub has_fullnode_addresses: bool,
 }
 
-/// Verify an existing genesis.json file
-pub fn verify_genesis_file(genesis_path: &str) -> Result<VerifyResult> {
+/// Verify an existing genesis.json file. If `config_path` is provided, also
+/// asserts that `Governance.owner()` equals the config's `governanceOwner`
+/// — without that field we can only check the on-chain owner is non-zero and
+/// `isInitialized()` is true.
+pub fn verify_genesis_file(
+    genesis_path: &str,
+    config_path: Option<&str>,
+) -> Result<VerifyResult> {
     info!("=== Genesis Verification ===");
     info!("Loading genesis file: {}", genesis_path);
+
+    // Load expected governance owner from config if a config path was given.
+    // Parse loosely (as serde_json::Value) so this code stays decoupled from
+    // GenesisConfig's full schema — verify must keep working even if config
+    // adds new required fields.
+    let expected_governance_owner: Option<Address> = match config_path {
+        Some(path) => {
+            let content = fs::read_to_string(path)
+                .context(format!("Failed to read config file: {}", path))?;
+            let v: serde_json::Value = serde_json::from_str(&content)
+                .context("Failed to parse config JSON")?;
+            let owner_str = v
+                .get("governanceOwner")
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| anyhow!("Config missing 'governanceOwner' field"))?;
+            let parsed: Address = owner_str
+                .parse()
+                .map_err(|e| anyhow!("Invalid governanceOwner in config {:?}: {}", owner_str, e))?;
+            info!("Loaded expected Governance owner from config: {:?}", parsed);
+            Some(parsed)
+        }
+        None => {
+            info!("No --config-file provided; will only check non-zero owner + isInitialized");
+            None
+        }
+    };
 
     // 1. Load genesis.json
     let genesis_content = fs::read_to_string(genesis_path)
@@ -181,6 +218,13 @@ pub fn verify_genesis_file(genesis_path: &str) -> Result<VerifyResult> {
 
     info!("ValidatorManagement contract found at {:?}", vm_addr);
 
+    // 3a. Verify Governance state. Collected separately and merged into the
+    // final result so a governance failure doesn't short-circuit the
+    // validator/epoch checks — we want a single comprehensive failure report
+    // out of one verify run, not the first-failure-wins.
+    info!("Verifying Governance state...");
+    let governance_errors = verify_governance(&db, expected_governance_owner);
+
     // 3. First verify epoch interval from EpochConfig
     info!("Verifying epoch interval from EpochConfig...");
     let epoch_interval = verify_epoch_interval(&db);
@@ -214,12 +258,142 @@ pub fn verify_genesis_file(genesis_path: &str) -> Result<VerifyResult> {
     match result {
         Ok((results, _)) => {
             if let Some(exec_result) = results.first() {
-                return process_execution_result(exec_result, epoch_interval);
+                let mut result = process_execution_result(exec_result, epoch_interval)?;
+                if !governance_errors.is_empty() {
+                    result.success = false;
+                    result.errors.extend(governance_errors);
+                }
+                return Ok(result);
             }
             Err(anyhow!("No execution result returned"))
         }
         Err(e) => Err(anyhow!("EVM execution failed: {:?}", e)),
     }
+}
+
+/// Inspect the planted Governance contract. Always asserts the contract is
+/// initialized and its `owner()` is non-zero; if `expected_owner` is provided
+/// (because the caller passed `--config-file`), also asserts strict equality.
+///
+/// Returns a list of human-readable error strings — empty if all checks pass.
+/// This shape mirrors the way other accumulating checks in this module work:
+/// one verify invocation should surface every problem, not just the first.
+fn verify_governance(
+    db: &revm::InMemoryDB,
+    expected_owner: Option<Address>,
+) -> Vec<String> {
+    let mut errors = Vec::new();
+
+    // --- isInitialized() ---
+    let init_call = IGovernance::isInitializedCall {};
+    let init_input: Bytes = init_call.abi_encode().into();
+    let init_tx = new_system_call_txn(GOVERNANCE_ADDR, init_input);
+    // See note above on the getActiveValidators call site: block.timestamp = 0
+    // is safe for these view-call ABI probes.
+    let env = prepare_env(1337, 0);
+    match execute_revm_sequential(db.clone(), SpecId::LATEST, env, &[init_tx], None) {
+        Ok((results, _)) => match results.first() {
+            Some(ExecutionResult::Success { output, .. }) => {
+                let bytes = match output {
+                    revm_primitives::Output::Call(b) => b,
+                    revm_primitives::Output::Create(b, _) => b,
+                };
+                match IGovernance::isInitializedCall::abi_decode_returns(bytes, false) {
+                    Ok(d) if d._0 => info!("✅ Governance.isInitialized() = true"),
+                    Ok(_) => {
+                        let msg = "Governance.isInitialized() returned false — Genesis.initialize did not run".to_string();
+                        error!("❌ {}", msg);
+                        errors.push(msg);
+                    }
+                    Err(e) => {
+                        let msg = format!("Failed to decode Governance.isInitialized(): {:?}", e);
+                        error!("❌ {}", msg);
+                        errors.push(msg);
+                    }
+                }
+            }
+            Some(other) => {
+                let msg = format!("Governance.isInitialized() did not succeed: {:?}", other);
+                error!("❌ {}", msg);
+                errors.push(msg);
+            }
+            None => {
+                let msg = "Governance.isInitialized() returned no execution result".to_string();
+                error!("❌ {}", msg);
+                errors.push(msg);
+            }
+        },
+        Err(e) => {
+            let msg = format!("Governance.isInitialized() EVM error: {:?}", e);
+            error!("❌ {}", msg);
+            errors.push(msg);
+        }
+    }
+
+    // --- owner() ---
+    let owner_call = IGovernance::ownerCall {};
+    let owner_input: Bytes = owner_call.abi_encode().into();
+    let owner_tx = new_system_call_txn(GOVERNANCE_ADDR, owner_input);
+    let env = prepare_env(1337, 0);
+    match execute_revm_sequential(db.clone(), SpecId::LATEST, env, &[owner_tx], None) {
+        Ok((results, _)) => match results.first() {
+            Some(ExecutionResult::Success { output, .. }) => {
+                let bytes = match output {
+                    revm_primitives::Output::Call(b) => b,
+                    revm_primitives::Output::Create(b, _) => b,
+                };
+                match IGovernance::ownerCall::abi_decode_returns(bytes, false) {
+                    Ok(decoded) => {
+                        let actual = decoded._0;
+                        if actual == Address::ZERO {
+                            // owner = 0 is structurally invalid: Governance.initialize
+                            // rejects address(0), and renounceOwnership reverts. If we
+                            // see it here, the artifact is broken regardless of config.
+                            let msg = "Governance.owner() = address(0) — Governance is unmanageable".to_string();
+                            error!("❌ {}", msg);
+                            errors.push(msg);
+                        } else {
+                            info!("Governance.owner() = {:?}", actual);
+                        }
+                        if let Some(expected) = expected_owner {
+                            if actual != expected {
+                                let msg = format!(
+                                    "Governance owner mismatch: config governanceOwner={:?}, on-chain owner()={:?}",
+                                    expected, actual
+                                );
+                                error!("❌ {}", msg);
+                                errors.push(msg);
+                            } else {
+                                info!("✅ Governance.owner() matches config");
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        let msg = format!("Failed to decode Governance.owner(): {:?}", e);
+                        error!("❌ {}", msg);
+                        errors.push(msg);
+                    }
+                }
+            }
+            Some(other) => {
+                let msg = format!("Governance.owner() did not succeed: {:?}", other);
+                error!("❌ {}", msg);
+                errors.push(msg);
+            }
+            None => {
+                let msg = "Governance.owner() returned no execution result".to_string();
+                error!("❌ {}", msg);
+                errors.push(msg);
+            }
+        },
+        Err(e) => {
+            let msg = format!("Governance.owner() EVM error: {:?}", e);
+            error!("❌ {}", msg);
+            errors.push(msg);
+        }
+    }
+
+    errors
 }
 
 /// Verify epoch interval by calling EpochConfig.epochIntervalMicros()


### PR DESCRIPTION
## Summary
- Generating a sealed `genesis.json` silently accepted a wrong `governanceOwner` — the field was passed to `Genesis.initialize` but never read back from chain state. Combined with `Governance.renounceOwnership` being permanently disabled, a typo would lock the executor set for the chain's lifetime with no recovery path.
- Adds two on-chain probes to `verify_result`: `Governance.owner()` must equal config's `governanceOwner`, and `Governance.isInitialized()` must be `true`.
- Refactored the new verifiers into `_at` primitive-typed inner functions so unit tests can exercise them without constructing a full `GenesisConfig`.

## Test plan
- [x] `cargo test --lib post_genesis` — 4 unit tests pass:
  - `governance_owner_matches_passes`
  - `governance_owner_mismatch_fails` (asserts error includes both addresses)
  - `governance_initialized_true_passes`
  - `governance_initialized_false_fails`
- [x] End-to-end: ran `genesis-tool generate` against `genesis_config_single.json`; observed new log lines `✅ Governance.isInitialized() = true` and `✅ Governance.owner() = 0x...01 matches config`, and overall genesis generation still completes.
- [x] Manual negative integration check: temporarily hardcoded a wrong expected address; the tool exited non-zero with `Genesis post-generation verification failed: Governance owner mismatch ...` before reverting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)