### PR TITLE
feat(oracle): add deterministic price resolver

### DIFF
--- a/spec_v2/oracle_price_feed_resolver.spec.md
+++ b/spec_v2/oracle_price_feed_resolver.spec.md
@@ -1,0 +1,91 @@
+---
+title: Price Feed Resolver Specification
+status: production candidate
+---
+
+# Price Feed Resolver
+
+This specification defines the contract boundary for Gravity's deterministic
+price feed. Validators observe the same finalized upstream round, reach
+consensus on its canonical payload, and `PriceFeedResolver` stores the latest
+accepted value for on-chain consumers.
+
+The first provider implementation uses a closed Binance USD-M index-price kline.
+Provider fetching and response validation live in `gravity-reth`; this contract
+does not perform HTTP requests or aggregate validator observations.
+
+## Source Identity
+
+Price feeds use source type `3`. Each configured instrument has a stable
+`sourceId`, and that value must equal `PricePayload.feedId`. NativeOracle tracks
+delivery progress independently for every `(sourceType, sourceId)` pair.
+
+## Price Payload ABI
+
+```solidity
+struct PricePayload {
+    uint256 feedId;
+    uint64 roundId;
+    uint64 resolvedAt;
+    uint8 decimals;
+    int256 price;
+}
+```
+
+For the Binance index-kline provider:
+
+- `roundId = bucketStartMs / intervalMs`
+- `resolvedAt = bucketEndMs`
+- `price` is the decimal `close` field scaled to the configured decimals
+- the NativeOracle delivery nonce is independent from `roundId` and remains
+  sequential for the feed
+
+The canonical payload is `abi.encode(PricePayload)`. Provider-specific URI
+parsing and exact closed-bucket checks are specified with the reth provider.
+
+## Contract Validation
+
+The resolver accepts a payload only when:
+
+- the caller is the NativeOracle system contract
+- `sourceType == 3`
+- `sourceId == feedId`
+- `roundId` is nonzero and greater than the latest accepted round
+- `resolvedAt` is nonzero and greater than the latest accepted timestamp
+- decimals do not exceed 18
+- price is positive
+
+Malformed payloads revert during ABI decoding. Any callback failure reverts the
+entire NativeOracle delivery, so source progress does not advance and the same
+delivery nonce remains retryable.
+
+## Storage And History
+
+`latestPrice(feedId)` exposes one fixed-size latest record per feed. A successful
+new round overwrites the preceding record. The resolver does not retain raw
+payloads or historical round mappings; historical values remain available from
+`PriceResolved` logs and the authoritative upstream source.
+
+NativeOracle never retains new raw `DataRecord` payloads; the callback return
+value is a deprecated compatibility field and does not control storage. This
+keeps chain-state growth bounded while preserving the latest query-ready price
+and source progress.
+
+## Aggregation Boundary
+
+Validator observations are reduced by JWK consensus before contract execution.
+The payload therefore contains one consensus-approved price, not an array of
+provider observations. Weighted mean, weighted median, source thresholds, and
+multi-provider normalization are outside this ABI and require a separately
+versioned source type and payload if introduced later.
+
+## Focused Tests
+
+```bash
+forge test --match-path 'test/unit/oracle/PriceFeedResolver.t.sol'
+```
+
+The suite covers latest-round storage, independent feeds, bounded storage,
+source identity, caller authorization, round and timestamp replay protection,
+price and decimal validation, malformed payloads, callback gas failure, and
+atomic retry behavior.

