### PR TITLE
build: strip CBOR metadata footer for deterministic bytecode

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -6,6 +6,11 @@ out = "out"
 test = "test"
 libs = ["lib"]
 solc = "0.8.30"
+# Strip the CBOR metadata footer (IPFS source hash + solc version marker) from
+# emitted bytecode so genesis-baked contracts are byte-identical across clones,
+# dependency layouts, and machines. Compiler pin above is what's load-bearing;
+# the in-bytecode version marker is just an artifact.
+bytecode_hash = "none"
 cache = true
 cache_path = 'cache'
 optimizer = true


### PR DESCRIPTION
## Summary
- Set `bytecode_hash = "none"` in `foundry.toml` so emitted bytecode no longer carries the appended CBOR metadata block (IPFS source hash + solc version marker).
- The `solc = "0.8.30"` pin above is what actually fixes the compiler version; the in-bytecode version marker is just an artifact.

## Why
The IPFS hash in the CBOR footer is computed over a metadata JSON that includes source-file paths, dependency layout, and remapping serialization. The same source produced different bytes across clones / `node_modules` layouts / machines, which polluted downstream consumers (most visibly: `gravity_chain_core_contracts` → `gravity-mainnet-gitops/genesis.json` regenerations would diff by hundreds of lines without any runtime behavior changing — see [PR #110 on the gitops side](https://github.com/Galxe/gravity-mainnet-gitops/pull/110) for the empirical diagnosis).

This change makes builds deterministic across clones, dependency layouts, OSes, and absolute-path differences.

## What this changes
- Each compiled contract's deployed bytecode shrinks by ~53 bytes (the stripped CBOR footer).
- Genesis-baked contracts will be byte-identical across regenerations from the same source.
- The compiler version pin in `foundry.toml` (`solc = "0.8.30"`) is now the sole record of which solc was used.

## What this trades away
- Block-explorer source-verification flows lose the IPFS source-hash marker. For chain-genesis contracts (baked in at genesis, never redeployed at runtime) this is standard practice and matches what Uniswap, OpenZeppelin libraries, and similar deterministic-build projects do.

## Test plan
- [ ] `forge clean && forge build` succeeds.
- [ ] Inspect one `out/**/*.json` artifact and confirm `deployedBytecode.object` no longer ends with the `a26469706673...64736f6c63...0033` CBOR footer.
- [ ] Re-run twice from clean clones in different paths; confirm artifacts hash identically.
- [ ] Downstream: re-run `gravity-sdk/cluster/genesis.sh` against this ref twice from scratch and confirm `genesis.json` is byte-identical both times.

🤖 Generated with [Claude Code](https://claude.com/claude-code)