### PR TITLE
refactor(oracle): split NativeOracle delivery core

### DIFF
--- a/spec_v2/oracle.spec.md
+++ b/spec_v2/oracle.spec.md
@@ -8,12 +8,13 @@ layer: oracle
 
 ## Overview
 
-The Native Oracle module enables Gravity to receive and store **verified external data** from any source. It is a single
+The Native Oracle module enables Gravity to receive and deliver **verified external data** from any source. It is a single
 contract deployed on Gravity that provides:
 
-1. **Consensus-validated data recording** from any external source
+1. **Consensus-validated data delivery** from any external source
 2. **Flexible callback routing** based on source type and source ID
-3. **Replay protection** via strictly increasing nonces
+3. **Replay protection** via sequential nonces
+4. **Bounded source progress** without retaining new payload history
 
 **Supported data sources include (extensible via governance):**
 
@@ -50,10 +51,10 @@ contract deployed on Gravity that provides:
 │   ┌─────────────────────────────────────────────────────────────────────┐  │
 │   │                         NativeOracle                                 │  │
 │   │                                                                      │  │
-│   │  • Stores verified data keyed by (sourceType, sourceId, nonce)     │  │
-│   │  • Tracks latest nonce per source (sourceType, sourceId)           │  │
-│   │  • Invokes callbacks with CALLER-SPECIFIED gas limit               │  │
-│   │  • Callback failures do NOT revert recording                        │  │
+│   │  • Delivers verified data to one configured callback               │  │
+│   │  • Tracks latest nonce and source position per source              │  │
+│   │  • Stores no new payload history                                    │  │
+│   │  • Callback and progress updates succeed or revert atomically       │  │
 │   └─────────────────────────────────────────────────────────────────────┘  │
 │                         │                                                   │
 │                         │ Callback: onOracleEvent()                        │
@@ -161,7 +162,7 @@ uint128 nonce;
 - `nonce == 1` for the first record per source
 - For each (sourceType, sourceId) pair, consecutive records MUST satisfy `newNonce == latestNonce + 1`
 
-### DataRecord
+### DataRecord (Legacy)
 
 ```solidity
 struct DataRecord {
@@ -171,21 +172,35 @@ struct DataRecord {
 }
 ```
 
-Record existence is determined by `recordedAt > 0`. `blockNumber` is carried independently of `nonce` so that a single source can mix sequence-based ordering with source-block provenance.
+Record existence is determined by `recordedAt > 0`. These records remain queryable after the hardfork, but new deliveries
+do not write this mapping. The existing `blockNumber` argument is interpreted as a source-defined restart position for new
+deliveries; its name is retained to preserve the existing `record()` and `recordBatch()` selectors.
+
+### SourceProgress
+
+```solidity
+struct SourceProgress {
+    uint128 latestNonce;
+    uint128 latestPosition;
+}
+```
+
+The two fields occupy one storage slot. `latestPosition` is an opaque, source-defined checkpoint used by the relayer for
+restart and cursor reconciliation.
 
 ---
 
 ## Contract: NativeOracle
 
-Stores verified data from external sources. Only writable by SYSTEM_CALLER via consensus.
+Delivers verified data from external sources. Only writable by SYSTEM_CALLER via consensus.
 
 ### State Variables
 
 ```solidity
-/// @notice Data records: sourceType -> sourceId -> nonce -> DataRecord
+/// @dev Legacy records retained at slot 0 for historical reads and layout compatibility
 mapping(uint32 => mapping(uint256 => mapping(uint128 => DataRecord))) private _records;
 
-/// @notice Latest nonce per source: sourceType -> sourceId -> nonce
+/// @dev Legacy nonces retained at slot 1 for hardfork fallback and layout compatibility
 mapping(uint32 => mapping(uint256 => uint128)) private _nonces;
 
 /// @notice Default callback handlers: sourceType -> callback contract
@@ -195,7 +210,20 @@ mapping(uint32 => address) private _defaultCallbacks;
 /// @notice Specialized callback handlers: sourceType -> sourceId -> callback contract
 /// @dev Overrides default callback for specific (sourceType, sourceId) pairs
 mapping(uint32 => mapping(uint256 => address)) private _callbacks;
+
+/// @dev Appended at slot 5; one packed progress slot per source
+mapping(uint32 => mapping(uint256 => SourceProgress)) private _sourceProgress;
 ```
+
+The deployed slots remain unchanged: `_records` = 0, `_nonces` = 1, `_defaultCallbacks` = 2, `_callbacks` = 3, and
+`_initialized` = 4. `_sourceProgress` is appended at slot 5. If no post-hardfork progress exists, reads fall back to the
+legacy nonce and latest legacy record position. The first new delivery must continue from `legacyNonce + 1`.
+
+Legacy callbacks were allowed to consume a payload without writing its `DataRecord`. For such a source,
+`getSourceProgress()` returns the authoritative nonzero legacy nonce with `latestPosition == 0`, meaning that the old
+position is unknown rather than source genesis. Reth reconciliation must use persisted/configured migration state for this
+transition and must not interpret zero as a confirmed historical cursor. The first successful post-hardfork delivery writes
+an authoritative nonzero position into `_sourceProgress`.
 
 ### Interface
 