--- a/src/oracle/resolver/PriceFeedResolver.sol
+++ b/src/oracle/resolver/PriceFeedResolver.sol
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import { IOracleCallback } from "../INativeOracle.sol";
+import { SystemAddresses } from "../../foundation/SystemAddresses.sol";
+import { requireAllowed } from "../../foundation/SystemAccessControl.sol";
+
+/// @title PriceFeedResolver
+/// @author Gravity Team
+/// @notice Stores the latest consensus-approved price round for each configured feed.
+contract PriceFeedResolver is IOracleCallback {
+    struct PricePayload {
+        uint256 feedId;
+        uint64 roundId;
+        uint64 resolvedAt;
+        uint8 decimals;
+        int256 price;
+    }
+
+    struct PriceRound {
+        bool exists;
+        uint64 roundId;
+        uint64 resolvedAt;
+        uint8 decimals;
+        int256 price;
+    }
+
+    /// @notice NativeOracle source type reserved for deterministic price feeds.
+    uint32 public constant SOURCE_TYPE_PRICE_FEED = 3;
+    /// @notice Maximum accepted fixed-point precision.
+    uint8 public constant MAX_PRICE_DECIMALS = 18;
+
+    /// @notice Latest accepted round for each feed identifier.
+    mapping(uint256 feedId => PriceRound round) public latestPrice;
+
+    /// @notice Emitted after a newer price round is accepted.
+    /// @param feedId Stable feed identifier matching the NativeOracle source ID.
+    /// @param roundId Provider-defined monotonically increasing round identifier.
+    /// @param price Positive fixed-point price.
+    /// @param decimals Number of decimal places in `price`.
+    /// @param resolvedAt Provider-defined monotonically increasing resolution timestamp.
+    event PriceResolved(
+        uint256 indexed feedId, uint64 indexed roundId, int256 price, uint8 decimals, uint64 resolvedAt
+    );
+
+    error UnsupportedSourceType(uint32 sourceType);
+    error SourceIdMismatch(uint256 expected, uint256 provided);
+    error StaleRound(uint64 latestRoundId, uint64 providedRoundId);
+    error StaleResolvedAt(uint64 latestResolvedAt, uint64 providedResolvedAt);
+    error InvalidPrice(int256 price);
+    error InvalidDecimals(uint8 decimals);
+
+    /// @inheritdoc IOracleCallback
+    function onOracleEvent(
+        uint32 sourceType,
+        uint256 sourceId,
+        uint128,
+        bytes calldata payload
+    ) external override returns (bool shouldStore) {
+        requireAllowed(SystemAddresses.NATIVE_ORACLE);
+        if (sourceType != SOURCE_TYPE_PRICE_FEED) revert UnsupportedSourceType(sourceType);
+
+        _resolvePrice(sourceId, abi.decode(payload, (PricePayload)));
+        return false;
+    }
+
+    function _resolvePrice(
+        uint256 sourceId,
+        PricePayload memory payload
+    ) internal {
+        if (sourceId != payload.feedId) revert SourceIdMismatch(payload.feedId, sourceId);
+
+        PriceRound memory current = latestPrice[payload.feedId];
+        if (payload.roundId == 0 || payload.roundId <= current.roundId) {
+            revert StaleRound(current.roundId, payload.roundId);
+        }
+        if (payload.resolvedAt <= current.resolvedAt) {
+            revert StaleResolvedAt(current.resolvedAt, payload.resolvedAt);
+        }
+        if (payload.decimals > MAX_PRICE_DECIMALS) revert InvalidDecimals(payload.decimals);
+        if (payload.price <= 0) revert InvalidPrice(payload.price);
+
+        latestPrice[payload.feedId] = PriceRound({
+            exists: true,
+            roundId: payload.roundId,
+            resolvedAt: payload.resolvedAt,
+            decimals: payload.decimals,
+            price: payload.price
+        });
+
+        emit PriceResolved(payload.feedId, payload.roundId, payload.price, payload.decimals, payload.resolvedAt);
+    }
+}

