### PR TITLE
feat: add governance early resolution threshold

### DIFF
--- a/src/foundation/Errors.sol
+++ b/src/foundation/Errors.sol
@@ -279,6 +279,11 @@ library Errors {
     /// @notice Minimum voting threshold must be greater than zero
     error InvalidVotingThreshold();
 
+    /// @notice Early resolution threshold must be greater than or equal to the minimum voting threshold
+    /// @param minVotingThreshold Minimum votes required for quorum
+    /// @param earlyResolutionVoteThreshold Votes required to close voting early
+    error InvalidEarlyResolutionVoteThreshold(uint128 minVotingThreshold, uint128 earlyResolutionVoteThreshold);
+
     /// @notice Required proposer stake must be greater than zero
     error InvalidProposerStake();
 
@@ -584,4 +589,3 @@ library Errors {
     /// @notice Operation is not supported
     error OperationNotSupported();
 }
-

--- a/src/foundation/Types.sol
+++ b/src/foundation/Types.sol
@@ -132,4 +132,7 @@ struct Proposal {
     bool isResolved;
     /// @notice When proposal was resolved (microseconds)
     uint64 resolutionTime;
+    /// @notice Optional early resolution vote threshold. Zero disables early resolution.
+    /// @dev If yesVotes or noVotes reaches this threshold, voting closes before expiration.
+    uint128 earlyResolutionVoteThreshold;
 }

--- a/src/governance/Governance.sol
+++ b/src/governance/Governance.sol
@@ -7,6 +7,7 @@ import { Proposal, ProposalState } from "../foundation/Types.sol";
 import { SystemAddresses } from "../foundation/SystemAddresses.sol";
 import { Errors } from "../foundation/Errors.sol";
 import { IStaking } from "../staking/IStaking.sol";
+import { IValidatorManagement } from "../staking/IValidatorManagement.sol";
 import { ITimestamp } from "../runtime/ITimestamp.sol";
 import { requireAllowed } from "../foundation/SystemAccessControl.sol";
 import { Ownable2Step, Ownable } from "@openzeppelin/access/Ownable2Step.sol";
@@ -154,6 +155,11 @@ contract Governance is IGovernance, Ownable2Step {
         return IStaking(SystemAddresses.STAKING);
     }
 
+    /// @notice Get validator manager contract
+    function _validatorManager() internal pure returns (IValidatorManagement) {
+        return IValidatorManagement(SystemAddresses.VALIDATOR_MANAGER);
+    }
+
     /// @notice Verify caller is the pool's voter
     function _requireVoter(
         address stakePool
@@ -171,6 +177,40 @@ contract Governance is IGovernance, Ownable2Step {
         if (!_staking().isPool(stakePool)) {
             revert Errors.InvalidPool(stakePool);
         }
+    }
+
+    /// @notice Return true if either side has reached the proposal's early resolution threshold.
+    function _canBeResolvedEarly(
+        Proposal storage p
+    ) internal view returns (bool) {
+        uint128 threshold = p.earlyResolutionVoteThreshold;
+        return threshold > 0 && (p.yesVotes >= threshold || p.noVotes >= threshold);
+    }
+
+    /// @notice Return true when no more votes are needed for state evaluation.
+    function _isVotingClosed(
+        Proposal storage p
+    ) internal view returns (bool) {
+        return _now() >= p.expirationTime || _canBeResolvedEarly(p);
+    }
+
+    /// @notice Return true if the current vote totals satisfy the passing condition.
+    function _hasSucceeded(
+        Proposal storage p
+    ) internal view returns (bool) {
+        return p.yesVotes > p.noVotes && p.yesVotes + p.noVotes >= p.minVoteThreshold;
+    }
+
+    /// @notice Compute Aptos-style default early resolution threshold.
+    /// @dev Uses current active validator total voting power as the voting-power supply.
+    ///      The threshold is 50% + 1, matching Aptos Governance.
+    function _defaultEarlyResolutionVoteThreshold() internal view returns (uint128) {
+        uint256 totalVotingPower = _validatorManager().getTotalVotingPower();
+        uint256 threshold = totalVotingPower / 2 + 1;
+        if (threshold > type(uint128).max) {
+            threshold = type(uint128).max;
+        }
+        return uint128(threshold);
     }
 
     // ========================================================================
@@ -203,21 +243,17 @@ contract Governance is IGovernance, Ownable2Step {
 
         // Check if resolved
         if (p.isResolved) {
-            // Determine if it passed
-            if (p.yesVotes > p.noVotes && p.yesVotes + p.noVotes >= p.minVoteThreshold) {
+            if (_hasSucceeded(p)) {
                 return ProposalState.SUCCEEDED;
             }
             return ProposalState.FAILED;
         }
 
-        // Not resolved yet
-        uint64 now_ = _now();
-        if (now_ < p.expirationTime) {
+        if (!_isVotingClosed(p)) {
             return ProposalState.PENDING;
         }
 
-        // Voting ended but not resolved - determine outcome
-        if (p.yesVotes > p.noVotes && p.yesVotes + p.noVotes >= p.minVoteThreshold) {
+        if (_hasSucceeded(p)) {
             return ProposalState.SUCCEEDED;
         }
         return ProposalState.FAILED;
@@ -254,16 +290,14 @@ contract Governance is IGovernance, Ownable2Step {
             return false;
         }
 
-        uint64 now_ = _now();
-
-        // Can resolve if voting period ended
-        if (now_ < p.expirationTime) {
+        if (!_isVotingClosed(p)) {
             return false;
         }
 
         // Atomicity guard: resolution must happen strictly after the last vote
         // This prevents flash loan attacks where someone borrows tokens, votes, and resolves in the same tx
         uint64 lastVote = lastVoteTime[proposalId];
+        uint64 now_ = _now();
         if (lastVote > 0 && now_ <= lastVote) {
             return false;
         }
@@ -317,6 +351,17 @@ contract Governance is IGovernance, Ownable2Step {
         return lastVoteTime[proposalId];
     }
 
+    /// @inheritdoc IGovernance
+    function getEarlyResolutionVoteThreshold(
+        uint64 proposalId
+    ) external view returns (uint128) {
+        Proposal storage p = _proposals[proposalId];
+        if (p.id == 0) {
+            revert Errors.ProposalNotFound(proposalId);
+        }
+        return p.earlyResolutionVoteThreshold;
+    }
+
     // ========================================================================
     // PROPOSAL MANAGEMENT
     // ========================================================================
@@ -368,6 +413,12 @@ contract Governance is IGovernance, Ownable2Step {
         // Create proposal
         proposalId = nextProposalId++;
 
+        uint128 minVoteThreshold = _config().minVotingThreshold();
+        uint128 earlyResolutionVoteThreshold = _defaultEarlyResolutionVoteThreshold();
+        if (earlyResolutionVoteThreshold < minVoteThreshold) {
+            revert Errors.InvalidEarlyResolutionVoteThreshold(minVoteThreshold, earlyResolutionVoteThreshold);
+        }
+
         _proposals[proposalId] = Proposal({
             id: proposalId,
             proposer: msg.sender,
@@ -375,11 +426,12 @@ contract Governance is IGovernance, Ownable2Step {
             metadataUri: metadataUri,
             creationTime: now_,
             expirationTime: expirationTime,
-            minVoteThreshold: _config().minVotingThreshold(),
+            minVoteThreshold: minVoteThreshold,
             yesVotes: 0,
             noVotes: 0,
             isResolved: false,
-            resolutionTime: 0
+            resolutionTime: 0,
+            earlyResolutionVoteThreshold: earlyResolutionVoteThreshold
         });
 
         emit ProposalCreated(proposalId, msg.sender, stakePool, executionHash, metadataUri);
@@ -506,8 +558,7 @@ contract Governance is IGovernance, Ownable2Step {
 
         uint64 now_ = _now();
 
-        // Check voting period has ended
-        if (now_ < p.expirationTime) {
+        if (!_isVotingClosed(p)) {
             revert Errors.VotingPeriodNotEnded(p.expirationTime);
         }
 
@@ -625,4 +676,3 @@ contract Governance is IGovernance, Ownable2Step {
         }
     }
 }
-

--- a/src/governance/Governance.sol
+++ b/src/governance/Governance.sol
@@ -203,10 +203,10 @@ contract Governance is IGovernance, Ownable2Step {
 
     /// @notice Compute Aptos-style default early resolution threshold.
     /// @dev Uses current active validator total voting power as the voting-power supply.
-    ///      The threshold is 50% + 1, matching Aptos Governance.
+    ///      The threshold is 2/3 + 1.
     function _defaultEarlyResolutionVoteThreshold() internal view returns (uint128) {
         uint256 totalVotingPower = _validatorManager().getTotalVotingPower();
-        uint256 threshold = totalVotingPower / 2 + 1;
+        uint256 threshold = (totalVotingPower / 3) * 2 + ((totalVotingPower % 3) * 2) / 3 + 1;
         if (threshold > type(uint128).max) {
             threshold = type(uint128).max;
         }

--- a/src/governance/IGovernance.sol
+++ b/src/governance/IGovernance.sol
@@ -124,6 +124,14 @@ interface IGovernance {
         uint64 proposalId
     ) external view returns (uint64);
 
+    /// @notice Get the early resolution vote threshold for a proposal
+    /// @dev Returns 0 if early resolution is disabled for the proposal
+    /// @param proposalId ID of the proposal
+    /// @return Early resolution vote threshold
+    function getEarlyResolutionVoteThreshold(
+        uint64 proposalId
+    ) external view returns (uint128);
+
     /// @notice Get all authorized executors
     /// @return Array of executor addresses
     function getExecutors() external view returns (address[] memory);
@@ -241,4 +249,3 @@ interface IGovernance {
         address executor
     ) external;
 }
-

--- a/test/unit/foundation/Types.t.sol
+++ b/test/unit/foundation/Types.t.sol
@@ -171,6 +171,7 @@ contract TypesTest is Test {
             creationTime: creationTime,
             expirationTime: expirationTime,
             minVoteThreshold: 1000 ether,
+            earlyResolutionVoteThreshold: 1000 ether,
             yesVotes: 0,
             noVotes: 0,
             isResolved: false,
@@ -184,6 +185,7 @@ contract TypesTest is Test {
         assertEq(prop.creationTime, creationTime);
         assertEq(prop.expirationTime, expirationTime);
         assertEq(prop.minVoteThreshold, 1000 ether);
+        assertEq(prop.earlyResolutionVoteThreshold, 1000 ether);
         assertEq(prop.yesVotes, 0);
         assertEq(prop.noVotes, 0);
         assertEq(prop.isResolved, false);
@@ -264,6 +266,7 @@ contract TypesTest is Test {
             creationTime: TIMESTAMP_NOV_2023,
             expirationTime: TIMESTAMP_NOV_2023 + ONE_DAY_MICROS,
             minVoteThreshold: 1000 ether,
+            earlyResolutionVoteThreshold: 1000 ether,
             yesVotes: 0,
             noVotes: 0,
             isResolved: false,
@@ -271,4 +274,3 @@ contract TypesTest is Test {
         });
     }
 }
-

--- a/test/unit/governance/Governance.t.sol
+++ b/test/unit/governance/Governance.t.sol
@@ -17,6 +17,8 @@ import { Ownable } from "@openzeppelin/access/Ownable.sol";
 
 /// @notice Mock ValidatorManagement for testing - all pools are non-validators
 contract MockValidatorManagement {
+    uint256 public totalVotingPower = 300 ether;
+
     function isValidator(
         address
     ) external pure returns (bool) {
@@ -27,6 +29,16 @@ contract MockValidatorManagement {
         address
     ) external pure returns (ValidatorStatus) {
         return ValidatorStatus.INACTIVE;
+    }
+
+    function getTotalVotingPower() external view returns (uint256) {
+        return totalVotingPower;
+    }
+
+    function setTotalVotingPower(
+        uint256 newTotalVotingPower
+    ) external {
+        totalVotingPower = newTotalVotingPower;
     }
 }
 
@@ -93,6 +105,7 @@ contract GovernanceTest is Test {
 
         // Deploy mock ValidatorManagement - returns false for isValidator()
         vm.etch(SystemAddresses.VALIDATOR_MANAGER, address(new MockValidatorManagement()).code);
+        MockValidatorManagement(SystemAddresses.VALIDATOR_MANAGER).setTotalVotingPower(300 ether);
 
         // Deploy mock Reconfiguration - returns false for isTransitionInProgress()
         // Staking.createPool now checks reconfiguration status
@@ -219,6 +232,8 @@ contract GovernanceTest is Test {
         assertEq(proposal.id, proposalId);
         assertEq(proposal.proposer, alice);
         assertEq(proposal.executionHash, executionHash);
+        assertEq(proposal.earlyResolutionVoteThreshold, 150 ether + 1);
+        assertEq(governance.getEarlyResolutionVoteThreshold(proposalId), 150 ether + 1);
         assertEq(proposal.yesVotes, 0);
         assertEq(proposal.noVotes, 0);
         assertEq(proposal.isResolved, false);
@@ -232,6 +247,22 @@ contract GovernanceTest is Test {
         vm.prank(alice);
         vm.expectRevert(abi.encodeWithSelector(Errors.InvalidPool.selector, invalidPool));
         governance.createProposal(invalidPool, targets, datas, "ipfs://test");
+    }
+
+    function test_RevertWhen_CreateProposalEarlyResolutionThresholdBelowMinThreshold() public {
+        address pool = _createStakePool(alice, 100 ether);
+        MockValidatorManagement(SystemAddresses.VALIDATOR_MANAGER).setTotalVotingPower(100 ether);
+
+        (address[] memory targets, bytes[] memory datas) = _toArrays(address(mockTarget), "");
+        uint128 earlyResolutionVoteThreshold = 50 ether + 1;
+
+        vm.prank(alice);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.InvalidEarlyResolutionVoteThreshold.selector, MIN_VOTING_THRESHOLD, earlyResolutionVoteThreshold
+            )
+        );
+        governance.createProposal(pool, targets, datas, "ipfs://test");
     }
 
     function test_RevertWhen_CreateProposalNotVoter() public {
@@ -537,6 +568,36 @@ contract GovernanceTest is Test {
 
         vm.expectRevert(abi.encodeWithSelector(Errors.VotingPeriodNotEnded.selector, proposal.expirationTime));
         governance.resolve(proposalId);
+    }
+
+    function test_EarlyResolveRequiresValidatorMajorityThreshold() public {
+        address pool = _createStakePool(alice, 200 ether);
+
+        (address[] memory targets, bytes[] memory datas) = _toArrays(address(mockTarget), "");
+
+        vm.prank(alice);
+        uint64 proposalId = governance.createProposal(pool, targets, datas, "ipfs://test");
+
+        assertEq(governance.getEarlyResolutionVoteThreshold(proposalId), 150 ether + 1);
+
+        vm.prank(alice);
+        governance.vote(pool, proposalId, MIN_VOTING_THRESHOLD, true);
+
+        assertEq(uint8(governance.getProposalState(proposalId)), uint8(ProposalState.PENDING));
+        assertFalse(governance.canResolve(proposalId));
+
+        vm.prank(alice);
+        governance.vote(pool, proposalId, 50 ether + 1, true);
+
+        assertEq(uint8(governance.getProposalState(proposalId)), uint8(ProposalState.SUCCEEDED));
+
+        _advanceTime(1);
+        assertTrue(governance.canResolve(proposalId));
+
+        governance.resolve(proposalId);
+        Proposal memory proposal = governance.getProposal(proposalId);
+        assertTrue(proposal.isResolved);
+        assertEq(uint8(governance.getProposalState(proposalId)), uint8(ProposalState.SUCCEEDED));
     }
 
     // ========================================================================
@@ -1689,4 +1750,3 @@ contract MockTarget {
         revert("MockTarget: always reverts");
     }
 }
-

--- a/test/unit/governance/Governance.t.sol
+++ b/test/unit/governance/Governance.t.sol
@@ -232,8 +232,8 @@ contract GovernanceTest is Test {
         assertEq(proposal.id, proposalId);
         assertEq(proposal.proposer, alice);
         assertEq(proposal.executionHash, executionHash);
-        assertEq(proposal.earlyResolutionVoteThreshold, 150 ether + 1);
-        assertEq(governance.getEarlyResolutionVoteThreshold(proposalId), 150 ether + 1);
+        assertEq(proposal.earlyResolutionVoteThreshold, 200 ether + 1);
+        assertEq(governance.getEarlyResolutionVoteThreshold(proposalId), 200 ether + 1);
         assertEq(proposal.yesVotes, 0);
         assertEq(proposal.noVotes, 0);
         assertEq(proposal.isResolved, false);
@@ -254,7 +254,7 @@ contract GovernanceTest is Test {
         MockValidatorManagement(SystemAddresses.VALIDATOR_MANAGER).setTotalVotingPower(100 ether);
 
         (address[] memory targets, bytes[] memory datas) = _toArrays(address(mockTarget), "");
-        uint128 earlyResolutionVoteThreshold = 50 ether + 1;
+        uint128 earlyResolutionVoteThreshold = 66 ether + 666666666666666667;
 
         vm.prank(alice);
         vm.expectRevert(
@@ -570,15 +570,15 @@ contract GovernanceTest is Test {
         governance.resolve(proposalId);
     }
 
-    function test_EarlyResolveRequiresValidatorMajorityThreshold() public {
-        address pool = _createStakePool(alice, 200 ether);
+    function test_EarlyResolveRequiresValidatorTwoThirdsThreshold() public {
+        address pool = _createStakePool(alice, 250 ether);
 
         (address[] memory targets, bytes[] memory datas) = _toArrays(address(mockTarget), "");
 
         vm.prank(alice);
         uint64 proposalId = governance.createProposal(pool, targets, datas, "ipfs://test");
 
-        assertEq(governance.getEarlyResolutionVoteThreshold(proposalId), 150 ether + 1);
+        assertEq(governance.getEarlyResolutionVoteThreshold(proposalId), 200 ether + 1);
 
         vm.prank(alice);
         governance.vote(pool, proposalId, MIN_VOTING_THRESHOLD, true);
@@ -587,7 +587,7 @@ contract GovernanceTest is Test {
         assertFalse(governance.canResolve(proposalId));
 
         vm.prank(alice);
-        governance.vote(pool, proposalId, 50 ether + 1, true);
+        governance.vote(pool, proposalId, 100 ether + 1, true);
 
         assertEq(uint8(governance.getProposalState(proposalId)), uint8(ProposalState.SUCCEEDED));
 


### PR DESCRIPTION
## Summary
- add an early resolution threshold to governance proposals
- snapshot the threshold at proposal creation from validator total voting power: floor(totalVotingPower * 2 / 3) + 1
- compute the two-thirds threshold as (totalVotingPower / 3) * 2 + ((totalVotingPower % 3) * 2) / 3 + 1 to avoid a theoretical uint256 overflow from totalVotingPower * 2
- preserve Proposal storage layout by appending the new field at the end
- reject proposals when the early resolution threshold is below the configured min voting threshold

## Tests
- forge test --match-path test/unit/governance/Governance.t.sol --match-test 'test_CreateProposal|test_EarlyResolveRequiresValidatorTwoThirdsThreshold|test_RevertWhen_CreateProposalEarlyResolutionThresholdBelowMinThreshold|test_RevertWhen_ResolveVotingNotEnded|test_ResolveSucceeded'
- forge test --match-path test/unit/foundation/Types.t.sol