@@ -207,9 +235,9 @@ interface INativeOracle {
     /// @param sourceType The source type (uint32, e.g., 0 = BLOCKCHAIN, 1 = JWK)
     /// @param sourceId The source identifier (e.g., chain ID for blockchains)
     /// @param nonce The nonce - must equal `currentNonce + 1` for this (sourceType, sourceId)
-    /// @param blockNumber The source block number (provenance, NOT used for ordering)
-    /// @param payload The data payload to store
-    /// @param callbackGasLimit Gas limit for callback execution (0 = invoke no callback, emit CallbackSkipped and store)
+    /// @param blockNumber Source-defined restart position; name retained for selector compatibility
+    /// @param payload The callback payload
+    /// @param callbackGasLimit Nonzero gas limit for callback execution
     function record(
         uint32 sourceType,
         uint256 sourceId,
@@ -220,12 +248,12 @@ interface INativeOracle {
     ) external;
 
     /// @notice Batch record multiple data entries from the same source
-    /// @dev Each record is validated individually with its own nonce/blockNumber/callbackGasLimit.
+    /// @dev Each delivery is validated individually with its own nonce/position/callbackGasLimit.
     ///      Callers typically pass strictly sequential nonces; the contract validates each as currentNonce+1.
     /// @param sourceType The source type
     /// @param sourceId The source identifier
     /// @param nonces Array of nonces (length N)
-    /// @param blockNumbers Array of source block numbers (length N)
+    /// @param blockNumbers Array of source-defined restart positions (length N)
     /// @param payloads Array of payloads (length N)
     /// @param callbackGasLimits Array of per-record gas limits (length N)
     function recordBatch(
@@ -243,7 +271,7 @@ interface INativeOracle {
     //   1. Default callback per sourceType - applies to all sources of that type
     //   2. Specialized callback per (sourceType, sourceId) - overrides default
     //
-    // When an oracle event is recorded, the system first checks for a specialized
+    // When an oracle event is delivered, the system first checks for a specialized
     // callback. If none is set, it falls back to the default callback for that
     // source type.
 
@@ -276,6 +304,11 @@ interface INativeOracle {
         uint256 sourceId
     ) external view returns (uint128 nonce);
 
+    function getSourceProgress(
+        uint32 sourceType,
+        uint256 sourceId
+    ) external view returns (SourceProgress memory progress);
+
     /// @notice Check if synced past a certain point
     function isSyncedPast(
         uint32 sourceType,
@@ -289,17 +322,13 @@ interface INativeOracle {
 
 ```solidity
 interface IOracleCallback {
-    /// @notice Called when an oracle event is recorded
-    /// @dev Callback failures are caught — do NOT revert oracle recording.
-    ///      The returned `shouldStore` flag tells NativeOracle whether to persist the payload
-    ///      into the `_records` mapping. Returning `false` lets callbacks that fully consume the
-    ///      payload (e.g., apply it to their own state) avoid paying for redundant storage.
+    /// @notice Called when an oracle event is delivered
+    /// @dev Callback failure reverts delivery and leaves source progress unchanged.
     /// @param sourceType The source type
     /// @param sourceId The source identifier
     /// @param nonce The nonce of the record
     /// @param payload The event payload (encoding depends on event type)
-    /// @return shouldStore If true, NativeOracle writes the DataRecord; if false, storage is skipped
-    ///                    (a `StorageSkipped` event is emitted instead).
+    /// @return shouldStore Deprecated compatibility return; NativeOracle accepts true or false
     function onOracleEvent(
         uint32 sourceType,
         uint256 sourceId,
@@ -309,12 +338,16 @@ interface IOracleCallback {
 }
 ```
 
-**Storage semantics**:
-- No callback registered → payload is always stored.
-- Callback registered but `callbackGasLimit == 0` → `CallbackSkipped` event, payload is still stored.
-- Callback succeeds and returns `true` → `CallbackSuccess` event, payload stored.
-- Callback succeeds and returns `false` → `CallbackSuccess` + `StorageSkipped` events, payload NOT stored (the callback "consumed" the data).
-- Callback reverts or runs out of gas → `CallbackFailed` event with revert bytes, payload stored anyway (fail-safe).
+**Delivery semantics**:
+
+- A deployed callback must resolve for every delivery; missing callbacks revert.
+- `callbackGasLimit` must be nonzero.
+- Callback return data must contain one canonical ABI boolean. Both `true` and `false` are accepted for compatibility.
+- Callback revert, out-of-gas, short return data, or a non-boolean return word reverts the entire delivery.
+- Source progress advances and `OracleDelivered` is emitted only after callback success.
+- `recordBatch()` is atomic: any invalid nonce or callback failure rolls back every callback and progress update in the batch.
+- Callback returndata copied into memory is capped at 256 bytes.
+- New payloads are never written to `_records`.
 
 ### Callback Resolution (2-Layer System)
 
@@ -324,49 +357,8 @@ The callback system uses a 2-layer resolution:
 2. **Specialized callback per (sourceType, sourceId)**: Overrides the default for specific sources (e.g., only Ethereum
    events)
 
-```solidity
-/// @notice Resolve callback using 2-layer lookup
-function _resolveCallback(
-    uint32 sourceType,
-    uint256 sourceId
-) internal view returns (address callback) {
-    // First check for specialized callback
-    address specialized = _callbacks[sourceType][sourceId];
-    if (specialized != address(0)) {
-        return specialized;
-    }
-    // Fall back to default callback for this source type
-    return _defaultCallbacks[sourceType];
-}
-
-function _invokeCallback(
-    uint32 sourceType,
-    uint256 sourceId,
-    uint128 nonce,
-    bytes calldata payload,
-    uint256 gasLimit
-) internal returns (bool shouldStore) {
-    address callback = _resolveCallback(sourceType, sourceId);
-    if (callback == address(0)) return true;           // no callback → store
-    if (gasLimit == 0) {
-        emit CallbackSkipped(sourceType, sourceId, nonce, callback);
-        return true;                                    // skip invocation, still store
-    }
-
-    try IOracleCallback(callback).onOracleEvent{gas: gasLimit}(
-        sourceType, sourceId, nonce, payload
-    ) returns (bool callbackShouldStore) {
-        emit CallbackSuccess(sourceType, sourceId, nonce, callback);
-        if (!callbackShouldStore) {
-            emit StorageSkipped(sourceType, sourceId, nonce, callback);
-        }
-        return callbackShouldStore;
-    } catch (bytes memory reason) {
-        emit CallbackFailed(sourceType, sourceId, nonce, callback, reason);
-        return true;                                    // on failure, store by default to preserve data
-    }
-}
-```
+Governance may unregister a callback by setting it to zero. Any nonzero callback registration must point to deployed
+contract code. Deliveries for an unregistered source remain fail-closed until governance configures a callback.
 
 **Example Usage:**
 
@@ -385,12 +377,13 @@ governance.setCallback(0, 10, optimismSpecialHandlerAddress);
 ### Events
 
 ```solidity
-/// @notice Emitted when data is recorded
-event DataRecorded(
+/// @notice Emitted after callback success and progress update
+event OracleDelivered(
     uint32 indexed sourceType,
     uint256 indexed sourceId,
     uint128 nonce,
-    uint256 dataLength
+    uint128 sourcePosition,
+    bytes32 payloadHash
 );
 
 /// @notice Emitted when a default callback is registered or updated
@@ -416,30 +409,8 @@ event CallbackSuccess(
     address callback
 );
 
-/// @notice Emitted when a callback fails (tx continues, does NOT revert)
-event CallbackFailed(
-    uint32 indexed sourceType,
-    uint256 indexed sourceId,
-    uint128 nonce,
-    address callback,
-    bytes reason
-);
-
-/// @notice Emitted when a callback is registered but gasLimit == 0 was passed (callback not invoked; record still stored)
-event CallbackSkipped(
-    uint32 indexed sourceType,
-    uint256 indexed sourceId,
-    uint128 nonce,
-    address callback
-);
-
-/// @notice Emitted when the callback returned shouldStore == false — the payload is NOT persisted
-event StorageSkipped(
-    uint32 indexed sourceType,
-    uint256 indexed sourceId,
-    uint128 nonce,
-    address callback
-);
+// DataRecorded, CallbackFailed, CallbackSkipped, and StorageSkipped remain in
+// the ABI for historical log decoding but are not emitted for new deliveries.
 ```
 
 ### Errors
@@ -462,6 +433,12 @@ error OracleBatchArrayLengthMismatch(
     uint256 payloadsLen,
     uint256 callbackGasLimitsLen
 );
+
+error InvalidOracleCallback(address callback);
+error OracleCallbackNotConfigured(uint32 sourceType, uint256 sourceId);
+error OracleCallbackGasLimitZero(uint32 sourceType, uint256 sourceId);
+error OracleCallbackFailed(uint32 sourceType, uint256 sourceId, uint128 nonce, address callback, bytes reason);
+error OracleSourcePositionOverflow(uint256 sourcePosition);
 ```
 
 ---
@@ -489,7 +466,10 @@ error OracleBatchArrayLengthMismatch(
 
 ## Contract: OracleTaskConfig
 
-Stores configuration for **continuous** oracle tasks that validators actively monitor off-chain. Tasks are keyed by `(sourceType, sourceId, taskName)`, allowing multiple tasks per source (e.g., an Ethereum chain can have a JWK-sync task, a block-header task, and a price-feed task simultaneously).
+Stores configuration for **continuous** oracle tasks that validators actively monitor off-chain. Tasks are keyed by
+`(sourceType, sourceId, taskName)`. Relayer-backed source types 0, 3, and 6 allow only one task for each
+`(sourceType, sourceId)` because `NativeOracle` owns one nonce/progress stream for that pair. Other source types may
+register multiple named tasks.
 
 ### System Address
 
@@ -541,6 +521,7 @@ interface IOracleTaskConfig {
 
 - `setTask()` reverts with `EmptyConfig` if `config.length == 0`.
 - Setting `taskName` that already exists overwrites in place (same `updatedAt` refresh).
+- Adding a second task name for relayer-backed source types 0, 3, or 6 reverts with `RelayerTaskAlreadyConfigured`.
 - `removeTask()` cleans up empty source-id and source-type registrations to keep the enumeration helpers bounded.
 
 ---
@@ -563,18 +544,23 @@ See `src/oracle/ondemand/` for the full on-demand-specific flow (request queue, 
 
 1. **Consensus Required**: All oracle data requires validator consensus via SYSTEM_CALLER
 2. **Callback Gas Limits**: Caller-specified gas limit prevents excessive gas consumption
-3. **Callback Failure Tolerance**: Failures do NOT revert oracle recording
+3. **Atomic Callback Failure**: Callback failure reverts the delivery and leaves progress retryable
 4. **GOVERNANCE Control**: Callback registration requires governance approval
-5. **Nonce Ordering**: Must start from 1 and strictly increase - prevents replay and ensures data freshness
+5. **Callback Code Validation**: Nonzero callback registrations must point to deployed contract code
+6. **Bounded Returndata**: NativeOracle copies at most 256 callback returndata bytes
+7. **Nonce Ordering**: Nonces start at 1 and increment by exactly one
+8. **Bounded State**: New deliveries overwrite one packed progress slot rather than retaining external payload bytes
 
 ---
 
 ## Invariants
 
-1. **Nonce Monotonicity**: For each (sourceType, sourceId), `latestNonce` only increases
-2. **Nonce Minimum**: First nonce for any source must be >= 1
-3. **Record Existence**: If `recordedAt > 0`, record was written by SYSTEM_CALLER
-4. **Callback Safety**: Callback failures never affect oracle state
+1. **Nonce Continuity**: For each `(sourceType, sourceId)`, a new nonce equals `latestNonce + 1`
+2. **Atomicity**: A successful delivery updates both callback state and source progress; a failed delivery updates neither
+3. **Batch Atomicity**: Any failure rolls back the complete `recordBatch()` transaction
+4. **Legacy Preservation**: Existing slots 0 through 4 and historical records remain readable
+5. **Progress Bound**: Each source adds at most one packed `SourceProgress` slot regardless of delivery count
+6. **Task Identity**: A relayer-backed `(sourceType, sourceId)` maps to at most one configured continuous task
 
 ---
 
@@ -583,26 +569,32 @@ See `src/oracle/ondemand/` for the full on-demand-specific flow (request queue, 
 ### Unit Tests
 
 1. **NativeOracle**
-   - Record data with sourceType, sourceId, nonce
-   - Batch recording with sequential nonces
-   - Nonce validation (must start from 1, must increase)
-   - Callback invocation with specified gas limit
-   - Callback failure handling (should not revert)
+   - Deliver data with source type, source ID, nonce, and source position
+   - Batch delivery with sequential nonces and atomic rollback
+   - Callback revert, zero gas, malformed return, and missing callback failures
+   - Bounded callback returndata
+   - Legacy progress fallback and first post-hardfork write
+   - No new `_records` payload history
    - 2-layer callback resolution:
      - Default callback per sourceType
      - Specialized callback per (sourceType, sourceId)
      - Specialized overrides default
      - Fallback to default when no specialized set
    - GOVERNANCE callback registration (setDefaultCallback, setCallback)
-   - Query functions (getRecord, getLatestNonce, isSyncedPast)
+   - Query functions (getRecord, getLatestNonce, getSourceProgress, isSyncedPast)
+
+2. **OracleTaskConfig**
+   - Existing task updates remain allowed
+   - Second task names are rejected for relayer-backed source types
+   - Multiple task names remain allowed for non-relayer source types
 
 ### Fuzz Tests
 
 1. **Random payloads and amounts**
 2. **Nonce ordering**
-3. **Nonce boundaries (must be >= 1)**
+3. **Nonce boundaries (the first nonce must equal 1)**
 4. **SourceType and SourceId combinations**
-5. **Callback gas limit boundaries**
+5. **Source position boundaries**
 
 ---
 

--- a/spec_v2/oracle_evm_bridge.spec.md
+++ b/spec_v2/oracle_evm_bridge.spec.md
@@ -58,9 +58,9 @@ consists of contracts deployed on both chains, providing:
 │   ┌─────────────────────────────────────────────────────────────────────┐  │
 │   │                         NativeOracle                                 │  │
 │   │                                                                      │  │
-│   │  • Stores verified payload                                          │  │
-│   │  • Invokes callback with specified gas limit                        │  │
-│   │  • Callback failures do NOT revert recording                        │  │
+│   │  • Delivers verified payload to the receiver                        │  │
+│   │  • Tracks one nonce and source position checkpoint                  │  │
+│   │  • Callback failure reverts without advancing progress              │  │
 │   └─────────────────────────────────────────────────────────────────────┘  │
 │                         │                                                   │
 │                         │ Callback: onOracleEvent()                        │
@@ -72,7 +72,7 @@ consists of contracts deployed on both chains, providing:
 │   │  • Parses PortalMessage payload                                     │  │
 │   │  • Verifies sender is trusted GBridgeSender                         │  │
 │   │  • Mints native G tokens via system precompile                      │  │
-│   │  • Tracks processed nonces for replay protection                    │  │
+│   │  • Relies on NativeOracle nonce continuity for replay protection    │  │
 │   └─────────────────────────────────────────────────────────────────────┘  │
 │                                                                             │
 └────────────────────────────────────────────────────────────────────────────┘
@@ -293,10 +293,10 @@ PortalMessage payloads.
 
 ```solidity
 abstract contract BlockchainEventHandler is IOracleCallback {
-    /// @notice Called by NativeOracle when a blockchain event is recorded
+    /// @notice Called by NativeOracle when a blockchain event is delivered
     /// @dev Parses the portal message payload and delegates to _handlePortalMessage().
-    ///      Returns `shouldStore` up to NativeOracle so the derived handler can decide whether
-    ///      the raw payload is worth persisting.
+    ///      The bool return is retained for callback ABI compatibility; NativeOracle does not
+    ///      persist new payload history.
     function onOracleEvent(
         uint32 sourceType,
         uint256 sourceId,
@@ -305,7 +305,7 @@ abstract contract BlockchainEventHandler is IOracleCallback {
     ) external override returns (bool shouldStore);
 
     /// @notice Handle a parsed portal message (override in derived contracts)
-    /// @return shouldStore Whether NativeOracle should persist the raw payload
+    /// @return shouldStore Deprecated compatibility return
     function _handlePortalMessage(
         uint32 sourceType,
         uint256 sourceId,
@@ -534,7 +534,7 @@ error MintFailed(address recipient, uint256 amount);
            sourceType=0,        // BLOCKCHAIN
            sourceId=1,          // Ethereum chain ID (matches GBridgeReceiver.trustedSourceId)
            nonce=currentNonce+1,// Sequential; NativeOracle enforces expectedNonce == currentNonce+1
-           blockNumber,         // From MessageSent.block_number; stored as provenance in DataRecord
+           blockNumber,         // From MessageSent.block_number; committed as latestPosition
            payload,             // Full portal message
            callbackGasLimit     // Caller-specified
        )
@@ -542,8 +542,9 @@ error MintFailed(address recipient, uint256 amount);
 3. NativeOracle on Gravity:
    └─> Validates nonce == currentNonce + 1 (reverts NonceNotSequential otherwise — replay-safe)
    └─> Resolves callback using 2-layer lookup → GBridgeReceiver
-   └─> Calls receiver.onOracleEvent{gas: callbackGasLimit}(...) — expects bool return
-   └─> Stores DataRecord (with blockNumber) iff callback returned true (or no callback / gas=0 / revert)
+   └─> Calls receiver.onOracleEvent{gas: callbackGasLimit}(...) — expects canonical bool return
+   └─> On success, commits nonce + source position and emits OracleDelivered
+   └─> On callback failure, reverts without advancing source progress
 
 4. GBridgeReceiver (extends BlockchainEventHandler):
    └─> Verifies sourceId == trustedSourceId
@@ -552,7 +553,7 @@ error MintFailed(address recipient, uint256 amount);
    └─> Calls NATIVE_MINT_PRECOMPILE (0x...1625F5000) via low-level call
        with callData = 0x01 || recipient || amount
    └─> Emits NativeMinted(recipient, amount, messageNonce)
-   └─> Returns shouldStore = true so the oracle keeps the payload for audit
+   └─> Returns the legacy bool for ABI compatibility; NativeOracle stores no new payload history
 ```
 
 ---
@@ -581,7 +582,7 @@ error MintFailed(address recipient, uint256 amount);
 1. **Fee Validation**: GravityPortal rejects both underpayment (`InsufficientFee`) and overpayment (`ExcessiveFee`) so a caller sees a deterministic cost.
 2. **Consensus Required**: All oracle data requires validator consensus via SYSTEM_CALLER
 3. **Source and Sender Verification**: GBridgeReceiver checks both `sourceId == trustedSourceId` and the in-payload `sender == trustedBridge`.
-4. **Callback Failure Tolerance**: Failures do NOT revert oracle recording; NativeOracle falls back to storing the payload for later inspection.
+4. **Atomic Callback Delivery**: Receiver failure reverts the NativeOracle delivery, so its nonce remains retryable and no source progress advances.
 5. **Replay Protection**: Enforced by NativeOracle's sequential-nonce rule (`nonce == currentNonce + 1`). GBridgeReceiver does NOT keep its own processed-nonce map; the legacy slot exists only as `__deprecated_processedNonces` for storage-layout compatibility.
 6. **Compact Encoding**: PortalMessage uses 36-byte overhead (vs 128+ with abi.encode)
 
@@ -590,7 +591,7 @@ error MintFailed(address recipient, uint256 amount);
 ## Invariants
 
 1. **Nonce Uniqueness**: Each nonce from GravityPortal is unique (monotonic uint128)
-2. **Callback Safety**: Callback failures never affect oracle state
+2. **Callback Atomicity**: Receiver state and NativeOracle source progress either both update or both revert
 3. **Token Conservation**: G tokens locked on Ethereum = native G minted on Gravity (minus failed mints)
 4. **Replay Prevention**: NativeOracle enforces `nonce == currentNonce + 1` per (sourceType, sourceId), so each portal nonce can be delivered to the receiver at most once.
 

--- a/src/foundation/Errors.sol
+++ b/src/foundation/Errors.sol
@@ -426,6 +426,14 @@ library Errors {
         uint256 noncesLength, uint256 blockNumbersLength, uint256 payloadsLength, uint256 gasLimitsLength
     );
 
+    /// @notice Oracle callbacks must be unset or point to deployed contract code
+    /// @param callback The invalid callback address
+    error InvalidOracleCallback(address callback);
+    error OracleCallbackNotConfigured(uint32 sourceType, uint256 sourceId);
+    error OracleCallbackGasLimitZero(uint32 sourceType, uint256 sourceId);
+    error OracleCallbackFailed(uint32 sourceType, uint256 sourceId, uint128 nonce, address callback, bytes reason);
+    error OracleSourcePositionOverflow(uint256 sourcePosition);
+
     // ========================================================================
     // VERSION CONFIG ERRORS
     // ========================================================================
@@ -584,4 +592,3 @@ library Errors {
     /// @notice Operation is not supported
     error OperationNotSupported();
 }
-

--- a/src/oracle/INativeOracle.sol
+++ b/src/oracle/INativeOracle.sol
@@ -4,9 +4,8 @@ pragma solidity ^0.8.30;
 /// @title INativeOracle
 /// @author Gravity Team
 /// @notice Interface for the Native Oracle contract
-/// @dev Stores verified data from external sources (blockchains, JWK providers, DNS records).
-///      Data is recorded by the consensus engine via SYSTEM_CALLER after validators reach consensus.
-///      Records are keyed by (sourceType, sourceId, nonce) tuple.
+/// @dev Delivers consensus-approved external data to callbacks and stores only the latest
+///      progress for each (sourceType, sourceId) pair. Legacy records remain queryable.
 interface INativeOracle {
     // ========================================================================
     // DATA STRUCTURES
@@ -23,6 +22,13 @@ interface INativeOracle {
         bytes data;
     }
 
+    /// @notice Latest accepted progress for one oracle source
+    /// @dev Both fields pack into one storage slot.
+    struct SourceProgress {
+        uint128 latestNonce;
+        uint128 latestPosition;
+    }
+
     // ========================================================================
     // SOURCE TYPE CONSTANTS
     // ========================================================================
@@ -32,18 +38,23 @@ interface INativeOracle {
     //   1 = JWK (JSON Web Keys from OAuth providers)
     //   2 = DNS (DNS records for zkEmail, etc.)
     //   3 = PRICE_FEED (price data from oracles)
+    //   4 = reserved (no runtime adapter in this branch)
+    //   5 = reserved (no runtime adapter in this branch)
+    //   6 = POLYMARKET_SETTLEMENT (Polygon CTF settlement mirror)
     // New types can be added without contract upgrades.
 
     // ========================================================================
     // EVENTS
     // ========================================================================
 
-    /// @notice Emitted when data is recorded
-    /// @param sourceType The source type (0 = BLOCKCHAIN, 1 = JWK, etc.)
-    /// @param sourceId The source identifier (e.g., chain ID for blockchains)
-    /// @param nonce The nonce (block height, timestamp, etc.)
-    /// @param dataLength Length of the stored data
+    /// @notice Legacy event retained in the ABI for historical log decoding
+    /// @dev New deliveries emit OracleDelivered instead.
     event DataRecorded(uint32 indexed sourceType, uint256 indexed sourceId, uint128 nonce, uint256 dataLength);
+
+    /// @notice Emitted after a consensus payload is successfully delivered
+    event OracleDelivered(
+        uint32 indexed sourceType, uint256 indexed sourceId, uint128 nonce, uint128 sourcePosition, bytes32 payloadHash
+    );
 
     /// @notice Emitted when a default callback is registered or updated
     /// @param sourceType The source type
@@ -67,41 +78,30 @@ interface INativeOracle {
     /// @param callback The callback contract address
     event CallbackSuccess(uint32 indexed sourceType, uint256 indexed sourceId, uint128 nonce, address callback);
 
-    /// @notice Emitted when a callback fails (tx continues, does NOT revert)
-    /// @param sourceType The source type
-    /// @param sourceId The source identifier
-    /// @param nonce The nonce of the record
-    /// @param callback The callback contract address
-    /// @param reason The failure reason
+    /// @notice Legacy event retained in the ABI for historical log decoding
+    /// @dev New callback failures revert atomically.
     event CallbackFailed(
         uint32 indexed sourceType, uint256 indexed sourceId, uint128 nonce, address callback, bytes reason
     );
 
-    /// @notice Emitted when payload storage is skipped (callback returned shouldStore=false)
-    /// @param sourceType The source type
-    /// @param sourceId The source identifier
-    /// @param nonce The nonce of the record
-    /// @param callback The callback contract that requested skip
+    /// @notice Legacy event retained in the ABI for historical log decoding
     event StorageSkipped(uint32 indexed sourceType, uint256 indexed sourceId, uint128 nonce, address callback);
 
-    /// @notice Emitted when callback execution is skipped due to gas limit 0
-    /// @param sourceType The source type
-    /// @param sourceId The source identifier
-    /// @param nonce The nonce of the record
-    /// @param callback The callback contract that was skipped
+    /// @notice Legacy event retained in the ABI for historical log decoding
     event CallbackSkipped(uint32 indexed sourceType, uint256 indexed sourceId, uint128 nonce, address callback);
 
     // ========================================================================
     // RECORDING FUNCTIONS (Consensus Only)
     // ========================================================================
 
-    /// @notice Record a single data entry
-    /// @dev Only callable by SYSTEM_CALLER. Invokes callback if registered.
+    /// @notice Deliver a single consensus-approved data entry
+    /// @dev Only callable by SYSTEM_CALLER. Callback execution and progress update are atomic.
     /// @param sourceType The source type (uint32, e.g., 0 = BLOCKCHAIN, 1 = JWK)
     /// @param sourceId The source identifier (e.g., chain ID for blockchains)
     /// @param nonce The nonce - must start from 1 and strictly increase
-    /// @param payload The data payload to store
-    /// @param callbackGasLimit Gas limit for callback execution (0 = no callback)
+    /// @param blockNumber Source-defined restart position; retained name preserves the existing ABI
+    /// @param payload The callback payload
+    /// @param callbackGasLimit Gas limit for callback execution
     function record(
         uint32 sourceType,
         uint256 sourceId,
@@ -111,14 +111,13 @@ interface INativeOracle {
         uint256 callbackGasLimit
     ) external;
 
-    /// @notice Batch record multiple data entries from the same source
-    /// @dev Only callable by SYSTEM_CALLER. More gas efficient for multiple records.
-    ///      Each nonce is validated individually to prevent overwriting existing records.
+    /// @notice Deliver multiple consensus-approved entries from the same source
+    /// @dev Only callable by SYSTEM_CALLER. The entire batch is atomic.
     /// @param sourceType The source type
     /// @param sourceId The source identifier
     /// @param nonces Array of nonces (must be strictly increasing, each > previous latestNonce)
-    /// @param payloads Array of payloads to store (must match nonces length)
-    /// @param callbackGasLimits Array of gas limits for callback execution per record (0 = no callback)
+    /// @param payloads Array of callback payloads (must match nonces length)
+    /// @param callbackGasLimits Array of nonzero callback gas limits
     function recordBatch(
         uint32 sourceType,
         uint256 sourceId,
@@ -184,8 +183,8 @@ interface INativeOracle {
     // QUERY FUNCTIONS
     // ========================================================================
 
-    /// @notice Get a record by its key tuple
-    /// @dev Record exists if record.recordedAt > 0
+    /// @notice Get a legacy record by its key tuple
+    /// @dev New deliveries do not write records. This getter remains for pre-upgrade history.
     /// @param sourceType The source type
     /// @param sourceId The source identifier
     /// @param nonce The nonce
@@ -199,11 +198,17 @@ interface INativeOracle {
     /// @notice Get the latest nonce for a source
     /// @param sourceType The source type
     /// @param sourceId The source identifier
-    /// @return nonce The latest nonce (0 if no records)
+    /// @return nonce The latest accepted nonce (0 if no delivery exists)
     function getLatestNonce(
         uint32 sourceType,
         uint256 sourceId
     ) external view returns (uint128 nonce);
+
+    /// @notice Get the effective latest progress, including legacy fallback
+    function getSourceProgress(
+        uint32 sourceType,
+        uint256 sourceId
+    ) external view returns (SourceProgress memory progress);
 
     /// @notice Check if a source has synced past a certain point
     /// @param sourceType The source type
@@ -220,18 +225,15 @@ interface INativeOracle {
 /// @title IOracleCallback
 /// @author Gravity Team
 /// @notice Interface for oracle callback handlers
-/// @dev Implement this to receive oracle events. Callbacks are invoked with caller-specified gas limit.
+/// @dev The bool return is retained for ABI compatibility but no longer controls NativeOracle storage.
 interface IOracleCallback {
     /// @notice Called when an oracle event is recorded
-    /// @dev Callback failures are caught - they do NOT revert the oracle recording.
-    ///      The return value controls whether NativeOracle stores the payload:
-    ///      - true: Store the payload in NativeOracle (default behavior)
-    ///      - false: Skip storage (callback handles its own storage, e.g., JWKManager)
+    /// @dev Callback failure reverts delivery, so callback state and source progress remain atomic.
     /// @param sourceType The source type
     /// @param sourceId The source identifier
     /// @param nonce The nonce of the record
     /// @param payload The event payload (encoding depends on event type)
-    /// @return shouldStore True if NativeOracle should store the payload, false to skip storage
+    /// @return shouldStore Deprecated and ignored by NativeOracle
     function onOracleEvent(
         uint32 sourceType,
         uint256 sourceId,

--- a/src/oracle/IOracleTaskConfig.sol
+++ b/src/oracle/IOracleTaskConfig.sol
@@ -6,7 +6,8 @@ pragma solidity ^0.8.30;
 /// @notice Interface for the Oracle Task Configuration contract
 /// @dev Stores configuration for continuous oracle tasks that validators actively monitor.
 ///      Tasks are keyed by (sourceType, sourceId, taskName) tuple.
-///      Multiple tasks can exist for the same (sourceType, sourceId) pair.
+///      Multiple tasks can exist for the same (sourceType, sourceId) pair except for relayer-backed
+///      sources, whose NativeOracle nonce stream is keyed only by that pair.
 interface IOracleTaskConfig {
     // ========================================================================
     // DATA STRUCTURES

--- a/src/oracle/NativeOracle.sol
+++ b/src/oracle/NativeOracle.sol
@@ -8,20 +8,19 @@ import { Errors } from "../foundation/Errors.sol";
 
 /// @title NativeOracle
 /// @author Gravity Team
-/// @notice Stores verified data from external sources (blockchains, JWK providers, DNS records)
-/// @dev Data is recorded by the consensus engine via SYSTEM_CALLER after validators reach consensus.
-///      Records are keyed by (sourceType, sourceId, nonce) tuple.
-///      Callbacks are invoked with caller-specified gas limit and failures do NOT revert oracle recording.
+/// @notice Delivers verified external data and stores one latest checkpoint per source
+/// @dev Legacy records and nonces retain their storage slots for hardfork compatibility.
 contract NativeOracle is INativeOracle {
+    uint256 private constant MAX_CALLBACK_RETURNDATA_BYTES = 256;
+
     // ========================================================================
     // STATE
     // ========================================================================
 
-    // TODO: refactor? how to upgrade
-    /// @notice Data records: sourceType -> sourceId -> nonce -> DataRecord
+    /// @dev Legacy records. Kept for historical reads and storage compatibility; never written.
     mapping(uint32 => mapping(uint256 => mapping(uint128 => DataRecord))) private _records;
 
-    /// @notice Latest nonce per source: sourceType -> sourceId -> nonce
+    /// @dev Legacy nonces. Kept for hardfork fallback and storage compatibility; never written.
     mapping(uint32 => mapping(uint256 => uint128)) private _nonces;
 
     /// @notice Default callback handlers: sourceType -> callback contract
@@ -32,6 +31,10 @@ contract NativeOracle is INativeOracle {
 
     /// @notice Whether the contract has been initialized
     bool private _initialized;
+
+    /// @notice Latest post-hardfork progress, packed into one slot per source
+    /// @dev Appended after every legacy field to preserve the deployed storage layout.
+    mapping(uint32 => mapping(uint256 => SourceProgress)) private _sourceProgress;
 
     // ========================================================================
     // INITIALIZATION
@@ -56,6 +59,7 @@ contract NativeOracle is INativeOracle {
         }
 
         for (uint256 i; i < length;) {
+            _validateCallback(callbacks[i]);
             _defaultCallbacks[sourceTypes[i]] = callbacks[i];
             emit DefaultCallbackSet(sourceTypes[i], address(0), callbacks[i]);
             unchecked {
@@ -80,24 +84,7 @@ contract NativeOracle is INativeOracle {
         uint256 callbackGasLimit
     ) external {
         requireAllowed(SystemAddresses.SYSTEM_CALLER);
-
-        // Validate and update nonce (always done regardless of storage)
-        _updateNonce(sourceType, sourceId, nonce);
-
-        // Invoke callback first to determine if we should store
-        // Default: store if no callback or callback fails
-        bool shouldStore = true;
-        shouldStore = _invokeCallback(sourceType, sourceId, nonce, payload, callbackGasLimit);
-
-        // Conditionally store record based on callback result
-        if (shouldStore) {
-            _records[sourceType][sourceId][nonce] = DataRecord({
-                recordedAt: uint64(block.timestamp), // NOTE: EVM seconds, NOT Gravity microseconds
-                blockNumber: blockNumber,
-                data: payload
-            });
-            emit DataRecorded(sourceType, sourceId, nonce, payload.length);
-        }
+        _deliver(sourceType, sourceId, nonce, blockNumber, payload, callbackGasLimit);
     }
 
     /// @inheritdoc INativeOracle
@@ -121,9 +108,9 @@ contract NativeOracle is INativeOracle {
             );
         }
 
-        // Record all data entries with individual nonce validation
+        // Deliver all entries atomically. Any callback failure reverts the full batch.
         for (uint256 i; i < length;) {
-            _recordSingle(sourceType, sourceId, nonces[i], blockNumbers[i], payloads[i], callbackGasLimits[i]);
+            _deliver(sourceType, sourceId, nonces[i], blockNumbers[i], payloads[i], callbackGasLimits[i]);
 
             unchecked {
                 ++i;
@@ -131,13 +118,13 @@ contract NativeOracle is INativeOracle {
         }
     }
 
-    /// @notice Internal helper to record a single entry (reduces stack depth)
+    /// @notice Deliver one entry and advance progress only after callback success
     /// @param sourceType The source type
     /// @param sourceId The source identifier
     /// @param nonce The nonce
     /// @param payload The payload data
     /// @param callbackGasLimit Gas limit for callback (0 = no callback)
-    function _recordSingle(
+    function _deliver(
         uint32 sourceType,
         uint256 sourceId,
         uint128 nonce,
@@ -145,23 +132,17 @@ contract NativeOracle is INativeOracle {
         bytes calldata payload,
         uint256 callbackGasLimit
     ) private {
-        // Validate and update nonce (always done regardless of storage)
-        _updateNonce(sourceType, sourceId, nonce);
-
-        // Invoke callback first to determine if we should store
-        // Default: store if no callback or callback fails
-        bool shouldStore = true;
-        shouldStore = _invokeCallback(sourceType, sourceId, nonce, payload, callbackGasLimit);
-
-        // Conditionally store record based on callback result
-        if (shouldStore) {
-            _records[sourceType][sourceId][nonce] = DataRecord({
-                recordedAt: uint64(block.timestamp), // NOTE: EVM seconds, NOT Gravity microseconds
-                blockNumber: blockNumber,
-                data: payload
-            });
-            emit DataRecorded(sourceType, sourceId, nonce, payload.length);
+        SourceProgress memory current = _getSourceProgress(sourceType, sourceId);
+        if (nonce != current.latestNonce + 1) {
+            revert Errors.NonceNotSequential(sourceType, sourceId, current.latestNonce + 1, nonce);
         }
+        if (blockNumber > type(uint128).max) revert Errors.OracleSourcePositionOverflow(blockNumber);
+
+        _invokeCallback(sourceType, sourceId, nonce, payload, callbackGasLimit);
+
+        uint128 sourcePosition = uint128(blockNumber);
+        _sourceProgress[sourceType][sourceId] = SourceProgress({ latestNonce: nonce, latestPosition: sourcePosition });
+        emit OracleDelivered(sourceType, sourceId, nonce, sourcePosition, keccak256(payload));
     }
 
     // ========================================================================
@@ -174,6 +155,7 @@ contract NativeOracle is INativeOracle {
         address callback
     ) external {
         requireAllowed(SystemAddresses.GOVERNANCE);
+        _validateCallback(callback);
 
         address oldCallback = _defaultCallbacks[sourceType];
         _defaultCallbacks[sourceType] = callback;
@@ -195,6 +177,7 @@ contract NativeOracle is INativeOracle {
         address callback
     ) external {
         requireAllowed(SystemAddresses.GOVERNANCE);
+        _validateCallback(callback);
 
         address oldCallback = _callbacks[sourceType][sourceId];
         _callbacks[sourceType][sourceId] = callback;
@@ -232,7 +215,15 @@ contract NativeOracle is INativeOracle {
         uint32 sourceType,
         uint256 sourceId
     ) external view returns (uint128 nonce) {
-        return _nonces[sourceType][sourceId];
+        return _getSourceProgress(sourceType, sourceId).latestNonce;
+    }
+
+    /// @inheritdoc INativeOracle
+    function getSourceProgress(
+        uint32 sourceType,
+        uint256 sourceId
+    ) external view returns (SourceProgress memory progress) {
+        return _getSourceProgress(sourceType, sourceId);
     }
 
     /// @inheritdoc INativeOracle
@@ -241,7 +232,7 @@ contract NativeOracle is INativeOracle {
         uint256 sourceId,
         uint128 nonce
     ) external view returns (bool) {
-        uint128 latestNonce = _nonces[sourceType][sourceId];
+        uint128 latestNonce = _getSourceProgress(sourceType, sourceId).latestNonce;
         return latestNonce > 0 && latestNonce >= nonce;
     }
 
@@ -249,24 +240,22 @@ contract NativeOracle is INativeOracle {
     // INTERNAL FUNCTIONS
     // ========================================================================
 
-    /// @notice Update nonce for a source
-    /// @dev Validates that nonce is sequential (currentNonce defaults to 0, so first nonce must be 1)
-    /// @param sourceType The source type
-    /// @param sourceId The source identifier
-    /// @param nonce The new nonce (must be currentNonce + 1)
-    function _updateNonce(
+    /// @notice Read post-hardfork progress or fall back to the latest legacy record
+    function _getSourceProgress(
         uint32 sourceType,
-        uint256 sourceId,
-        uint128 nonce
-    ) internal {
-        uint128 currentNonce = _nonces[sourceType][sourceId];
+        uint256 sourceId
+    ) internal view returns (SourceProgress memory progress) {
+        progress = _sourceProgress[sourceType][sourceId];
+        if (progress.latestNonce != 0) return progress;
 
-        // Nonce must be sequential (currentNonce defaults to 0, so first nonce must be 1)
-        if (nonce != currentNonce + 1) {
-            revert Errors.NonceNotSequential(sourceType, sourceId, currentNonce + 1, nonce);
+        uint128 legacyNonce = _nonces[sourceType][sourceId];
+        if (legacyNonce == 0) return progress;
+
+        uint256 legacyPosition = _records[sourceType][sourceId][legacyNonce].blockNumber;
+        if (legacyPosition > type(uint128).max) {
+            revert Errors.OracleSourcePositionOverflow(legacyPosition);
         }
-
-        _nonces[sourceType][sourceId] = nonce;
+        progress = SourceProgress({ latestNonce: legacyNonce, latestPosition: uint128(legacyPosition) });
     }
 
     /// @notice Resolve callback using 2-layer lookup
@@ -285,43 +274,70 @@ contract NativeOracle is INativeOracle {
         return _defaultCallbacks[sourceType];
     }
 
-    /// @notice Invoke callback with specified gas limit
-    /// @dev Failures are caught to prevent DOS attacks. Returns whether storage should happen.
+    /// @notice Invoke callback with bounded returndata and fail atomically
     /// @param sourceType The source type
     /// @param sourceId The source identifier
     /// @param nonce The nonce of the record
     /// @param payload The event payload
     /// @param gasLimit Gas limit for callback execution
-    /// @return shouldStore True if payload should be stored, false to skip storage
     function _invokeCallback(
         uint32 sourceType,
         uint256 sourceId,
         uint128 nonce,
         bytes calldata payload,
         uint256 gasLimit
-    ) internal returns (bool shouldStore) {
+    ) internal {
         address callback = _resolveCallback(sourceType, sourceId);
-        if (callback == address(0)) return true; // No callback = store by default
+        if (callback == address(0)) {
+            revert Errors.OracleCallbackNotConfigured(sourceType, sourceId);
+        }
         if (gasLimit == 0) {
-            emit CallbackSkipped(sourceType, sourceId, nonce, callback);
-            return true;
+            revert Errors.OracleCallbackGasLimitZero(sourceType, sourceId);
         }
 
-        // Try to call the callback with specified gas limit
-        // This prevents malicious callbacks from:
-        // 1. Consuming excessive gas
-        // 2. Blocking oracle updates by reverting
-        try IOracleCallback(callback).onOracleEvent{ gas: gasLimit }(sourceType, sourceId, nonce, payload) returns (
-            bool callbackShouldStore
-        ) {
-            emit CallbackSuccess(sourceType, sourceId, nonce, callback);
-            if (!callbackShouldStore) {
-                emit StorageSkipped(sourceType, sourceId, nonce, callback);
-            }
-            return callbackShouldStore;
-        } catch (bytes memory reason) {
-            emit CallbackFailed(sourceType, sourceId, nonce, callback, reason);
-            return true; // On failure, store by default to preserve data
+        bytes memory callData = abi.encodeCall(IOracleCallback.onOracleEvent, (sourceType, sourceId, nonce, payload));
+        (bool success, bytes memory returnData) = _callWithBoundedReturndata(callback, gasLimit, callData);
+
+        if (!success || returnData.length < 32) {
+            revert Errors.OracleCallbackFailed(sourceType, sourceId, nonce, callback, returnData);
+        }
+
+        uint256 rawReturnValue;
+        assembly ("memory-safe") {
+            rawReturnValue := mload(add(returnData, 0x20))
+        }
+        if (rawReturnValue > 1) {
+            revert Errors.OracleCallbackFailed(sourceType, sourceId, nonce, callback, returnData);
+        }
+
+        emit CallbackSuccess(sourceType, sourceId, nonce, callback);
+    }
+
+    /// @dev Calls a callback without automatically copying unbounded returndata into memory.
+    function _callWithBoundedReturndata(
+        address callback,
+        uint256 gasLimit,
+        bytes memory callData
+    ) private returns (bool success, bytes memory returnData) {
+        uint256 maxReturnData = MAX_CALLBACK_RETURNDATA_BYTES;
+        assembly ("memory-safe") {
+            success := call(gasLimit, callback, 0, add(callData, 0x20), mload(callData), 0, 0)
+
+            let returnSize := returndatasize()
+            if gt(returnSize, maxReturnData) { returnSize := maxReturnData }
+
+            returnData := mload(0x40)
+            mstore(returnData, returnSize)
+            returndatacopy(add(returnData, 0x20), 0, returnSize)
+            mstore(0x40, and(add(add(returnData, 0x3f), returnSize), not(0x1f)))
+        }
+    }
+
+    function _validateCallback(
+        address callback
+    ) private view {
+        if (callback != address(0) && callback.code.length == 0) {
+            revert Errors.InvalidOracleCallback(callback);
         }
     }
 }

--- a/src/oracle/OracleTaskConfig.sol
+++ b/src/oracle/OracleTaskConfig.sol
@@ -11,11 +11,20 @@ import { EnumerableSet } from "@openzeppelin/utils/structs/EnumerableSet.sol";
 /// @author Gravity Team
 /// @notice Stores configuration for continuous oracle tasks that validators actively monitor
 /// @dev Tasks are keyed by (sourceType, sourceId, taskName) tuple.
-///      Multiple tasks can exist for the same (sourceType, sourceId) pair.
+///      Relayer-backed sources allow one task per (sourceType, sourceId) because NativeOracle uses
+///      one nonce stream for that pair. Other source types may register multiple named tasks.
 ///      Only GOVERNANCE can create, update, or remove tasks.
 contract OracleTaskConfig is IOracleTaskConfig {
     using EnumerableSet for EnumerableSet.Bytes32Set;
     using EnumerableSet for EnumerableSet.UintSet;
+
+    uint32 private constant SOURCE_TYPE_BLOCKCHAIN = 0;
+    uint32 private constant SOURCE_TYPE_PRICE_FEED = 3;
+    uint32 private constant SOURCE_TYPE_POLYMARKET_SETTLEMENT = 6;
+
+    error RelayerTaskAlreadyConfigured(
+        uint32 sourceType, uint256 sourceId, bytes32 existingTaskName, bytes32 requestedTaskName
+    );
 
     // ========================================================================
     // STATE
@@ -50,6 +59,11 @@ contract OracleTaskConfig is IOracleTaskConfig {
             revert Errors.EmptyConfig();
         }
 
+        EnumerableSet.Bytes32Set storage taskNames = _taskNames[sourceType][sourceId];
+        if (_isRelayerBackedSourceType(sourceType) && !taskNames.contains(taskName) && taskNames.length() != 0) {
+            revert RelayerTaskAlreadyConfigured(sourceType, sourceId, taskNames.at(0), taskName);
+        }
+
         // Register source type and source ID for enumeration (no-op if already exists)
         _registeredSourceTypes.add(sourceType);
         _registeredSourceIds[sourceType].add(sourceId);
@@ -61,6 +75,13 @@ contract OracleTaskConfig is IOracleTaskConfig {
         _tasks[sourceType][sourceId][taskName] = OracleTask({ config: config, updatedAt: uint64(block.timestamp) });
 
         emit TaskSet(sourceType, sourceId, taskName, config);
+    }
+
+    function _isRelayerBackedSourceType(
+        uint32 sourceType
+    ) private pure returns (bool) {
+        return sourceType == SOURCE_TYPE_BLOCKCHAIN || sourceType == SOURCE_TYPE_PRICE_FEED
+            || sourceType == SOURCE_TYPE_POLYMARKET_SETTLEMENT;
     }
 
     /// @inheritdoc IOracleTaskConfig

--- a/test/unit/oracle/JWKManager.t.sol
+++ b/test/unit/oracle/JWKManager.t.sol
@@ -139,22 +139,18 @@ contract JWKManagerTest is Test {
         // Verify key1 exists
         assertTrue(jwkManager.hasJWK(GOOGLE_ISSUER, "key1"));
 
-        // Second record with same version - callback will fail but NativeOracle won't revert
-        // (because callback failures are caught). The data will be stored in NativeOracle
-        // but JWKManager will NOT update its state.
+        // A non-increasing version fails atomically. The nonce stays retryable.
         uint256 sourceId = uint256(keccak256(GOOGLE_ISSUER));
         bytes memory payload = _createPayload(GOOGLE_ISSUER, 1, jwks); // Same version
 
+        vm.expectPartialRevert(Errors.OracleCallbackFailed.selector);
         vm.prank(systemCaller);
         oracle.record(SOURCE_TYPE_JWK, sourceId, 2, 0, payload, CALLBACK_GAS_LIMIT);
 
-        // JWKManager still has the original version (callback failed, state unchanged)
         IJWKManager.ProviderJWKs memory provider = jwkManager.getProviderJWKs(GOOGLE_ISSUER);
         assertEq(provider.version, 1);
-
-        // NativeOracle stored the data (because callback failure defaults to store)
-        INativeOracle.DataRecord memory record = oracle.getRecord(SOURCE_TYPE_JWK, sourceId, 2);
-        assertTrue(record.recordedAt > 0);
+        assertEq(oracle.getLatestNonce(SOURCE_TYPE_JWK, sourceId), 1);
+        assertEq(oracle.getRecord(SOURCE_TYPE_JWK, sourceId, 2).recordedAt, 0);
     }
 
     function test_OnOracleEvent_UpdateExistingProvider() public {
@@ -586,17 +582,16 @@ contract JWKManagerTest is Test {
         // First record succeeds
         _recordJWK(GOOGLE_ISSUER, version1, jwks, 1);
 
-        // Second with non-increasing version causes callback failure
-        // JWKManager state should not change
+        // A non-increasing version fails atomically.
         uint256 sourceId = uint256(keccak256(GOOGLE_ISSUER));
         bytes memory payload = _createPayload(GOOGLE_ISSUER, version2, jwks);
 
+        vm.expectPartialRevert(Errors.OracleCallbackFailed.selector);
         vm.prank(systemCaller);
         oracle.record(SOURCE_TYPE_JWK, sourceId, 2, 0, payload, CALLBACK_GAS_LIMIT);
 
-        // JWKManager still has the original version (callback failed)
         IJWKManager.ProviderJWKs memory provider = jwkManager.getProviderJWKs(GOOGLE_ISSUER);
         assertEq(provider.version, version1);
+        assertEq(oracle.getLatestNonce(SOURCE_TYPE_JWK, sourceId), 1);
     }
 }
-

--- a/test/unit/oracle/NativeOracle.t.sol
+++ b/test/unit/oracle/NativeOracle.t.sol
@@ -1,14 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.30;
 
-import { Test, Vm } from "forge-std/Test.sol";
+import { Test } from "forge-std/Test.sol";
 import { NativeOracle } from "../../../src/oracle/NativeOracle.sol";
 import { INativeOracle, IOracleCallback } from "../../../src/oracle/INativeOracle.sol";
 import { SystemAddresses } from "../../../src/foundation/SystemAddresses.sol";
 import { Errors } from "../../../src/foundation/Errors.sol";
 
-/// @title MockOracleCallback
-/// @notice Mock callback handler for testing
 contract MockOracleCallback is IOracleCallback {
     uint32 public lastSourceType;
     uint256 public lastSourceId;
@@ -16,951 +14,440 @@ contract MockOracleCallback is IOracleCallback {
     bytes public lastPayload;
     uint256 public callCount;
     bool public shouldRevert;
-    bool public shouldConsumeAllGas;
-    bool public returnShouldStore = true; // Default: store in NativeOracle
+    bool public returnValue = true;
 
     function onOracleEvent(
         uint32 sourceType,
         uint256 sourceId,
         uint128 nonce,
         bytes calldata payload
-    ) external override returns (bool shouldStore) {
-        if (shouldRevert) {
-            revert("MockCallback: intentional revert");
-        }
-        if (shouldConsumeAllGas) {
-            // Consume all gas by infinite loop
-            while (true) { }
-        }
+    ) external override returns (bool) {
+        if (shouldRevert) revert("intentional callback failure");
 
         lastSourceType = sourceType;
         lastSourceId = sourceId;
         lastNonce = nonce;
         lastPayload = payload;
-        callCount++;
-
-        return returnShouldStore;
+        ++callCount;
+        return returnValue;
     }
 
     function setRevert(
-        bool _shouldRevert
+        bool value
     ) external {
-        shouldRevert = _shouldRevert;
+        shouldRevert = value;
     }
 
-    function setConsumeAllGas(
-        bool _shouldConsumeAllGas
+    function setReturnValue(
+        bool value
     ) external {
-        shouldConsumeAllGas = _shouldConsumeAllGas;
-    }
-
-    function setShouldStore(
-        bool _shouldStore
-    ) external {
-        returnShouldStore = _shouldStore;
+        returnValue = value;
     }
 }
 
-/// @title NativeOracleTest
-/// @notice Comprehensive unit tests for NativeOracle contract
+contract MalformedReturnCallback {
+    uint256 private immutable _returnWord;
+    uint256 private immutable _returnSize;
+
+    constructor(
+        uint256 returnWord,
+        uint256 returnSize
+    ) {
+        _returnWord = returnWord;
+        _returnSize = returnSize;
+    }
+
+    fallback() external {
+        uint256 returnWord = _returnWord;
+        uint256 returnSize = _returnSize;
+        assembly ("memory-safe") {
+            mstore(0, returnWord)
+            return(0, returnSize)
+        }
+    }
+}
+
 contract NativeOracleTest is Test {
-    NativeOracle public oracle;
-    MockOracleCallback public mockCallback;
+    NativeOracle internal oracle;
+    MockOracleCallback internal callback;
 
-    // Test addresses
-    address public systemCaller;
-    address public governance;
-    address public alice;
-    address public bob;
+    uint32 internal constant SOURCE_TYPE_BLOCKCHAIN = 0;
+    uint32 internal constant SOURCE_TYPE_JWK = 1;
+    uint256 internal constant ETHEREUM_SOURCE_ID = 1;
+    uint256 internal constant GOOGLE_JWK_SOURCE_ID = 2;
+    uint256 internal constant CALLBACK_GAS_LIMIT = 500_000;
 
-    // Test data - Source types as uint32 (0 = BLOCKCHAIN, 1 = JWK, etc.)
-    uint32 public constant SOURCE_TYPE_BLOCKCHAIN = 0;
-    uint32 public constant SOURCE_TYPE_JWK = 1;
-    uint256 public constant ETHEREUM_SOURCE_ID = 1; // Ethereum chain ID
-    uint256 public constant GOOGLE_JWK_SOURCE_ID = 1; // Google JWK provider
-    uint256 public constant CALLBACK_GAS_LIMIT = 500_000;
+    address internal systemCaller = SystemAddresses.SYSTEM_CALLER;
+    address internal governance = SystemAddresses.GOVERNANCE;
+    address internal alice = makeAddr("alice");
 
     function setUp() public {
-        // Set up addresses
-        systemCaller = SystemAddresses.SYSTEM_CALLER;
-        governance = SystemAddresses.GOVERNANCE;
-        alice = makeAddr("alice");
-        bob = makeAddr("bob");
-
-        // Deploy oracle
         oracle = new NativeOracle();
+        callback = new MockOracleCallback();
 
-        // Deploy mock callback
-        mockCallback = new MockOracleCallback();
+        vm.startPrank(governance);
+        oracle.setDefaultCallback(SOURCE_TYPE_BLOCKCHAIN, address(callback));
+        oracle.setDefaultCallback(SOURCE_TYPE_JWK, address(callback));
+        vm.stopPrank();
     }
 
-    // ========================================================================
-    // RECORD TESTS
-    // ========================================================================
-
-    function test_Record() public {
+    function test_RecordStoresOnlyLatestProgress() public {
         bytes memory payload = abi.encode(alice, uint256(100), "deposit");
-        uint128 nonce = 1;
 
-        vm.prank(systemCaller);
-        oracle.record(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, nonce, 0, payload, CALLBACK_GAS_LIMIT);
+        _record(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, 1, 19_876_543, payload, CALLBACK_GAS_LIMIT);
 
-        // Verify record exists (recordedAt > 0 means exists)
-        INativeOracle.DataRecord memory record = oracle.getRecord(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, nonce);
-        assertTrue(record.recordedAt > 0);
-        assertEq(record.data, payload);
-
-        // Verify latest nonce
-        assertEq(oracle.getLatestNonce(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID), nonce);
-    }
-
-    function test_Record_RevertWhenNotSystemCaller() public {
-        bytes memory payload = abi.encode(alice, uint256(100));
-
-        vm.expectRevert();
-        vm.prank(alice);
-        oracle.record(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, 1, 0, payload, CALLBACK_GAS_LIMIT);
-    }
-
-    function test_Record_RevertWhenNonceIsZero() public {
-        bytes memory payload = abi.encode("first");
-
-        // Try to record with nonce = 0 (latestNonce starts at 0, so first nonce must be 1)
-        vm.expectRevert(
-            abi.encodeWithSelector(Errors.NonceNotSequential.selector, SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, 1, 0)
-        );
-        vm.prank(systemCaller);
-        oracle.record(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, 0, 0, payload, CALLBACK_GAS_LIMIT);
-    }
-
-    function test_Record_RevertWhenNonceNotSequential() public {
-        bytes memory payload1 = abi.encode("first");
-
-        // Record first (nonce must be 1)
-        vm.prank(systemCaller);
-        oracle.record(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, 1, 0, payload1, CALLBACK_GAS_LIMIT);
-
-        // Try to record with same nonce (expected: 2, provided: 1)
-        bytes memory payload2 = abi.encode("second");
-
-        vm.expectRevert(
-            abi.encodeWithSelector(Errors.NonceNotSequential.selector, SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, 2, 1)
-        );
-        vm.prank(systemCaller);
-        oracle.record(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, 1, 0, payload2, CALLBACK_GAS_LIMIT);
-
-        // Try to record with a gap (expected: 2, provided: 5)
-        vm.expectRevert(
-            abi.encodeWithSelector(Errors.NonceNotSequential.selector, SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, 2, 5)
-        );
-        vm.prank(systemCaller);
-        oracle.record(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, 5, 0, payload2, CALLBACK_GAS_LIMIT);
-    }
-
-    function test_Record_MultipleSourcesIndependent() public {
-        bytes memory payload1 = abi.encode("ethereum event");
-        bytes memory payload2 = abi.encode("google jwk");
-
-        // Record to ethereum source (first nonce must be 1)
-        vm.prank(systemCaller);
-        oracle.record(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, 1, 0, payload1, CALLBACK_GAS_LIMIT);
-
-        // Record to google source (first nonce must also be 1, independent source)
-        vm.prank(systemCaller);
-        oracle.record(SOURCE_TYPE_JWK, GOOGLE_JWK_SOURCE_ID, 1, 0, payload2, CALLBACK_GAS_LIMIT);
-
-        // Verify both sources
+        INativeOracle.SourceProgress memory progress =
+            oracle.getSourceProgress(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID);
+        assertEq(progress.latestNonce, 1);
+        assertEq(progress.latestPosition, 19_876_543);
         assertEq(oracle.getLatestNonce(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID), 1);
-        assertEq(oracle.getLatestNonce(SOURCE_TYPE_JWK, GOOGLE_JWK_SOURCE_ID), 1);
+        assertTrue(oracle.isSyncedPast(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, 1));
+
+        INativeOracle.DataRecord memory record = oracle.getRecord(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, 1);
+        assertEq(record.recordedAt, 0);
+        assertEq(record.blockNumber, 0);
+        assertEq(record.data.length, 0);
+
+        assertEq(callback.lastSourceType(), SOURCE_TYPE_BLOCKCHAIN);
+        assertEq(callback.lastSourceId(), ETHEREUM_SOURCE_ID);
+        assertEq(callback.lastNonce(), 1);
+        assertEq(callback.lastPayload(), payload);
     }
 
-    // ========================================================================
-    // BATCH RECORDING TESTS
-    // ========================================================================
+    function test_RecordOverwritesOneProgressSlot() public {
+        _record(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, 1, 100, hex"01", CALLBACK_GAS_LIMIT);
+        _record(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, 2, 110, hex"02", CALLBACK_GAS_LIMIT);
 
-    function test_RecordBatch() public {
+        INativeOracle.SourceProgress memory progress =
+            oracle.getSourceProgress(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID);
+        assertEq(progress.latestNonce, 2);
+        assertEq(progress.latestPosition, 110);
+        assertEq(oracle.getRecord(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, 1).recordedAt, 0);
+        assertEq(oracle.getRecord(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, 2).recordedAt, 0);
+    }
+
+    function test_RecordMultipleSourcesRemainIndependent() public {
+        _record(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, 1, 101, hex"01", CALLBACK_GAS_LIMIT);
+        _record(SOURCE_TYPE_JWK, GOOGLE_JWK_SOURCE_ID, 1, 202, hex"02", CALLBACK_GAS_LIMIT);
+
+        INativeOracle.SourceProgress memory blockchain =
+            oracle.getSourceProgress(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID);
+        INativeOracle.SourceProgress memory jwk = oracle.getSourceProgress(SOURCE_TYPE_JWK, GOOGLE_JWK_SOURCE_ID);
+        assertEq(blockchain.latestNonce, 1);
+        assertEq(blockchain.latestPosition, 101);
+        assertEq(jwk.latestNonce, 1);
+        assertEq(jwk.latestPosition, 202);
+    }
+
+    function test_RecordBatchAdvancesToFinalProgressWithoutHistory() public {
         uint128[] memory nonces = new uint128[](3);
-        uint256[] memory blockNumbers = new uint256[](3);
+        uint256[] memory positions = new uint256[](3);
         bytes[] memory payloads = new bytes[](3);
         uint256[] memory gasLimits = new uint256[](3);
-
-        for (uint256 i = 0; i < 3; i++) {
-            nonces[i] = 1 + uint128(i); // Sequential: 1, 2, 3
-            blockNumbers[i] = 0;
-            payloads[i] = abi.encode("event", i);
+        for (uint256 i; i < 3; ++i) {
+            nonces[i] = uint128(i + 1);
+            positions[i] = 1_000 + i;
+            payloads[i] = abi.encode(i);
             gasLimits[i] = CALLBACK_GAS_LIMIT;
         }
 
         vm.prank(systemCaller);
-        oracle.recordBatch(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, nonces, blockNumbers, payloads, gasLimits);
+        oracle.recordBatch(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, nonces, positions, payloads, gasLimits);
 
-        // Verify all records exist (recordedAt > 0 means exists)
-        for (uint256 i = 0; i < 3; i++) {
-            INativeOracle.DataRecord memory record =
-                oracle.getRecord(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, nonces[i]);
-            assertTrue(record.recordedAt > 0);
-            assertEq(record.data, payloads[i]);
+        INativeOracle.SourceProgress memory progress =
+            oracle.getSourceProgress(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID);
+        assertEq(progress.latestNonce, 3);
+        assertEq(progress.latestPosition, 1_002);
+        assertEq(callback.callCount(), 3);
+        for (uint128 nonce = 1; nonce <= 3; ++nonce) {
+            assertEq(oracle.getRecord(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, nonce).recordedAt, 0);
         }
-
-        // Verify latest nonce is the final nonce
-        assertEq(oracle.getLatestNonce(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID), nonces[2]);
     }
 
-    function test_RecordBatch_EmptyArrays() public {
-        uint128[] memory nonces = new uint128[](0);
-        uint256[] memory blockNumbers = new uint256[](0);
-        bytes[] memory payloads = new bytes[](0);
-        uint256[] memory gasLimits = new uint256[](0);
+    function test_RecordBatchIsAtomic() public {
+        uint128[] memory nonces = new uint128[](2);
+        nonces[0] = 1;
+        nonces[1] = 3;
+        uint256[] memory positions = new uint256[](2);
+        positions[0] = 100;
+        positions[1] = 300;
+        bytes[] memory payloads = new bytes[](2);
+        payloads[0] = hex"01";
+        payloads[1] = hex"03";
+        uint256[] memory gasLimits = new uint256[](2);
+        gasLimits[0] = CALLBACK_GAS_LIMIT;
+        gasLimits[1] = CALLBACK_GAS_LIMIT;
 
+        vm.expectRevert(
+            abi.encodeWithSelector(Errors.NonceNotSequential.selector, SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, 2, 3)
+        );
         vm.prank(systemCaller);
-        oracle.recordBatch(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, nonces, blockNumbers, payloads, gasLimits);
+        oracle.recordBatch(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, nonces, positions, payloads, gasLimits);
 
-        // Nothing should be recorded
+        assertEq(oracle.getLatestNonce(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID), 0);
+        assertEq(callback.callCount(), 0);
+    }
+
+    function test_RecordBatchRejectsMismatchedLengths() public {
+        uint128[] memory nonces = new uint128[](1);
+        uint256[] memory positions = new uint256[](0);
+        bytes[] memory payloads = new bytes[](1);
+        uint256[] memory gasLimits = new uint256[](1);
+
+        vm.expectRevert(abi.encodeWithSelector(Errors.OracleBatchArrayLengthMismatch.selector, 1, 0, 1, 1));
+        vm.prank(systemCaller);
+        oracle.recordBatch(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, nonces, positions, payloads, gasLimits);
+    }
+
+    function test_RecordBatchAllowsEmptyBatch() public {
+        vm.prank(systemCaller);
+        oracle.recordBatch(
+            SOURCE_TYPE_BLOCKCHAIN,
+            ETHEREUM_SOURCE_ID,
+            new uint128[](0),
+            new uint256[](0),
+            new bytes[](0),
+            new uint256[](0)
+        );
         assertEq(oracle.getLatestNonce(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID), 0);
     }
 
-    function test_RecordBatch_RevertWhenArrayLengthMismatch() public {
-        uint128[] memory nonces = new uint128[](3);
-        uint256[] memory blockNumbers = new uint256[](3);
-        bytes[] memory payloads = new bytes[](2); // Mismatched length
-        uint256[] memory gasLimits = new uint256[](3);
-
-        for (uint256 i = 0; i < 3; i++) {
-            nonces[i] = 1000 + uint128(i);
-            blockNumbers[i] = 0;
-            gasLimits[i] = CALLBACK_GAS_LIMIT;
-        }
-        payloads[0] = abi.encode("event0");
-        payloads[1] = abi.encode("event1");
-
-        vm.expectRevert(abi.encodeWithSelector(Errors.OracleBatchArrayLengthMismatch.selector, 3, 3, 2, 3));
-        vm.prank(systemCaller);
-        oracle.recordBatch(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, nonces, blockNumbers, payloads, gasLimits);
-    }
-
-    function test_RecordBatch_RevertWhenBlockNumbersLengthMismatch() public {
-        uint128[] memory nonces = new uint128[](3);
-        uint256[] memory blockNumbers = new uint256[](2); // Mismatched length
-        bytes[] memory payloads = new bytes[](3);
-        uint256[] memory gasLimits = new uint256[](3);
-
-        for (uint256 i = 0; i < 3; i++) {
-            nonces[i] = 1000 + uint128(i);
-            payloads[i] = abi.encode("event", i);
-            gasLimits[i] = CALLBACK_GAS_LIMIT;
-        }
-        blockNumbers[0] = 0;
-        blockNumbers[1] = 0;
-
-        vm.expectRevert(abi.encodeWithSelector(Errors.OracleBatchArrayLengthMismatch.selector, 3, 2, 3, 3));
-        vm.prank(systemCaller);
-        oracle.recordBatch(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, nonces, blockNumbers, payloads, gasLimits);
-    }
-
-    function test_RecordBatch_RevertWhenNonceNotSequential() public {
-        // First, record at nonce 1
-        bytes memory payload = abi.encode("first");
-        vm.prank(systemCaller);
-        oracle.record(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, 1, 0, payload, CALLBACK_GAS_LIMIT);
-
-        // Now try batch starting at nonce 1 (should fail - must be 2)
-        uint128[] memory nonces = new uint128[](2);
-        uint256[] memory blockNumbers = new uint256[](2);
-        bytes[] memory payloads = new bytes[](2);
-        uint256[] memory gasLimits = new uint256[](2);
-
-        nonces[0] = 1; // Invalid: same as existing, expected 2
-        nonces[1] = 2;
-        blockNumbers[0] = 0;
-        blockNumbers[1] = 0;
-        payloads[0] = abi.encode("batch0");
-        payloads[1] = abi.encode("batch1");
-        gasLimits[0] = CALLBACK_GAS_LIMIT;
-        gasLimits[1] = CALLBACK_GAS_LIMIT;
-
-        vm.expectRevert(
-            abi.encodeWithSelector(Errors.NonceNotSequential.selector, SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, 2, 1)
-        );
-        vm.prank(systemCaller);
-        oracle.recordBatch(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, nonces, blockNumbers, payloads, gasLimits);
-    }
-
-    function test_RecordBatch_RevertWhenBatchNoncesNotSequential() public {
-        // Try batch with non-sequential nonces within the batch
-        uint128[] memory nonces = new uint128[](3);
-        uint256[] memory blockNumbers = new uint256[](3);
-        bytes[] memory payloads = new bytes[](3);
-        uint256[] memory gasLimits = new uint256[](3);
-
-        nonces[0] = 1;
-        nonces[1] = 2;
-        nonces[2] = 2; // Invalid: not sequential (expected 3)
-        blockNumbers[0] = 0;
-        blockNumbers[1] = 0;
-        blockNumbers[2] = 0;
-        payloads[0] = abi.encode("batch0");
-        payloads[1] = abi.encode("batch1");
-        payloads[2] = abi.encode("batch2");
-        gasLimits[0] = CALLBACK_GAS_LIMIT;
-        gasLimits[1] = CALLBACK_GAS_LIMIT;
-        gasLimits[2] = CALLBACK_GAS_LIMIT;
-
-        vm.expectRevert(
-            abi.encodeWithSelector(Errors.NonceNotSequential.selector, SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, 3, 2)
-        );
-        vm.prank(systemCaller);
-        oracle.recordBatch(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, nonces, blockNumbers, payloads, gasLimits);
-    }
-
-    // ========================================================================
-    // CALLBACK TESTS
-    // ========================================================================
-
-    function test_SetDefaultCallback() public {
-        vm.prank(governance);
-        oracle.setDefaultCallback(SOURCE_TYPE_BLOCKCHAIN, address(mockCallback));
-
-        assertEq(oracle.getDefaultCallback(SOURCE_TYPE_BLOCKCHAIN), address(mockCallback));
-    }
-
-    function test_SetDefaultCallback_RevertWhenNotGovernance() public {
+    function test_RecordRevertsWhenNotSystemCaller() public {
         vm.expectRevert();
         vm.prank(alice);
-        oracle.setDefaultCallback(SOURCE_TYPE_BLOCKCHAIN, address(mockCallback));
+        oracle.record(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, 1, 100, hex"01", CALLBACK_GAS_LIMIT);
     }
 
-    function test_SetDefaultCallback_Unregister() public {
-        // Register default callback
-        vm.prank(governance);
-        oracle.setDefaultCallback(SOURCE_TYPE_BLOCKCHAIN, address(mockCallback));
+    function test_RecordRequiresSequentialNonce() public {
+        vm.expectRevert(
+            abi.encodeWithSelector(Errors.NonceNotSequential.selector, SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, 1, 0)
+        );
+        _record(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, 0, 100, hex"00", CALLBACK_GAS_LIMIT);
 
-        // Unregister by setting to zero
+        _record(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, 1, 100, hex"01", CALLBACK_GAS_LIMIT);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(Errors.NonceNotSequential.selector, SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, 2, 3)
+        );
+        _record(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, 3, 300, hex"03", CALLBACK_GAS_LIMIT);
+    }
+
+    function test_RecordRejectsPositionOverflow() public {
+        vm.expectRevert(
+            abi.encodeWithSelector(Errors.OracleSourcePositionOverflow.selector, uint256(type(uint128).max) + 1)
+        );
+        _record(
+            SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, 1, uint256(type(uint128).max) + 1, hex"01", CALLBACK_GAS_LIMIT
+        );
+    }
+
+    function test_MissingCallbackRevertsWithoutAdvancing() public {
         vm.prank(governance);
         oracle.setDefaultCallback(SOURCE_TYPE_BLOCKCHAIN, address(0));
 
-        assertEq(oracle.getDefaultCallback(SOURCE_TYPE_BLOCKCHAIN), address(0));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.OracleCallbackNotConfigured.selector, SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID
+            )
+        );
+        _record(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, 1, 100, hex"01", CALLBACK_GAS_LIMIT);
+        assertEq(oracle.getLatestNonce(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID), 0);
     }
 
-    function test_SetCallback() public {
-        vm.prank(governance);
-        oracle.setCallback(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, address(mockCallback));
-
-        assertEq(oracle.getCallback(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID), address(mockCallback));
+    function test_ZeroCallbackGasRevertsWithoutAdvancing() public {
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.OracleCallbackGasLimitZero.selector, SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID
+            )
+        );
+        _record(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, 1, 100, hex"01", 0);
+        assertEq(oracle.getLatestNonce(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID), 0);
     }
 
-    function test_SetCallback_RevertWhenNotGovernance() public {
-        vm.expectRevert();
-        vm.prank(alice);
-        oracle.setCallback(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, address(mockCallback));
+    function test_CallbackRevertIsAtomic() public {
+        callback.setRevert(true);
+
+        vm.expectPartialRevert(Errors.OracleCallbackFailed.selector);
+        _record(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, 1, 100, hex"01", CALLBACK_GAS_LIMIT);
+
+        assertEq(oracle.getLatestNonce(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID), 0);
+        assertEq(callback.callCount(), 0);
     }
 
-    function test_SetCallback_Unregister() public {
-        // Register callback
-        vm.prank(governance);
-        oracle.setCallback(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, address(mockCallback));
+    function test_CallbackFalseReturnIsAcceptedButDoesNotStorePayload() public {
+        callback.setReturnValue(false);
+        _record(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, 1, 100, hex"01", CALLBACK_GAS_LIMIT);
 
-        // Unregister by setting to zero
-        vm.prank(governance);
-        oracle.setCallback(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, address(0));
-
-        assertEq(oracle.getCallback(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID), address(0));
+        assertEq(oracle.getLatestNonce(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID), 1);
+        assertEq(oracle.getRecord(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, 1).recordedAt, 0);
     }
 
-    function test_GetCallback_TwoLayerResolution() public {
-        MockOracleCallback defaultCallback = new MockOracleCallback();
-        MockOracleCallback specializedCallback = new MockOracleCallback();
-
-        // Set default callback for BLOCKCHAIN type
+    function test_MalformedCallbackReturnReverts() public {
+        MalformedReturnCallback malformed = new MalformedReturnCallback(2, 32);
         vm.prank(governance);
-        oracle.setDefaultCallback(SOURCE_TYPE_BLOCKCHAIN, address(defaultCallback));
+        oracle.setDefaultCallback(SOURCE_TYPE_BLOCKCHAIN, address(malformed));
 
-        // Before specialized is set, getCallback returns default
-        assertEq(oracle.getCallback(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID), address(defaultCallback));
-
-        // Set specialized callback for ETHEREUM_SOURCE_ID
-        vm.prank(governance);
-        oracle.setCallback(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, address(specializedCallback));
-
-        // Now getCallback returns specialized
-        assertEq(oracle.getCallback(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID), address(specializedCallback));
-
-        // Other source IDs still use default
-        uint256 arbitrumSourceId = 42161;
-        assertEq(oracle.getCallback(SOURCE_TYPE_BLOCKCHAIN, arbitrumSourceId), address(defaultCallback));
-
-        // Unregister specialized, falls back to default
-        vm.prank(governance);
-        oracle.setCallback(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, address(0));
-        assertEq(oracle.getCallback(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID), address(defaultCallback));
+        vm.expectPartialRevert(Errors.OracleCallbackFailed.selector);
+        _record(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, 1, 100, hex"01", CALLBACK_GAS_LIMIT);
+        assertEq(oracle.getLatestNonce(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID), 0);
     }
 
-    function test_CallbackInvoked() public {
-        // Register callback
+    function test_ShortCallbackReturnReverts() public {
+        MalformedReturnCallback malformed = new MalformedReturnCallback(1, 1);
         vm.prank(governance);
-        oracle.setCallback(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, address(mockCallback));
+        oracle.setDefaultCallback(SOURCE_TYPE_BLOCKCHAIN, address(malformed));
 
-        // Record
-        bytes memory payload = abi.encode(alice, uint256(100));
-        uint128 nonce = 1;
-
-        vm.prank(systemCaller);
-        oracle.record(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, nonce, 0, payload, CALLBACK_GAS_LIMIT);
-
-        // Verify callback was invoked
-        assertEq(mockCallback.callCount(), 1);
-        assertEq(mockCallback.lastSourceType(), SOURCE_TYPE_BLOCKCHAIN);
-        assertEq(mockCallback.lastSourceId(), ETHEREUM_SOURCE_ID);
-        assertEq(mockCallback.lastNonce(), nonce);
-        assertEq(mockCallback.lastPayload(), payload);
+        vm.expectPartialRevert(Errors.OracleCallbackFailed.selector);
+        _record(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, 1, 100, hex"01", CALLBACK_GAS_LIMIT);
     }
 
-    function test_CallbackNotInvokedWhenGasLimitZero() public {
-        // Register callback
+    function test_LongCallbackReturnIsBoundedAndAccepted() public {
+        MalformedReturnCallback longReturn = new MalformedReturnCallback(1, 4_096);
         vm.prank(governance);
-        oracle.setCallback(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, address(mockCallback));
+        oracle.setDefaultCallback(SOURCE_TYPE_BLOCKCHAIN, address(longReturn));
 
-        // Record with zero gas limit
-        bytes memory payload = abi.encode(alice, uint256(100));
-        uint128 nonce = 1;
-
-        vm.prank(systemCaller);
-        oracle.record(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, nonce, 0, payload, 0);
-
-        // Verify callback was NOT invoked
-        assertEq(mockCallback.callCount(), 0);
-    }
-
-    function test_DefaultCallbackInvoked() public {
-        // Register default callback for BLOCKCHAIN type
-        vm.prank(governance);
-        oracle.setDefaultCallback(SOURCE_TYPE_BLOCKCHAIN, address(mockCallback));
-
-        // Record (no specialized callback set)
-        bytes memory payload = abi.encode(alice, uint256(100));
-        uint128 nonce = 1;
-
-        vm.prank(systemCaller);
-        oracle.record(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, nonce, 0, payload, CALLBACK_GAS_LIMIT);
-
-        // Verify default callback was invoked
-        assertEq(mockCallback.callCount(), 1);
-        assertEq(mockCallback.lastSourceType(), SOURCE_TYPE_BLOCKCHAIN);
-        assertEq(mockCallback.lastSourceId(), ETHEREUM_SOURCE_ID);
-        assertEq(mockCallback.lastNonce(), nonce);
-        assertEq(mockCallback.lastPayload(), payload);
+        _record(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, 1, 100, hex"01", CALLBACK_GAS_LIMIT);
+        assertEq(oracle.getLatestNonce(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID), 1);
     }
 
     function test_SpecializedCallbackOverridesDefault() public {
-        MockOracleCallback defaultCallback = new MockOracleCallback();
-        MockOracleCallback specializedCallback = new MockOracleCallback();
-
-        // Set default callback
+        MockOracleCallback specialized = new MockOracleCallback();
         vm.prank(governance);
-        oracle.setDefaultCallback(SOURCE_TYPE_BLOCKCHAIN, address(defaultCallback));
+        oracle.setCallback(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, address(specialized));
 
-        // Set specialized callback for ETHEREUM_SOURCE_ID
+        _record(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, 1, 100, hex"01", CALLBACK_GAS_LIMIT);
+        assertEq(specialized.callCount(), 1);
+        assertEq(callback.callCount(), 0);
+        assertEq(oracle.getCallback(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID), address(specialized));
+    }
+
+    function test_SetCallbackRejectsAddressWithoutCode() public {
+        vm.expectRevert(abi.encodeWithSelector(Errors.InvalidOracleCallback.selector, alice));
         vm.prank(governance);
-        oracle.setCallback(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, address(specializedCallback));
-
-        // Record
-        bytes memory payload = abi.encode(alice, uint256(100));
-
-        vm.prank(systemCaller);
-        oracle.record(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, 1, 0, payload, CALLBACK_GAS_LIMIT);
-
-        // Specialized callback should be invoked, not default
-        assertEq(specializedCallback.callCount(), 1);
-        assertEq(defaultCallback.callCount(), 0);
+        oracle.setCallback(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, alice);
     }
 
-    function test_DefaultCallbackForDifferentSourceIds() public {
-        MockOracleCallback defaultCallback = new MockOracleCallback();
-        MockOracleCallback specializedCallback = new MockOracleCallback();
-        uint256 arbitrumSourceId = 42161;
-
-        // Set default callback for BLOCKCHAIN type
+    function test_SetDefaultCallbackRejectsAddressWithoutCode() public {
+        vm.expectRevert(abi.encodeWithSelector(Errors.InvalidOracleCallback.selector, alice));
         vm.prank(governance);
-        oracle.setDefaultCallback(SOURCE_TYPE_BLOCKCHAIN, address(defaultCallback));
-
-        // Set specialized callback only for ETHEREUM_SOURCE_ID
-        vm.prank(governance);
-        oracle.setCallback(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, address(specializedCallback));
-
-        // Record for Arbitrum (should use default)
-        bytes memory payload1 = abi.encode("arbitrum event");
-        vm.prank(systemCaller);
-        oracle.record(SOURCE_TYPE_BLOCKCHAIN, arbitrumSourceId, 1, 0, payload1, CALLBACK_GAS_LIMIT);
-
-        // Record for Ethereum (should use specialized)
-        bytes memory payload2 = abi.encode("ethereum event");
-        vm.prank(systemCaller);
-        oracle.record(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, 1, 0, payload2, CALLBACK_GAS_LIMIT);
-
-        // Verify correct callbacks were invoked
-        assertEq(defaultCallback.callCount(), 1);
-        assertEq(defaultCallback.lastSourceId(), arbitrumSourceId);
-
-        assertEq(specializedCallback.callCount(), 1);
-        assertEq(specializedCallback.lastSourceId(), ETHEREUM_SOURCE_ID);
+        oracle.setDefaultCallback(SOURCE_TYPE_BLOCKCHAIN, alice);
     }
 
-    function test_CallbackFailureDoesNotRevert() public {
-        // Register callback that reverts
-        mockCallback.setRevert(true);
-        vm.prank(governance);
-        oracle.setCallback(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, address(mockCallback));
+    function test_InitializeRejectsAddressWithoutCode() public {
+        uint32[] memory sourceTypes = new uint32[](1);
+        sourceTypes[0] = SOURCE_TYPE_BLOCKCHAIN;
+        address[] memory callbacks = new address[](1);
+        callbacks[0] = alice;
 
-        // Record - should NOT revert even though callback fails
-        bytes memory payload = abi.encode(alice, uint256(100));
-        uint128 nonce = 1;
-
-        vm.prank(systemCaller);
-        oracle.record(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, nonce, 0, payload, CALLBACK_GAS_LIMIT);
-
-        // Record should still exist (recordedAt > 0 means exists)
-        INativeOracle.DataRecord memory record = oracle.getRecord(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, nonce);
-        assertTrue(record.recordedAt > 0);
-
-        // Callback was not successfully called
-        assertEq(mockCallback.callCount(), 0);
+        vm.expectRevert(abi.encodeWithSelector(Errors.InvalidOracleCallback.selector, alice));
+        vm.prank(SystemAddresses.GENESIS);
+        oracle.initialize(sourceTypes, callbacks);
     }
 
-    function test_CallbackGasLimitEnforced() public {
-        // Register callback that consumes all gas
-        mockCallback.setConsumeAllGas(true);
-        vm.prank(governance);
-        oracle.setCallback(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, address(mockCallback));
-
-        // Record - should NOT revert even though callback runs out of gas
-        bytes memory payload = abi.encode(alice, uint256(100));
-        uint128 nonce = 1;
-
-        vm.prank(systemCaller);
-        oracle.record(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, nonce, 0, payload, CALLBACK_GAS_LIMIT);
-
-        // Record should still exist (recordedAt > 0 means exists)
-        INativeOracle.DataRecord memory record = oracle.getRecord(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, nonce);
-        assertTrue(record.recordedAt > 0);
-    }
-
-    function test_CallbackInvokedForBatch() public {
-        // Register callback
-        vm.prank(governance);
-        oracle.setCallback(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, address(mockCallback));
-
-        // Record batch
-        uint128[] memory nonces = new uint128[](3);
-        uint256[] memory blockNumbers = new uint256[](3);
-        bytes[] memory payloads = new bytes[](3);
-        uint256[] memory gasLimits = new uint256[](3);
-
-        for (uint256 i = 0; i < 3; i++) {
-            nonces[i] = 1 + uint128(i); // Sequential: 1, 2, 3
-            blockNumbers[i] = 0;
-            payloads[i] = abi.encode("event", i);
-            gasLimits[i] = CALLBACK_GAS_LIMIT;
-        }
-
-        vm.prank(systemCaller);
-        oracle.recordBatch(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, nonces, blockNumbers, payloads, gasLimits);
-
-        // Callback should be invoked 3 times
-        assertEq(mockCallback.callCount(), 3);
-    }
-
-    function test_CallbackNotInvokedForBatchWhenGasLimitZero() public {
-        // Register callback
-        vm.prank(governance);
-        oracle.setCallback(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, address(mockCallback));
-
-        // Record batch with zero gas limits
-        uint128[] memory nonces = new uint128[](3);
-        uint256[] memory blockNumbers = new uint256[](3);
-        bytes[] memory payloads = new bytes[](3);
-        uint256[] memory gasLimits = new uint256[](3);
-
-        for (uint256 i = 0; i < 3; i++) {
-            nonces[i] = 1 + uint128(i); // Sequential: 1, 2, 3
-            blockNumbers[i] = 0;
-            payloads[i] = abi.encode("event", i);
-            gasLimits[i] = 0; // Zero gas limit
-        }
-
-        vm.prank(systemCaller);
-        oracle.recordBatch(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, nonces, blockNumbers, payloads, gasLimits);
-
-        // Callback should NOT be invoked
-        assertEq(mockCallback.callCount(), 0);
-    }
-
-    function test_CallbackPartiallyInvokedForBatch() public {
-        // Register callback
-        vm.prank(governance);
-        oracle.setCallback(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, address(mockCallback));
-
-        // Record batch with mixed gas limits (some zero, some non-zero)
-        uint128[] memory nonces = new uint128[](3);
-        uint256[] memory blockNumbers = new uint256[](3);
-        bytes[] memory payloads = new bytes[](3);
-        uint256[] memory gasLimits = new uint256[](3);
-
-        nonces[0] = 1;
-        nonces[1] = 2;
-        nonces[2] = 3;
-        blockNumbers[0] = 0;
-        blockNumbers[1] = 0;
-        blockNumbers[2] = 0;
-        payloads[0] = abi.encode("event0");
-        payloads[1] = abi.encode("event1");
-        payloads[2] = abi.encode("event2");
-        gasLimits[0] = CALLBACK_GAS_LIMIT; // Will invoke callback
-        gasLimits[1] = 0; // Will NOT invoke callback
-        gasLimits[2] = CALLBACK_GAS_LIMIT; // Will invoke callback
-
-        vm.prank(systemCaller);
-        oracle.recordBatch(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, nonces, blockNumbers, payloads, gasLimits);
-
-        // Callback should be invoked only 2 times
-        assertEq(mockCallback.callCount(), 2);
-    }
-
-    // ========================================================================
-    // QUERY TESTS
-    // ========================================================================
-
-    function test_GetRecord() public {
-        bytes memory payload = abi.encode(alice, uint256(100), "deposit");
-        uint128 nonce = 1;
-
-        vm.prank(systemCaller);
-        oracle.record(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, nonce, 0, payload, CALLBACK_GAS_LIMIT);
-
-        // Get record
-        INativeOracle.DataRecord memory record = oracle.getRecord(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, nonce);
-        assertTrue(record.recordedAt > 0);
-        assertEq(record.data, payload);
-    }
-
-    function test_GetRecord_NotFound() public view {
-        INativeOracle.DataRecord memory record = oracle.getRecord(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, 999);
-        assertEq(record.recordedAt, 0); // Not found
-    }
-
-    function test_IsSyncedPast() public {
-        bytes memory payload = abi.encode("test");
-
-        // Before recording, not synced
-        assertFalse(oracle.isSyncedPast(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, 1));
-
-        // Record nonces 1 and 2
-        vm.prank(systemCaller);
-        oracle.record(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, 1, 0, payload, CALLBACK_GAS_LIMIT);
-        vm.prank(systemCaller);
-        oracle.record(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, 2, 0, payload, CALLBACK_GAS_LIMIT);
-
-        // Now synced past 1 and 2
-        assertTrue(oracle.isSyncedPast(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, 1));
-        assertTrue(oracle.isSyncedPast(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, 2));
-
-        // Not synced past 3
-        assertFalse(oracle.isSyncedPast(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, 3));
-    }
-
-    // ========================================================================
-    // FUZZ TESTS
-    // ========================================================================
-
-    function testFuzz_Record(
-        bytes memory payload
-    ) public {
-        // Sequential nonce: first record must use nonce 1
-        uint128 nonce = 1;
-
-        vm.prank(systemCaller);
-        oracle.record(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, nonce, 0, payload, CALLBACK_GAS_LIMIT);
-
-        INativeOracle.DataRecord memory record = oracle.getRecord(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, nonce);
-        assertTrue(record.recordedAt > 0);
-        assertEq(record.data, payload);
-    }
-
-    function testFuzz_NonceMustBeSequential(
-        uint128 badNonce
-    ) public {
-        // First record must be nonce 1
-        bytes memory payload1 = abi.encode("first");
-        vm.prank(systemCaller);
-        oracle.record(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, 1, 0, payload1, CALLBACK_GAS_LIMIT);
-
-        // Any nonce that isn't 2 should fail
-        vm.assume(badNonce != 2);
-
-        bytes memory payload2 = abi.encode("second");
-
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                Errors.NonceNotSequential.selector, SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, 2, badNonce
-            )
+    function test_LegacyProgressFallbackAndFirstNewWrite() public {
+        uint128 legacyNonce = 41;
+        uint256 legacyPosition = 19_876_500;
+        vm.store(
+            address(oracle), _legacyNonceSlot(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID), bytes32(uint256(legacyNonce))
         );
-        vm.prank(systemCaller);
-        oracle.record(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, badNonce, 0, payload2, CALLBACK_GAS_LIMIT);
+        vm.store(
+            address(oracle),
+            bytes32(uint256(_legacyRecordSlot(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, legacyNonce)) + 1),
+            bytes32(legacyPosition)
+        );
+
+        INativeOracle.SourceProgress memory progress =
+            oracle.getSourceProgress(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID);
+        assertEq(progress.latestNonce, legacyNonce);
+        assertEq(progress.latestPosition, legacyPosition);
+
+        _record(
+            SOURCE_TYPE_BLOCKCHAIN,
+            ETHEREUM_SOURCE_ID,
+            legacyNonce + 1,
+            legacyPosition + 10,
+            hex"42",
+            CALLBACK_GAS_LIMIT
+        );
+
+        progress = oracle.getSourceProgress(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID);
+        assertEq(progress.latestNonce, legacyNonce + 1);
+        assertEq(progress.latestPosition, legacyPosition + 10);
+        assertEq(
+            uint256(vm.load(address(oracle), _legacyNonceSlot(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID))), legacyNonce
+        );
     }
 
-    function testFuzz_SourceTypeAndId(
+    function test_LegacyProgressWithoutStoredRecordMarksPositionUnknown() public {
+        uint128 legacyNonce = 41;
+        vm.store(
+            address(oracle), _legacyNonceSlot(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID), bytes32(uint256(legacyNonce))
+        );
+
+        INativeOracle.SourceProgress memory progress =
+            oracle.getSourceProgress(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID);
+        assertEq(progress.latestNonce, legacyNonce);
+        assertEq(progress.latestPosition, 0);
+
+        _record(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, legacyNonce + 1, 19_876_510, hex"42", CALLBACK_GAS_LIMIT);
+        progress = oracle.getSourceProgress(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID);
+        assertEq(progress.latestNonce, legacyNonce + 1);
+        assertEq(progress.latestPosition, 19_876_510);
+    }
+
+    function test_EventsOracleDeliveredAndCallbackSuccess() public {
+        bytes memory payload = hex"aabbcc";
+
+        vm.expectEmit(true, true, false, true, address(oracle));
+        emit INativeOracle.CallbackSuccess(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, 1, address(callback));
+        vm.expectEmit(true, true, false, true, address(oracle));
+        emit INativeOracle.OracleDelivered(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, 1, 123, keccak256(payload));
+        _record(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, 1, 123, payload, CALLBACK_GAS_LIMIT);
+    }
+
+    function testFuzz_RecordTracksLatestProgress(
+        uint32 sourceType,
+        uint256 sourceId,
+        uint128 position,
+        bytes calldata payload
+    ) public {
+        vm.assume(payload.length < 4_096);
+        vm.prank(governance);
+        oracle.setDefaultCallback(sourceType, address(callback));
+
+        _record(sourceType, sourceId, 1, position, payload, CALLBACK_GAS_LIMIT);
+        INativeOracle.SourceProgress memory progress = oracle.getSourceProgress(sourceType, sourceId);
+        assertEq(progress.latestNonce, 1);
+        assertEq(progress.latestPosition, position);
+    }
+
+    function _record(
+        uint32 sourceType,
+        uint256 sourceId,
+        uint128 nonce,
+        uint256 position,
+        bytes memory payload,
+        uint256 gasLimit
+    ) internal {
+        vm.prank(systemCaller);
+        oracle.record(sourceType, sourceId, nonce, position, payload, gasLimit);
+    }
+
+    function _legacyNonceSlot(
         uint32 sourceType,
         uint256 sourceId
-    ) public {
-        // Sequential nonce: first record must use nonce 1
-        uint128 nonce = 1;
-
-        bytes memory payload = abi.encode("test", sourceType, sourceId);
-
-        vm.prank(systemCaller);
-        oracle.record(sourceType, sourceId, nonce, 0, payload, CALLBACK_GAS_LIMIT);
-
-        assertEq(oracle.getLatestNonce(sourceType, sourceId), nonce);
+    ) internal pure returns (bytes32) {
+        bytes32 typeSlot = keccak256(abi.encode(sourceType, uint256(1)));
+        return keccak256(abi.encode(sourceId, typeSlot));
     }
 
-    // ========================================================================
-    // EVENT TESTS
-    // ========================================================================
-
-    function test_Events_DataRecorded() public {
-        bytes memory payload = abi.encode(alice, uint256(100));
-        uint128 nonce = 1;
-
-        vm.expectEmit(true, true, true, true);
-        emit INativeOracle.DataRecorded(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, nonce, payload.length);
-
-        vm.prank(systemCaller);
-        oracle.record(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, nonce, 0, payload, CALLBACK_GAS_LIMIT);
-    }
-
-    function test_Events_DefaultCallbackSet() public {
-        vm.expectEmit(true, true, true, true);
-        emit INativeOracle.DefaultCallbackSet(SOURCE_TYPE_BLOCKCHAIN, address(0), address(mockCallback));
-
-        vm.prank(governance);
-        oracle.setDefaultCallback(SOURCE_TYPE_BLOCKCHAIN, address(mockCallback));
-    }
-
-    function test_Events_CallbackSet() public {
-        vm.expectEmit(true, true, true, true);
-        emit INativeOracle.CallbackSet(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, address(0), address(mockCallback));
-
-        vm.prank(governance);
-        oracle.setCallback(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, address(mockCallback));
-    }
-
-    function test_Events_CallbackSuccess() public {
-        vm.prank(governance);
-        oracle.setCallback(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, address(mockCallback));
-
-        bytes memory payload = abi.encode(alice, uint256(100));
-        uint128 nonce = 1;
-
-        vm.expectEmit(true, true, false, true);
-        emit INativeOracle.CallbackSuccess(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, nonce, address(mockCallback));
-
-        vm.prank(systemCaller);
-        oracle.record(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, nonce, 0, payload, CALLBACK_GAS_LIMIT);
-    }
-
-    function test_Events_CallbackFailed() public {
-        mockCallback.setRevert(true);
-        vm.prank(governance);
-        oracle.setCallback(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, address(mockCallback));
-
-        bytes memory payload = abi.encode(alice, uint256(100));
-        uint128 nonce = 1;
-
-        // CallbackFailed event should be emitted
-        vm.prank(systemCaller);
-        oracle.record(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, nonce, 0, payload, CALLBACK_GAS_LIMIT);
-        // Can't easily test the exact event due to dynamic reason bytes,
-        // but we verified the record exists and callback count is 0 in earlier test
-    }
-
-    // ========================================================================
-    // EDGE CASE TESTS
-    // ========================================================================
-
-    function test_EmptyPayload() public {
-        bytes memory payload = "";
-        uint128 nonce = 1;
-
-        vm.prank(systemCaller);
-        oracle.record(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, nonce, 0, payload, CALLBACK_GAS_LIMIT);
-
-        INativeOracle.DataRecord memory record = oracle.getRecord(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, nonce);
-        assertTrue(record.recordedAt > 0);
-    }
-
-    function test_LargePayload() public {
-        // Create a large payload (1KB)
-        bytes memory payload = new bytes(1024);
-        for (uint256 i = 0; i < 1024; i++) {
-            payload[i] = bytes1(uint8(i % 256));
-        }
-        uint128 nonce = 1;
-
-        vm.prank(systemCaller);
-        oracle.record(SOURCE_TYPE_JWK, GOOGLE_JWK_SOURCE_ID, nonce, 0, payload, CALLBACK_GAS_LIMIT);
-
-        INativeOracle.DataRecord memory record = oracle.getRecord(SOURCE_TYPE_JWK, GOOGLE_JWK_SOURCE_ID, nonce);
-        assertEq(record.data, payload);
-    }
-
-    function test_NonceMustStartFromOne() public {
-        bytes memory payload = abi.encode("test");
-
-        // Nonce = 1 should work
-        vm.prank(systemCaller);
-        oracle.record(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, 1, 0, payload, CALLBACK_GAS_LIMIT);
-
-        INativeOracle.DataRecord memory record = oracle.getRecord(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, 1);
-        assertTrue(record.recordedAt > 0);
-    }
-
-    // ========================================================================
-    // SKIP-STORAGE TESTS (callback returns shouldStore=false)
-    // ========================================================================
-
-    function test_CallbackSkipStorage() public {
-        // Register callback that returns shouldStore=false
-        mockCallback.setShouldStore(false);
-        vm.prank(governance);
-        oracle.setCallback(SOURCE_TYPE_JWK, GOOGLE_JWK_SOURCE_ID, address(mockCallback));
-
-        bytes memory payload = abi.encode("jwk data");
-        uint128 nonce = 1;
-
-        vm.prank(systemCaller);
-        oracle.record(SOURCE_TYPE_JWK, GOOGLE_JWK_SOURCE_ID, nonce, 0, payload, CALLBACK_GAS_LIMIT);
-
-        // Callback was invoked
-        assertEq(mockCallback.callCount(), 1);
-
-        // But record was NOT stored (recordedAt == 0)
-        INativeOracle.DataRecord memory record = oracle.getRecord(SOURCE_TYPE_JWK, GOOGLE_JWK_SOURCE_ID, nonce);
-        assertEq(record.recordedAt, 0);
-
-        // Nonce was still updated (for replay protection)
-        assertEq(oracle.getLatestNonce(SOURCE_TYPE_JWK, GOOGLE_JWK_SOURCE_ID), nonce);
-    }
-
-    function test_CallbackStoreByDefault() public {
-        // Register callback that returns shouldStore=true (default)
-        vm.prank(governance);
-        oracle.setCallback(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, address(mockCallback));
-
-        bytes memory payload = abi.encode("blockchain event");
-        uint128 nonce = 1;
-
-        vm.prank(systemCaller);
-        oracle.record(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, nonce, 0, payload, CALLBACK_GAS_LIMIT);
-
-        // Callback was invoked
-        assertEq(mockCallback.callCount(), 1);
-
-        // Record WAS stored
-        INativeOracle.DataRecord memory record = oracle.getRecord(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, nonce);
-        assertTrue(record.recordedAt > 0);
-        assertEq(record.data, payload);
-    }
-
-    function test_NoCallbackStoresByDefault() public {
-        // No callback registered - should always store
-        bytes memory payload = abi.encode("no callback");
-        uint128 nonce = 1;
-
-        vm.prank(systemCaller);
-        oracle.record(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, nonce, 0, payload, CALLBACK_GAS_LIMIT);
-
-        // Record WAS stored
-        INativeOracle.DataRecord memory record = oracle.getRecord(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, nonce);
-        assertTrue(record.recordedAt > 0);
-    }
-
-    function test_CallbackFailureStoresByDefault() public {
-        // Register callback that reverts
-        mockCallback.setRevert(true);
-        mockCallback.setShouldStore(false); // Would skip if it succeeded
-        vm.prank(governance);
-        oracle.setCallback(SOURCE_TYPE_JWK, GOOGLE_JWK_SOURCE_ID, address(mockCallback));
-
-        bytes memory payload = abi.encode("jwk data");
-        uint128 nonce = 1;
-
-        vm.prank(systemCaller);
-        oracle.record(SOURCE_TYPE_JWK, GOOGLE_JWK_SOURCE_ID, nonce, 0, payload, CALLBACK_GAS_LIMIT);
-
-        // Callback failed (callCount not incremented)
-        assertEq(mockCallback.callCount(), 0);
-
-        // But record WAS stored (failure defaults to store)
-        INativeOracle.DataRecord memory record = oracle.getRecord(SOURCE_TYPE_JWK, GOOGLE_JWK_SOURCE_ID, nonce);
-        assertTrue(record.recordedAt > 0);
-        assertEq(record.data, payload);
-    }
-
-    function test_BatchSkipStoragePerRecord() public {
-        // Create two callbacks with different behaviors
-        MockOracleCallback storeCallback = new MockOracleCallback();
-        storeCallback.setShouldStore(true);
-
-        MockOracleCallback skipCallback = new MockOracleCallback();
-        skipCallback.setShouldStore(false);
-
-        // Set default callback for JWK type that skips storage
-        vm.prank(governance);
-        oracle.setDefaultCallback(SOURCE_TYPE_JWK, address(skipCallback));
-
-        // Record batch
-        uint128[] memory nonces = new uint128[](3);
-        uint256[] memory blockNumbers = new uint256[](3);
-        bytes[] memory payloads = new bytes[](3);
-        uint256[] memory gasLimits = new uint256[](3);
-
-        for (uint256 i = 0; i < 3; i++) {
-            nonces[i] = 1 + uint128(i); // Sequential: 1, 2, 3
-            blockNumbers[i] = 0;
-            payloads[i] = abi.encode("event", i);
-            gasLimits[i] = CALLBACK_GAS_LIMIT;
-        }
-
-        vm.prank(systemCaller);
-        oracle.recordBatch(SOURCE_TYPE_JWK, GOOGLE_JWK_SOURCE_ID, nonces, blockNumbers, payloads, gasLimits);
-
-        // All callbacks were invoked
-        assertEq(skipCallback.callCount(), 3);
-
-        // No records were stored
-        for (uint256 i = 0; i < 3; i++) {
-            INativeOracle.DataRecord memory record = oracle.getRecord(SOURCE_TYPE_JWK, GOOGLE_JWK_SOURCE_ID, nonces[i]);
-            assertEq(record.recordedAt, 0);
-        }
-
-        // But nonce was updated
-        assertEq(oracle.getLatestNonce(SOURCE_TYPE_JWK, GOOGLE_JWK_SOURCE_ID), nonces[2]);
-    }
-
-    function test_Events_StorageSkipped() public {
-        mockCallback.setShouldStore(false);
-        vm.prank(governance);
-        oracle.setCallback(SOURCE_TYPE_JWK, GOOGLE_JWK_SOURCE_ID, address(mockCallback));
-
-        bytes memory payload = abi.encode("jwk data");
-        uint128 nonce = 1;
-
-        // Expect both CallbackSuccess and StorageSkipped events
-        vm.expectEmit(true, true, false, true);
-        emit INativeOracle.CallbackSuccess(SOURCE_TYPE_JWK, GOOGLE_JWK_SOURCE_ID, nonce, address(mockCallback));
-
-        vm.expectEmit(true, true, false, true);
-        emit INativeOracle.StorageSkipped(SOURCE_TYPE_JWK, GOOGLE_JWK_SOURCE_ID, nonce, address(mockCallback));
-
-        vm.prank(systemCaller);
-        oracle.record(SOURCE_TYPE_JWK, GOOGLE_JWK_SOURCE_ID, nonce, 0, payload, CALLBACK_GAS_LIMIT);
+    function _legacyRecordSlot(
+        uint32 sourceType,
+        uint256 sourceId,
+        uint128 nonce
+    ) internal pure returns (bytes32) {
+        bytes32 typeSlot = keccak256(abi.encode(sourceType, uint256(0)));
+        bytes32 sourceSlot = keccak256(abi.encode(sourceId, typeSlot));
+        return keccak256(abi.encode(nonce, sourceSlot));
     }
 }

--- a/test/unit/oracle/OracleTaskConfig.t.sol
+++ b/test/unit/oracle/OracleTaskConfig.t.sol
@@ -21,6 +21,8 @@ contract OracleTaskConfigTest is Test {
     uint32 public constant SOURCE_TYPE_BLOCKCHAIN = 0;
     uint32 public constant SOURCE_TYPE_JWK = 1;
     uint32 public constant SOURCE_TYPE_DNS = 2;
+    uint32 public constant SOURCE_TYPE_PRICE_FEED = 3;
+    uint32 public constant SOURCE_TYPE_POLYMARKET_SETTLEMENT = 6;
     uint256 public constant ETHEREUM_SOURCE_ID = 1;
     uint256 public constant ARBITRUM_SOURCE_ID = 42161;
 
@@ -95,30 +97,34 @@ contract OracleTaskConfigTest is Test {
         taskConfig.setTask(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, TASK_EVENTS, config);
     }
 
-    function test_SetTask_MultipleTasksPerSource() public {
+    function test_SetTask_MultipleTasksPerNonRelayerSource() public {
         bytes memory eventsConfig = abi.encode("events config");
         bytes memory stateRootsConfig = abi.encode("state roots config");
         bytes memory receiptsConfig = abi.encode("receipts config");
 
         vm.startPrank(governance);
-        taskConfig.setTask(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, TASK_EVENTS, eventsConfig);
-        taskConfig.setTask(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, TASK_STATE_ROOTS, stateRootsConfig);
-        taskConfig.setTask(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, TASK_RECEIPTS, receiptsConfig);
+        taskConfig.setTask(SOURCE_TYPE_JWK, ETHEREUM_SOURCE_ID, TASK_EVENTS, eventsConfig);
+        taskConfig.setTask(SOURCE_TYPE_JWK, ETHEREUM_SOURCE_ID, TASK_STATE_ROOTS, stateRootsConfig);
+        taskConfig.setTask(SOURCE_TYPE_JWK, ETHEREUM_SOURCE_ID, TASK_RECEIPTS, receiptsConfig);
         vm.stopPrank();
 
         // Verify all tasks exist
-        assertEq(taskConfig.getTask(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, TASK_EVENTS).config, eventsConfig);
-        assertEq(
-            taskConfig.getTask(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, TASK_STATE_ROOTS).config, stateRootsConfig
-        );
-        assertEq(taskConfig.getTask(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, TASK_RECEIPTS).config, receiptsConfig);
+        assertEq(taskConfig.getTask(SOURCE_TYPE_JWK, ETHEREUM_SOURCE_ID, TASK_EVENTS).config, eventsConfig);
+        assertEq(taskConfig.getTask(SOURCE_TYPE_JWK, ETHEREUM_SOURCE_ID, TASK_STATE_ROOTS).config, stateRootsConfig);
+        assertEq(taskConfig.getTask(SOURCE_TYPE_JWK, ETHEREUM_SOURCE_ID, TASK_RECEIPTS).config, receiptsConfig);
 
         // Verify task count
-        assertEq(taskConfig.getTaskCount(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID), 3);
+        assertEq(taskConfig.getTaskCount(SOURCE_TYPE_JWK, ETHEREUM_SOURCE_ID), 3);
 
         // Verify task names are enumerable
-        bytes32[] memory taskNames = taskConfig.getTaskNames(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID);
+        bytes32[] memory taskNames = taskConfig.getTaskNames(SOURCE_TYPE_JWK, ETHEREUM_SOURCE_ID);
         assertEq(taskNames.length, 3);
+    }
+
+    function test_SetTask_RejectsSecondRelayerTaskForSameSource() public {
+        _assertSecondRelayerTaskRejected(SOURCE_TYPE_BLOCKCHAIN, 1);
+        _assertSecondRelayerTaskRejected(SOURCE_TYPE_PRICE_FEED, 2);
+        _assertSecondRelayerTaskRejected(SOURCE_TYPE_POLYMARKET_SETTLEMENT, 3);
     }
 
     function test_SetTask_MultipleSources() public {
@@ -186,21 +192,19 @@ contract OracleTaskConfigTest is Test {
         bytes memory stateRootsConfig = abi.encode("state roots config");
 
         vm.startPrank(governance);
-        taskConfig.setTask(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, TASK_EVENTS, eventsConfig);
-        taskConfig.setTask(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, TASK_STATE_ROOTS, stateRootsConfig);
+        taskConfig.setTask(SOURCE_TYPE_JWK, ETHEREUM_SOURCE_ID, TASK_EVENTS, eventsConfig);
+        taskConfig.setTask(SOURCE_TYPE_JWK, ETHEREUM_SOURCE_ID, TASK_STATE_ROOTS, stateRootsConfig);
         vm.stopPrank();
 
-        assertEq(taskConfig.getTaskCount(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID), 2);
+        assertEq(taskConfig.getTaskCount(SOURCE_TYPE_JWK, ETHEREUM_SOURCE_ID), 2);
 
         vm.prank(governance);
-        taskConfig.removeTask(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, TASK_EVENTS);
+        taskConfig.removeTask(SOURCE_TYPE_JWK, ETHEREUM_SOURCE_ID, TASK_EVENTS);
 
-        assertFalse(taskConfig.hasTask(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, TASK_EVENTS));
-        assertTrue(taskConfig.hasTask(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, TASK_STATE_ROOTS));
-        assertEq(
-            taskConfig.getTask(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, TASK_STATE_ROOTS).config, stateRootsConfig
-        );
-        assertEq(taskConfig.getTaskCount(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID), 1);
+        assertFalse(taskConfig.hasTask(SOURCE_TYPE_JWK, ETHEREUM_SOURCE_ID, TASK_EVENTS));
+        assertTrue(taskConfig.hasTask(SOURCE_TYPE_JWK, ETHEREUM_SOURCE_ID, TASK_STATE_ROOTS));
+        assertEq(taskConfig.getTask(SOURCE_TYPE_JWK, ETHEREUM_SOURCE_ID, TASK_STATE_ROOTS).config, stateRootsConfig);
+        assertEq(taskConfig.getTaskCount(SOURCE_TYPE_JWK, ETHEREUM_SOURCE_ID), 1);
     }
 
     function test_RemoveTask_DoesNotAffectOtherSources() public {
@@ -246,11 +250,11 @@ contract OracleTaskConfigTest is Test {
         bytes memory config2 = abi.encode("config2");
 
         vm.startPrank(governance);
-        taskConfig.setTask(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, TASK_EVENTS, config1);
-        taskConfig.setTask(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, TASK_STATE_ROOTS, config2);
+        taskConfig.setTask(SOURCE_TYPE_JWK, ETHEREUM_SOURCE_ID, TASK_EVENTS, config1);
+        taskConfig.setTask(SOURCE_TYPE_JWK, ETHEREUM_SOURCE_ID, TASK_STATE_ROOTS, config2);
         vm.stopPrank();
 
-        bytes32[] memory taskNames = taskConfig.getTaskNames(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID);
+        bytes32[] memory taskNames = taskConfig.getTaskNames(SOURCE_TYPE_JWK, ETHEREUM_SOURCE_ID);
         assertEq(taskNames.length, 2);
 
         // Check that both task names are in the array
@@ -265,30 +269,30 @@ contract OracleTaskConfigTest is Test {
     }
 
     function test_GetTaskCount() public {
-        assertEq(taskConfig.getTaskCount(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID), 0);
+        assertEq(taskConfig.getTaskCount(SOURCE_TYPE_JWK, ETHEREUM_SOURCE_ID), 0);
 
         bytes memory config = abi.encode("config");
         vm.prank(governance);
-        taskConfig.setTask(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, TASK_EVENTS, config);
+        taskConfig.setTask(SOURCE_TYPE_JWK, ETHEREUM_SOURCE_ID, TASK_EVENTS, config);
 
-        assertEq(taskConfig.getTaskCount(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID), 1);
+        assertEq(taskConfig.getTaskCount(SOURCE_TYPE_JWK, ETHEREUM_SOURCE_ID), 1);
 
         vm.prank(governance);
-        taskConfig.setTask(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, TASK_STATE_ROOTS, config);
+        taskConfig.setTask(SOURCE_TYPE_JWK, ETHEREUM_SOURCE_ID, TASK_STATE_ROOTS, config);
 
-        assertEq(taskConfig.getTaskCount(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID), 2);
+        assertEq(taskConfig.getTaskCount(SOURCE_TYPE_JWK, ETHEREUM_SOURCE_ID), 2);
     }
 
     function test_GetTaskNameAt() public {
         bytes memory config = abi.encode("config");
 
         vm.startPrank(governance);
-        taskConfig.setTask(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, TASK_EVENTS, config);
-        taskConfig.setTask(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, TASK_STATE_ROOTS, config);
+        taskConfig.setTask(SOURCE_TYPE_JWK, ETHEREUM_SOURCE_ID, TASK_EVENTS, config);
+        taskConfig.setTask(SOURCE_TYPE_JWK, ETHEREUM_SOURCE_ID, TASK_STATE_ROOTS, config);
         vm.stopPrank();
 
-        bytes32 name0 = taskConfig.getTaskNameAt(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, 0);
-        bytes32 name1 = taskConfig.getTaskNameAt(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, 1);
+        bytes32 name0 = taskConfig.getTaskNameAt(SOURCE_TYPE_JWK, ETHEREUM_SOURCE_ID, 0);
+        bytes32 name1 = taskConfig.getTaskNameAt(SOURCE_TYPE_JWK, ETHEREUM_SOURCE_ID, 1);
 
         // Both should be valid task names
         assertTrue(name0 == TASK_EVENTS || name0 == TASK_STATE_ROOTS);
@@ -372,6 +376,10 @@ contract OracleTaskConfigTest is Test {
         bytes32 taskName2
     ) public {
         vm.assume(taskName1 != taskName2);
+        vm.assume(
+            sourceType != SOURCE_TYPE_BLOCKCHAIN && sourceType != SOURCE_TYPE_PRICE_FEED
+                && sourceType != SOURCE_TYPE_POLYMARKET_SETTLEMENT
+        );
 
         bytes memory config1 = abi.encode("config1");
         bytes memory config2 = abi.encode("config2");
@@ -529,33 +537,53 @@ contract OracleTaskConfigTest is Test {
 
         // Add two tasks to same source
         vm.startPrank(governance);
-        taskConfig.setTask(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, TASK_EVENTS, config);
-        taskConfig.setTask(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, TASK_STATE_ROOTS, config);
+        taskConfig.setTask(SOURCE_TYPE_JWK, ETHEREUM_SOURCE_ID, TASK_EVENTS, config);
+        taskConfig.setTask(SOURCE_TYPE_JWK, ETHEREUM_SOURCE_ID, TASK_STATE_ROOTS, config);
         vm.stopPrank();
 
         // Verify source is registered
         uint32[] memory sourceTypes = taskConfig.getSourceTypes();
         assertEq(sourceTypes.length, 1);
-        uint256[] memory sourceIds = taskConfig.getSourceIds(SOURCE_TYPE_BLOCKCHAIN);
+        uint256[] memory sourceIds = taskConfig.getSourceIds(SOURCE_TYPE_JWK);
         assertEq(sourceIds.length, 1);
 
         // Remove first task - source should still be registered
         vm.prank(governance);
-        taskConfig.removeTask(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, TASK_EVENTS);
+        taskConfig.removeTask(SOURCE_TYPE_JWK, ETHEREUM_SOURCE_ID, TASK_EVENTS);
 
         sourceTypes = taskConfig.getSourceTypes();
         assertEq(sourceTypes.length, 1);
-        sourceIds = taskConfig.getSourceIds(SOURCE_TYPE_BLOCKCHAIN);
+        sourceIds = taskConfig.getSourceIds(SOURCE_TYPE_JWK);
         assertEq(sourceIds.length, 1);
 
         // Remove second task - source should be cleaned up
         vm.prank(governance);
-        taskConfig.removeTask(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, TASK_STATE_ROOTS);
+        taskConfig.removeTask(SOURCE_TYPE_JWK, ETHEREUM_SOURCE_ID, TASK_STATE_ROOTS);
 
         sourceTypes = taskConfig.getSourceTypes();
         assertEq(sourceTypes.length, 0);
-        sourceIds = taskConfig.getSourceIds(SOURCE_TYPE_BLOCKCHAIN);
+        sourceIds = taskConfig.getSourceIds(SOURCE_TYPE_JWK);
         assertEq(sourceIds.length, 0);
+    }
+
+    function _assertSecondRelayerTaskRejected(
+        uint32 sourceType,
+        uint256 sourceId
+    ) internal {
+        vm.prank(governance);
+        taskConfig.setTask(sourceType, sourceId, TASK_EVENTS, abi.encode("events config"));
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                OracleTaskConfig.RelayerTaskAlreadyConfigured.selector,
+                sourceType,
+                sourceId,
+                TASK_EVENTS,
+                TASK_STATE_ROOTS
+            )
+        );
+        vm.prank(governance);
+        taskConfig.setTask(sourceType, sourceId, TASK_STATE_ROOTS, abi.encode("state roots config"));
     }
 
     function test_SourceEnumeration_MultipleSourceTypes() public {
@@ -583,4 +611,3 @@ contract OracleTaskConfigTest is Test {
         }
     }
 }
-


### PR DESCRIPTION
## Summary

This is the first contracts slice from the oversized Oracle draft #107.

- preserve the deployed NativeOracle storage slots and existing external selectors
- append one packed SourceProgress checkpoint per (sourceType, sourceId)
- deliver consensus payloads atomically to callbacks without retaining new payload history
- validate callback code, require nonzero callback gas, and bound callback returndata
- constrain relayer-backed source types 0, 3, and 6 to one task name per NativeOracle nonce stream
- retain focused source type 0, bridge, JWK, legacy migration, batch, and callback regression coverage

## Compatibility and hardfork boundary

- legacy slots 0-4 remain unchanged; SourceProgress is appended at slot 5
- record, recordBatch, legacy getter, and callback-management selectors are unchanged
- legacy records and historical events remain queryable/decodable
- the callback bool return remains ABI-compatible but no longer controls NativeOracle storage
- callback failure, missing callback, and zero callback gas now revert atomically and do not advance progress
- old deployments may contain latestNonce > 0 with latestPosition == 0 when a legacy callback returned false and no record was stored; zero is an unknown transition position, not source genesis

The protocol code can be reviewed and merged independently, but the new hardfork behavior must not be activated until the matching gravity-reth core handles that unknown-position transition explicitly.

## Scope

Included:
- NativeOracle and INativeOracle
- OracleTaskConfig identity constraint
- shared Oracle errors
- focused unit/regression tests
- protocol and bridge compatibility specifications

Not included:
- PriceFeedResolver or Binance provider behavior
- Polymarket resolver or prediction-market product
- gravity-reth or gravity-sdk runtime changes
- frontend/demo/runbook material

## Validation

- full Foundry suite: 1029 passed, 0 failed, 0 skipped
- Oracle-focused Foundry suite: 267 passed, 0 failed, 0 skipped
- forge fmt --check on every changed Solidity file
- git diff --check
- old/new method-selector comparison
- storage-layout comparison confirming slots 0-4 unchanged and slot 5 appended
- changed-file scan found no credentials or user-specific absolute paths

## Tracking

- Split plan: Galxe/gravity-audit#1038
- Audit finding: Galxe/gravity-audit#1033
- Original integration draft: #107
- Aptos fixed-size source progress prerequisite: Galxe/gravity-aptos#79 (merged)