--- a/test/unit/oracle/PriceFeedResolver.t.sol
+++ b/test/unit/oracle/PriceFeedResolver.t.sol
@@ -1,0 +1,201 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import { Test } from "forge-std/Test.sol";
+import { Errors } from "../../../src/foundation/Errors.sol";
+import { SystemAddresses } from "../../../src/foundation/SystemAddresses.sol";
+import { NotAllowed } from "../../../src/foundation/SystemAccessControl.sol";
+import { INativeOracle } from "../../../src/oracle/INativeOracle.sol";
+import { NativeOracle } from "../../../src/oracle/NativeOracle.sol";
+import { PriceFeedResolver } from "../../../src/oracle/resolver/PriceFeedResolver.sol";
+
+contract PriceFeedResolverTest is Test {
+    NativeOracle public oracle;
+    PriceFeedResolver public resolver;
+
+    uint32 public constant SOURCE_TYPE_PRICE_FEED = 3;
+    uint256 public constant FEED_ID = 1;
+    uint256 public constant CALLBACK_GAS_LIMIT = 500_000;
+
+    event PriceResolved(
+        uint256 indexed feedId, uint64 indexed roundId, int256 price, uint8 decimals, uint64 resolvedAt
+    );
+
+    function setUp() public {
+        vm.etch(SystemAddresses.NATIVE_ORACLE, address(new NativeOracle()).code);
+        oracle = NativeOracle(SystemAddresses.NATIVE_ORACLE);
+        resolver = new PriceFeedResolver();
+
+        vm.prank(SystemAddresses.GOVERNANCE);
+        oracle.setDefaultCallback(SOURCE_TYPE_PRICE_FEED, address(resolver));
+    }
+
+    function test_StoresLatestPriceAndSourceProgress() public {
+        bytes memory payload = _payload(FEED_ID, 1, 1_010, 8, 196_12500000);
+
+        vm.expectEmit(true, true, false, true, address(resolver));
+        emit PriceResolved(FEED_ID, 1, 196_12500000, 8, 1_010);
+        _record(FEED_ID, 1, 1_010, payload, CALLBACK_GAS_LIMIT);
+
+        (bool exists, uint64 roundId, uint64 resolvedAt, uint8 decimals, int256 price) = resolver.latestPrice(FEED_ID);
+        assertTrue(exists);
+        assertEq(roundId, 1);
+        assertEq(resolvedAt, 1_010);
+        assertEq(decimals, 8);
+        assertEq(price, 196_12500000);
+
+        INativeOracle.SourceProgress memory progress = oracle.getSourceProgress(SOURCE_TYPE_PRICE_FEED, FEED_ID);
+        assertEq(progress.latestNonce, 1);
+        assertEq(progress.latestPosition, 1_010);
+        assertEq(oracle.getRecord(SOURCE_TYPE_PRICE_FEED, FEED_ID, 1).recordedAt, 0);
+    }
+
+    function test_NextRoundOverwritesLatestPriceWithoutHistory() public {
+        _record(FEED_ID, 1, 1_010, _payload(FEED_ID, 1, 1_010, 8, 196_12500000), CALLBACK_GAS_LIMIT);
+        _record(FEED_ID, 2, 2_010, _payload(FEED_ID, 2, 2_010, 8, 197_50000000), CALLBACK_GAS_LIMIT);
+
+        (bool exists, uint64 roundId, uint64 resolvedAt,, int256 price) = resolver.latestPrice(FEED_ID);
+        assertTrue(exists);
+        assertEq(roundId, 2);
+        assertEq(resolvedAt, 2_010);
+        assertEq(price, 197_50000000);
+        assertEq(oracle.getLatestNonce(SOURCE_TYPE_PRICE_FEED, FEED_ID), 2);
+        assertEq(oracle.getRecord(SOURCE_TYPE_PRICE_FEED, FEED_ID, 1).recordedAt, 0);
+        assertEq(oracle.getRecord(SOURCE_TYPE_PRICE_FEED, FEED_ID, 2).recordedAt, 0);
+    }
+
+    function test_IndependentFeedsDoNotOverwriteEachOther() public {
+        uint256 secondFeedId = 2;
+        _record(FEED_ID, 1, 1_010, _payload(FEED_ID, 1, 1_010, 8, 196_12500000), CALLBACK_GAS_LIMIT);
+        _record(secondFeedId, 1, 1_010, _payload(secondFeedId, 1, 1_010, 6, 28_500000), CALLBACK_GAS_LIMIT);
+
+        (,,,, int256 firstPrice) = resolver.latestPrice(FEED_ID);
+        (bool exists, uint64 roundId,, uint8 decimals, int256 secondPrice) = resolver.latestPrice(secondFeedId);
+        assertEq(firstPrice, 196_12500000);
+        assertTrue(exists);
+        assertEq(roundId, 1);
+        assertEq(decimals, 6);
+        assertEq(secondPrice, 28_500000);
+    }
+
+    function test_ZeroRoundRevertsAtomically() public {
+        vm.expectPartialRevert(Errors.OracleCallbackFailed.selector);
+        _record(FEED_ID, 1, 1_010, _payload(FEED_ID, 0, 1_010, 8, 196_12500000), CALLBACK_GAS_LIMIT);
+        _assertUnchanged();
+    }
+
+    function test_ZeroResolvedAtRevertsAtomically() public {
+        vm.expectPartialRevert(Errors.OracleCallbackFailed.selector);
+        _record(FEED_ID, 1, 1, _payload(FEED_ID, 1, 0, 8, 196_12500000), CALLBACK_GAS_LIMIT);
+        _assertUnchanged();
+    }
+
+    function test_ZeroPriceRevertsAtomically() public {
+        vm.expectPartialRevert(Errors.OracleCallbackFailed.selector);
+        _record(FEED_ID, 1, 1_010, _payload(FEED_ID, 1, 1_010, 8, 0), CALLBACK_GAS_LIMIT);
+        _assertUnchanged();
+    }
+
+    function test_NegativePriceRevertsAtomically() public {
+        vm.expectPartialRevert(Errors.OracleCallbackFailed.selector);
+        _record(FEED_ID, 1, 1_010, _payload(FEED_ID, 1, 1_010, 8, -1), CALLBACK_GAS_LIMIT);
+        _assertUnchanged();
+    }
+
+    function test_ExcessiveDecimalsRevertsAtomically() public {
+        bytes memory payload = _payload(FEED_ID, 1, 1_010, resolver.MAX_PRICE_DECIMALS() + 1, 196_12500000);
+
+        vm.expectPartialRevert(Errors.OracleCallbackFailed.selector);
+        _record(FEED_ID, 1, 1_010, payload, CALLBACK_GAS_LIMIT);
+        _assertUnchanged();
+    }
+
+    function test_StaleRoundRevertsWithoutAdvancingProgress() public {
+        _record(FEED_ID, 1, 2_010, _payload(FEED_ID, 2, 2_010, 8, 197_50000000), CALLBACK_GAS_LIMIT);
+
+        vm.expectPartialRevert(Errors.OracleCallbackFailed.selector);
+        _record(FEED_ID, 2, 3_010, _payload(FEED_ID, 1, 3_010, 8, 196_12500000), CALLBACK_GAS_LIMIT);
+
+        (, uint64 roundId, uint64 resolvedAt,, int256 price) = resolver.latestPrice(FEED_ID);
+        assertEq(roundId, 2);
+        assertEq(resolvedAt, 2_010);
+        assertEq(price, 197_50000000);
+        assertEq(oracle.getLatestNonce(SOURCE_TYPE_PRICE_FEED, FEED_ID), 1);
+    }
+
+    function test_StaleResolvedAtRevertsWithoutAdvancingProgress() public {
+        _record(FEED_ID, 1, 2_010, _payload(FEED_ID, 1, 2_010, 8, 196_12500000), CALLBACK_GAS_LIMIT);
+
+        vm.expectPartialRevert(Errors.OracleCallbackFailed.selector);
+        _record(FEED_ID, 2, 2_010, _payload(FEED_ID, 2, 2_010, 8, 197_50000000), CALLBACK_GAS_LIMIT);
+        assertEq(oracle.getLatestNonce(SOURCE_TYPE_PRICE_FEED, FEED_ID), 1);
+    }
+
+    function test_SourceIdMismatchRevertsAtomically() public {
+        vm.expectPartialRevert(Errors.OracleCallbackFailed.selector);
+        _record(FEED_ID + 1, 1, 1_010, _payload(FEED_ID, 1, 1_010, 8, 196_12500000), CALLBACK_GAS_LIMIT);
+
+        (bool exists,,,,) = resolver.latestPrice(FEED_ID);
+        assertFalse(exists);
+        assertEq(oracle.getLatestNonce(SOURCE_TYPE_PRICE_FEED, FEED_ID + 1), 0);
+    }
+
+    function test_MalformedPayloadRevertsAtomically() public {
+        vm.expectPartialRevert(Errors.OracleCallbackFailed.selector);
+        _record(FEED_ID, 1, 1_010, hex"1234", CALLBACK_GAS_LIMIT);
+        _assertUnchanged();
+    }
+
+    function test_CallbackGasFailureLeavesNoPriceOrProgress() public {
+        vm.expectPartialRevert(Errors.OracleCallbackFailed.selector);
+        _record(FEED_ID, 1, 1_010, _payload(FEED_ID, 1, 1_010, 8, 196_12500000), 1);
+        _assertUnchanged();
+    }
+
+    function test_RevertWhenCallbackCalledOutsideNativeOracle() public {
+        bytes memory payload = _payload(FEED_ID, 1, 1_010, 8, 196_12500000);
+        address caller = makeAddr("caller");
+
+        vm.expectRevert(abi.encodeWithSelector(NotAllowed.selector, caller, SystemAddresses.NATIVE_ORACLE));
+        vm.prank(caller);
+        resolver.onOracleEvent(SOURCE_TYPE_PRICE_FEED, FEED_ID, 1, payload);
+    }
+
+    function test_RevertWhenNativeOracleUsesWrongSourceType() public {
+        vm.expectRevert(abi.encodeWithSelector(PriceFeedResolver.UnsupportedSourceType.selector, uint32(4)));
+        vm.prank(SystemAddresses.NATIVE_ORACLE);
+        resolver.onOracleEvent(4, FEED_ID, 1, _payload(FEED_ID, 1, 1_010, 8, 196_12500000));
+    }
+
+    function _assertUnchanged() internal view {
+        (bool exists,,,,) = resolver.latestPrice(FEED_ID);
+        assertFalse(exists);
+        assertEq(oracle.getLatestNonce(SOURCE_TYPE_PRICE_FEED, FEED_ID), 0);
+        assertEq(oracle.getRecord(SOURCE_TYPE_PRICE_FEED, FEED_ID, 1).recordedAt, 0);
+    }
+
+    function _record(
+        uint256 sourceId,
+        uint128 nonce,
+        uint256 sourcePosition,
+        bytes memory payload,
+        uint256 callbackGasLimit
+    ) internal {
+        vm.prank(SystemAddresses.SYSTEM_CALLER);
+        oracle.record(SOURCE_TYPE_PRICE_FEED, sourceId, nonce, sourcePosition, payload, callbackGasLimit);
+    }
+
+    function _payload(
+        uint256 feedId,
+        uint64 roundId,
+        uint64 resolvedAt,
+        uint8 decimals,
+        int256 price
+    ) internal pure returns (bytes memory) {
+        return abi.encode(
+            PriceFeedResolver.PricePayload({
+                feedId: feedId, roundId: roundId, resolvedAt: resolvedAt, decimals: decimals, price: price
+            })
+        );
+    }
+}


