### PR TITLE
fix(mainnet): fail closed on pending ownership

### DIFF
--- a/scripts/mainnet/VerifyBridgeMainnet.s.sol
+++ b/scripts/mainnet/VerifyBridgeMainnet.s.sol
@@ -27,9 +27,9 @@ import { GBridgeSender } from "src/oracle/evm/native_token_bridge/GBridgeSender.
 ///
 /// @dev    PRODUCTION OWNERSHIP MODEL — DeployBridgeKeystore.s.sol transfers
 ///         ownership of both contracts to a multisig via Ownable2Step. Set
-///         MULTISIG_ADDRESS (the final owner) and, optionally, DEPLOYER_ADDRESS
-///         (the temporary owner during handoff) and FEE_RECIPIENT_ADDRESS. The
-///         verifier accepts either:
+///         MULTISIG_ADDRESS (the final owner), DEPLOYER_ADDRESS (the temporary
+///         owner, required while the handoff is pending), and optionally
+///         FEE_RECIPIENT_ADDRESS. The verifier accepts either:
 ///           - FINALIZED : owner == multisig && pendingOwner == 0
 ///           - PENDING   : pendingOwner == multisig (acceptOwnership() not yet
 ///                         called) — reported as a loud WARNING, not a failure.
@@ -57,7 +57,7 @@ contract VerifyBridgeMainnet is Script {
 
     struct Expected {
         address owner; // intended FINAL owner (multisig, or EOA for a legacy deployment)
-        address deployer; // temporary owner during an Ownable2Step handoff; 0 if unknown
+        address deployer; // expected temporary owner during an Ownable2Step handoff
         address feeRecipient; // portal fee recipient (defaults to `owner`)
         address gToken;
         uint256 baseFee;
@@ -185,10 +185,10 @@ contract VerifyBridgeMainnet is Script {
     /// @notice Verify an Ownable2Step contract's owner against the intended final owner.
     /// @dev Accepts two valid states; reverts on anything else:
     ///        - FINALIZED : owner == e.owner && pendingOwner == 0
-    ///        - PENDING   : pendingOwner == e.owner  (handoff initiated, not yet
-    ///                      accepted; loud WARNING but not a failure). When
-    ///                      DEPLOYER_ADDRESS is provided, the current owner must
-    ///                      additionally equal it for the PENDING state to hold.
+    ///        - PENDING   : pendingOwner == e.owner and currentOwner == e.deployer
+    ///                      (handoff initiated, not yet accepted; loud WARNING but
+    ///                      not a failure). DEPLOYER_ADDRESS must be explicitly
+    ///                      provided for the PENDING state to hold.
     function _verifyOwnership(
         string memory label,
         address currentOwner,
@@ -200,7 +200,7 @@ contract VerifyBridgeMainnet is Script {
             return;
         }
         bool pendingToFinalOwner = pendingOwner == e.owner;
-        bool deployerOk = e.deployer == address(0) || currentOwner == e.deployer;
+        bool deployerOk = e.deployer != address(0) && currentOwner == e.deployer;
         if (pendingToFinalOwner && deployerOk) {
             // PENDING — handoff initiated but acceptOwnership() not yet called.
             console.log("   WARNING:", label, "ownership handoff is PENDING");
@@ -212,6 +212,7 @@ contract VerifyBridgeMainnet is Script {
         console.log("   ", label, "current owner :", currentOwner);
         console.log("   ", label, "pendingOwner  :", pendingOwner);
         console.log("   ", label, "expected owner:", e.owner);
+        console.log("   ", label, "expected deployer:", e.deployer);
         revert(string.concat("ownership mismatch: ", label));
     }
 

--- a/test/unit/oracle/VerifyBridgeMainnet.t.sol
+++ b/test/unit/oracle/VerifyBridgeMainnet.t.sol
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import { Test } from "forge-std/Test.sol";
+import { VerifyBridgeMainnet } from "scripts/mainnet/VerifyBridgeMainnet.s.sol";
+
+contract VerifyBridgeMainnetHarness is VerifyBridgeMainnet {
+    function verifyOwnership(
+        address currentOwner,
+        address pendingOwner,
+        address expectedOwner,
+        address expectedDeployer
+    ) external pure {
+        Expected memory expected;
+        expected.owner = expectedOwner;
+        expected.deployer = expectedDeployer;
+
+        _verifyOwnership("test", currentOwner, pendingOwner, expected);
+    }
+}
+
+contract VerifyBridgeMainnetTest is Test {
+    VerifyBridgeMainnetHarness internal verifier;
+
+    address internal deployer = makeAddr("deployer");
+    address internal multisig = makeAddr("multisig");
+    address internal attacker = makeAddr("attacker");
+
+    function setUp() public {
+        verifier = new VerifyBridgeMainnetHarness();
+    }
+
+    function test_FinalizedOwnershipPassesWithoutExpectedDeployer() public view {
+        verifier.verifyOwnership(multisig, address(0), multisig, address(0));
+    }
+
+    function test_PendingOwnershipPassesWithExpectedDeployer() public view {
+        verifier.verifyOwnership(deployer, multisig, multisig, deployer);
+    }
+
+    function test_RevertWhen_PendingOwnershipHasNoExpectedDeployer() public {
+        vm.expectRevert("ownership mismatch: test");
+        verifier.verifyOwnership(attacker, multisig, multisig, address(0));
+    }
+
+    function test_RevertWhen_PendingOwnershipHasUnexpectedCurrentOwner() public {
+        vm.expectRevert("ownership mismatch: test");
+        verifier.verifyOwnership(attacker, multisig, multisig, deployer);
+    }
+}


### PR DESCRIPTION
## Summary

- fail closed when a bridge ownership handoff is still pending but `DEPLOYER_ADDRESS` is unset
- require the on-chain current owner to match the explicitly expected temporary deployer
- preserve finalized ownership verification without requiring a deployer value
- add regression coverage for finalized, valid pending, missing-deployer, and wrong-owner states

## Root cause

The verifier treated `address(0)` as a wildcard for the expected deployer. As a result, any current owner passed verification as long as `pendingOwner` matched the intended multisig, even though the current owner retained all `onlyOwner` permissions until the multisig accepted ownership.

## Impact

Pending handoffs now pass only when `DEPLOYER_ADDRESS` is explicitly configured and matches the current owner. Fully finalized multisig ownership remains compatible with an unset deployer value.

## Validation

- `forge fmt --check scripts/mainnet/VerifyBridgeMainnet.s.sol test/unit/oracle/VerifyBridgeMainnet.t.sol`
- `forge test --offline --match-path test/unit/oracle/VerifyBridgeMainnet.t.sol -vvv` (4 passed)
- `forge test --offline --skip DeployBridgeHandoff.t.sol` (36 suites, 1,051 passed)
- `git diff --check`

The skip above excludes an unrelated untracked local test file that is not part of this PR; all tracked Foundry tests passed.

Closes Galxe/gravity-audit#762