### PR DESCRIPTION
## Description

Adds the contract-side Price Feed core from the Oracle PR split tracked in [gravity-audit#1038](https://github.com/Galxe/gravity-audit/issues/1038) and motivated by [gravity-audit#1033](https://github.com/Galxe/gravity-audit/issues/1033).

This PR intentionally contains only:

- `PriceFeedResolver` for NativeOracle source type `3`
- the canonical `PricePayload { feedId, roundId, resolvedAt, decimals, price }` ABI
- latest-round storage with source identity, round/timestamp replay, decimal, and positive-price validation
- focused callback and atomic-failure tests
- a short protocol specification covering the contract/provider boundary

The resolver accepts calls only from the NativeOracle system address. Callback failure reverts the complete delivery before NativeOracle advances source progress, so rejected payloads remain retryable at the same delivery nonce.

The first provider will be a closed Binance index-price kline, but HTTP fetching, URI/config parsing, exact bucket validation, fixed-point parsing, and source type `3` callback gas policy remain in the follow-up gravity-reth provider PR. This PR contains no Binance networking, Polygon/Polymarket code, deployment changes, SDK E2E, frontend, or multi-provider aggregation.

### Compatibility and storage

- Adds one standalone contract; no existing contract or interface is modified.
- Does not change existing selectors, system-contract storage, Genesis, or source type `0` behavior.
- Stores one fixed-size latest record per feed and no raw payload/history mapping.
- Uses the existing standard `500,000` callback gas budget in tests; the previous oversized integration branch's `2,000,000` value is not carried into the price path.
- Resolver runtime bytecode is 1,166 bytes.

### Validation

- `forge test --summary`: 1,044 passed, 0 failed, 0 skipped
- `forge test --match-path 'test/unit/oracle/*.t.sol' --summary`: 282 passed, 0 failed, 0 skipped
- focused `PriceFeedResolver` suite: 15 passed, 0 failed, 0 skipped
- `forge fmt --check`
- `forge build --sizes`
- Solhint on `PriceFeedResolver.sol`: 0 errors (only generic gas-style advisories)
- ABI compared field-for-field with the pending gravity-reth Binance provider implementation
- staged diff scanned for credentials and user-specific absolute paths

## Type of Change

- [x] 📚 Documentation    (Non-breaking change; Changes in the documentation)
- [ ] 🔧 Bug fix          (Non-breaking change; Fixes an existing bug)
- [ ] 🥂 Improvement      (Non-breaking change; Improves existing feature)
- [x] 🚀 New feature      (Non-breaking change; Adds functionality)
- [ ] 🔐 Security fix     (Non-breaking change; Patches a security issue)
- [ ] 💥 Breaking change  (Breaks existing functionality)

<!--
    Leave this section as-is, no changes are to be made below this point!
-->
