### PR TITLE
feat(oracle): add Polymarket settlement resolver

### DIFF
--- a/spec_v2/oracle_polymarket_settlement_resolver.spec.md
+++ b/spec_v2/oracle_polymarket_settlement_resolver.spec.md
@@ -1,0 +1,113 @@
+---
+title: Polymarket Settlement Resolver Specification
+status: production candidate
+---
+
+# Polymarket Settlement Resolver
+
+This specification defines the contract boundary for mirroring one finalized
+Polygon Conditional Tokens Framework (CTF) condition into Gravity. Validators
+independently scan Polygon, agree on canonical event bytes through JWK consensus,
+and deliver one terminal settlement through `NativeOracle`.
+
+Polygon RPC access, finalized-block selection, event ordering, and cursor
+persistence belong to the `gravity-reth` provider. The resolver performs no RPC
+requests and does not independently prove Polygon finality.
+
+## Source And Mirror Identity
+
+Polymarket settlements use source type `6`. Governance registers one immutable
+mirror identity:
+
+```text
+(mirrorId, polygonChainId=137, ctf, conditionId, outcomeSlotCount)
+```
+
+`mirrorId` is the NativeOracle `sourceId` and must fit the `uint64` identity used
+by relayer task URIs. Every accepted payload must match all registered fields.
+The resolver also recomputes the CTF condition identity:
+
+```solidity
+conditionId = keccak256(abi.encodePacked(oracle, questionId, outcomeSlotCount));
+```
+
+This binds event provenance to the reviewed condition rather than trusting
+independent metadata fields.
+
+## Canonical Payload ABI
+
+```solidity
+struct PolymarketSettlementPayload {
+    uint256 mirrorId;
+    uint256 polygonChainId;
+    address ctf;
+    address oracle;
+    bytes32 conditionId;
+    bytes32 questionId;
+    uint256 outcomeSlotCount;
+    uint256[] payoutNumerators;
+    bytes32 txHash;
+    uint256 logIndex;
+    uint8 settlementKind;
+}
+```
+
+`settlementKind=1` identifies a CTF `ConditionResolution` event. The canonical
+resolver payload is exactly `abi.encode(PolymarketSettlementPayload)`. Its byte
+length must match the registered outcome count, and decode/re-encode hashes must
+match. Trailing bytes, alternate dynamic offsets, malformed narrow values, and
+other non-canonical encodings are rejected.
+
+## Terminal Classification
+
+The payout vector must contain exactly `outcomeSlotCount` elements and at least
+one positive value:
+
+- exactly one positive slot becomes `ResolvedWinner` with that `winningSlot`
+- multiple positive slots become `ResolvedVoidable`
+- an all-zero or malformed vector reverts delivery and creates no terminal state
+
+`ResolvedVoidable` is a source-derived terminal result, not a Gravity timeout.
+There is no local settlement deadline. A canonical Polygon resolution remains
+valid regardless of how much Gravity wall-clock time has elapsed.
+
+## Atomic Delivery
+
+`NativeOracle` invokes the resolver atomically. Invalid identity, malformed ABI,
+insufficient callback gas, or a duplicate terminal settlement reverts the whole
+delivery. Source nonce and source position therefore do not advance, and the
+same delivery remains retryable.
+
+New NativeOracle deliveries do not retain raw payload history. Consequently the
+resolver has no replay API or pending-raw-record state. Its observable states are
+only `None`, `ResolvedWinner`, and `ResolvedVoidable`.
+
+## Storage And Provenance
+
+Each mirror stores at most one fixed-size terminal settlement, including the
+classification, winning slot, delivery nonce, Gravity observation timestamp,
+Polygon oracle and question ID, transaction hash, and log index. Registered
+chain, CTF, condition, and outcome count remain in the immutable mirror
+configuration. The full payout vector is emitted with the resolution event but
+is not duplicated in permanent contract storage.
+
+`recordedAt` is audit metadata only. It must never invalidate or change a
+canonical Polygon terminal result. The finalized Polygon block is the
+NativeOracle source position and is available through `getSourceProgress(6,
+mirrorId)`.
+
+The resolver supports up to 32 outcomes within the standard 500,000 callback
+gas limit. Callback cost remains bounded because outcome values are classified
+in memory and are not copied into a dynamic storage array.
+
+## Focused Tests
+
+```bash
+forge test --match-path 'test/unit/oracle/PolymarketSettlementResolver.t.sol'
+```
+
+The suite covers governance registration, relayer identity width, caller and
+source authorization, canonical ABI enforcement, every registered identity
+field, derived CTF condition identity, payout classification, independent
+mirrors, provenance, duplicate settlement rejection, callback gas failure, and
+atomic source-progress rollback.

--- a/src/oracle/resolver/IPolymarketSettlementResolver.sol
+++ b/src/oracle/resolver/IPolymarketSettlementResolver.sol
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+/// @title IPolymarketSettlementResolver
+/// @notice Read interface for contracts consuming mirrored Polygon CTF settlements.
+interface IPolymarketSettlementResolver {
+    /// @notice Terminal classification of a canonical CTF payout vector.
+    enum ObservationStatus {
+        None,
+        ResolvedWinner,
+        ResolvedVoidable
+    }
+
+    /// @notice Return the immutable Polygon condition registered for a mirror.
+    function getMirrorConfig(
+        uint256 mirrorId
+    )
+        external
+        view
+        returns (bool exists, uint256 polygonChainId, address ctf, bytes32 conditionId, uint256 outcomeSlotCount);
+
+    /// @notice Return true after the registered condition reaches a canonical terminal state.
+    function isSettlementObserved(
+        uint256 mirrorId,
+        bytes32 conditionId
+    ) external view returns (bool observed);
+
+    /// @notice Return the terminal classification and source-event provenance.
+    /// @dev `recordedAt` is Gravity audit metadata and never limits source finality.
+    function getSettlementObservation(
+        uint256 mirrorId,
+        bytes32 conditionId
+    )
+        external
+        view
+        returns (
+            ObservationStatus status,
+            uint8 winningSlot,
+            uint128 nonce,
+            uint64 recordedAt,
+            bytes32 txHash,
+            uint256 logIndex
+        );
+
+    /// @notice Return canonical settlement metadata for auditing and integrations.
+    function getSettlement(
+        uint256 mirrorId,
+        bytes32 conditionId
+    )
+        external
+        view
+        returns (
+            bool exists,
+            uint128 nonce,
+            uint256 polygonChainId,
+            address ctf,
+            address oracle,
+            bytes32 questionId,
+            uint256 outcomeSlotCount,
+            bytes32 txHash,
+            uint256 logIndex,
+            uint8 settlementKind
+        );
+}

--- a/src/oracle/resolver/PolymarketSettlementResolver.sol
+++ b/src/oracle/resolver/PolymarketSettlementResolver.sol
@@ -1,0 +1,357 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import { IOracleCallback } from "../INativeOracle.sol";
+import { IPolymarketSettlementResolver } from "./IPolymarketSettlementResolver.sol";
+import { SystemAddresses } from "../../foundation/SystemAddresses.sol";
+import { requireAllowed } from "../../foundation/SystemAccessControl.sol";
+
+/// @title PolymarketSettlementResolver
+/// @notice Stores canonical terminal Polygon CTF settlements agreed by Gravity validators.
+/// @dev Each governance-registered mirror is permanently bound to one Polygon condition.
+contract PolymarketSettlementResolver is IOracleCallback, IPolymarketSettlementResolver {
+    /// @notice NativeOracle source type reserved for Polymarket settlement mirrors.
+    uint32 public constant SOURCE_TYPE_POLYMARKET_SETTLEMENT = 6;
+    /// @notice Polygon PoS mainnet chain identifier.
+    uint256 public constant POLYGON_CHAIN_ID = 137;
+    /// @notice Payload discriminator for a CTF `ConditionResolution` event.
+    uint8 public constant SETTLEMENT_KIND_CTF_CONDITION_RESOLUTION = 1;
+    /// @notice Maximum supported outcome count, bounding decode and callback costs.
+    uint256 public constant MAX_OUTCOME_SLOT_COUNT = 32;
+
+    uint256 private constant _MIN_OUTCOME_SLOT_COUNT = 2;
+    // Top-level tuple offset, eleven tuple-head words, array length, then N array elements.
+    uint256 private constant _ENCODED_PAYLOAD_BASE_WORDS = 13;
+
+    struct MirrorConfig {
+        bool exists;
+        uint64 polygonChainId;
+        address ctf;
+        uint8 outcomeSlotCount;
+        bytes32 conditionId;
+    }
+
+    /// @notice Canonical callback payload produced by the Polygon settlement provider.
+    struct PolymarketSettlementPayload {
+        uint256 mirrorId;
+        uint256 polygonChainId;
+        address ctf;
+        address oracle;
+        bytes32 conditionId;
+        bytes32 questionId;
+        uint256 outcomeSlotCount;
+        uint256[] payoutNumerators;
+        bytes32 txHash;
+        uint256 logIndex;
+        uint8 settlementKind;
+    }
+
+    struct Settlement {
+        ObservationStatus status;
+        uint8 winningSlot;
+        uint64 recordedAt;
+        uint128 nonce;
+        address oracle;
+        uint64 logIndex;
+        bytes32 questionId;
+        bytes32 txHash;
+    }
+
+    mapping(uint256 mirrorId => MirrorConfig config) private _mirrorConfigs;
+    mapping(uint256 mirrorId => Settlement settlement) private _settlements;
+
+    event MirrorRegistered(
+        uint256 indexed mirrorId,
+        uint256 polygonChainId,
+        address indexed ctf,
+        bytes32 indexed conditionId,
+        uint256 outcomeSlotCount
+    );
+
+    event PolymarketConditionResolved(
+        uint256 indexed mirrorId,
+        bytes32 indexed conditionId,
+        bytes32 indexed questionId,
+        uint128 nonce,
+        address oracle,
+        bytes32 txHash,
+        uint256 logIndex,
+        ObservationStatus status,
+        uint8 winningSlot,
+        uint256[] payoutNumerators
+    );
+
+    error UnsupportedSourceType(uint32 sourceType);
+    error MirrorNotRegistered(uint256 mirrorId);
+    error SourceIdMismatch(uint256 expected, uint256 provided);
+    error InvalidMirrorConfig();
+    error InvalidSettlementKind(uint8 settlementKind);
+    error InvalidSettlementPayload();
+    error ConditionMismatch(bytes32 expected, bytes32 provided);
+    error ConditionIdentityMismatch(bytes32 expected, bytes32 provided);
+    error CtfMismatch(address expected, address provided);
+    error ChainIdMismatch(uint256 expected, uint256 provided);
+    error OutcomeSlotCountMismatch(uint256 expected, uint256 provided);
+    error MirrorAlreadyRegistered(uint256 mirrorId);
+    error SettlementAlreadyResolved(uint256 mirrorId);
+
+    /// @notice Bind a stable mirror ID to exactly one Polygon CTF condition.
+    /// @dev `mirrorId` is restricted to the `uint64` identity supported by relayer task URIs.
+    function registerMirror(
+        uint256 mirrorId,
+        uint256 polygonChainId,
+        address ctf,
+        bytes32 conditionId,
+        uint256 outcomeSlotCount
+    ) external {
+        requireAllowed(SystemAddresses.GOVERNANCE);
+
+        if (
+            mirrorId == 0 || mirrorId > type(uint64).max || polygonChainId != POLYGON_CHAIN_ID || ctf == address(0)
+                || conditionId == bytes32(0) || outcomeSlotCount < _MIN_OUTCOME_SLOT_COUNT
+                || outcomeSlotCount > MAX_OUTCOME_SLOT_COUNT
+        ) {
+            revert InvalidMirrorConfig();
+        }
+        if (_mirrorConfigs[mirrorId].exists) revert MirrorAlreadyRegistered(mirrorId);
+
+        _mirrorConfigs[mirrorId] = MirrorConfig({
+            exists: true,
+            // Bounds are fixed to Polygon mainnet above.
+            // forge-lint: disable-next-line(unsafe-typecast)
+            polygonChainId: uint64(polygonChainId),
+            ctf: ctf,
+            // Bounds are checked against MAX_OUTCOME_SLOT_COUNT above.
+            // forge-lint: disable-next-line(unsafe-typecast)
+            outcomeSlotCount: uint8(outcomeSlotCount),
+            conditionId: conditionId
+        });
+
+        emit MirrorRegistered(mirrorId, polygonChainId, ctf, conditionId, outcomeSlotCount);
+    }
+
+    /// @inheritdoc IPolymarketSettlementResolver
+    function getMirrorConfig(
+        uint256 mirrorId
+    )
+        external
+        view
+        override
+        returns (bool exists, uint256 polygonChainId, address ctf, bytes32 conditionId, uint256 outcomeSlotCount)
+    {
+        MirrorConfig storage config = _mirrorConfigs[mirrorId];
+        return (config.exists, config.polygonChainId, config.ctf, config.conditionId, config.outcomeSlotCount);
+    }
+
+    /// @inheritdoc IOracleCallback
+    function onOracleEvent(
+        uint32 sourceType,
+        uint256 sourceId,
+        uint128 nonce,
+        bytes calldata payload
+    ) external override returns (bool shouldStore) {
+        requireAllowed(SystemAddresses.NATIVE_ORACLE);
+        if (sourceType != SOURCE_TYPE_POLYMARKET_SETTLEMENT) revert UnsupportedSourceType(sourceType);
+
+        _resolveEncoded(sourceId, nonce, payload);
+        return false;
+    }
+
+    /// @inheritdoc IPolymarketSettlementResolver
+    function isSettlementObserved(
+        uint256 mirrorId,
+        bytes32 conditionId
+    ) external view override returns (bool observed) {
+        return _isRegisteredCondition(mirrorId, conditionId) && _settlements[mirrorId].status != ObservationStatus.None;
+    }
+
+    /// @inheritdoc IPolymarketSettlementResolver
+    function getSettlementObservation(
+        uint256 mirrorId,
+        bytes32 conditionId
+    )
+        external
+        view
+        override
+        returns (
+            ObservationStatus status,
+            uint8 winningSlot,
+            uint128 nonce,
+            uint64 recordedAt,
+            bytes32 txHash,
+            uint256 logIndex
+        )
+    {
+        if (!_isRegisteredCondition(mirrorId, conditionId)) {
+            return (ObservationStatus.None, type(uint8).max, 0, 0, bytes32(0), 0);
+        }
+
+        Settlement storage settlement = _settlements[mirrorId];
+        if (settlement.status == ObservationStatus.None) {
+            return (ObservationStatus.None, type(uint8).max, 0, 0, bytes32(0), 0);
+        }
+        return (
+            settlement.status,
+            settlement.winningSlot,
+            settlement.nonce,
+            settlement.recordedAt,
+            settlement.txHash,
+            settlement.logIndex
+        );
+    }
+
+    /// @notice Strictly classify canonical payload bytes without modifying state.
+    function classifySettlementPayload(
+        uint256 sourceId,
+        bytes calldata encoded
+    ) external view returns (ObservationStatus status, uint8 winningSlot) {
+        (, status, winningSlot) = _decodeAndClassify(sourceId, encoded);
+    }
+
+    /// @inheritdoc IPolymarketSettlementResolver
+    function getSettlement(
+        uint256 mirrorId,
+        bytes32 conditionId
+    )
+        external
+        view
+        override
+        returns (
+            bool exists,
+            uint128 nonce,
+            uint256 polygonChainId,
+            address ctf,
+            address oracle,
+            bytes32 questionId,
+            uint256 outcomeSlotCount,
+            bytes32 txHash,
+            uint256 logIndex,
+            uint8 settlementKind
+        )
+    {
+        if (!_isRegisteredCondition(mirrorId, conditionId)) {
+            return (false, 0, 0, address(0), address(0), bytes32(0), 0, bytes32(0), 0, 0);
+        }
+
+        Settlement storage settlement = _settlements[mirrorId];
+        if (settlement.status == ObservationStatus.None) {
+            return (false, 0, 0, address(0), address(0), bytes32(0), 0, bytes32(0), 0, 0);
+        }
+
+        MirrorConfig storage config = _mirrorConfigs[mirrorId];
+        return (
+            true,
+            settlement.nonce,
+            config.polygonChainId,
+            config.ctf,
+            settlement.oracle,
+            settlement.questionId,
+            config.outcomeSlotCount,
+            settlement.txHash,
+            settlement.logIndex,
+            SETTLEMENT_KIND_CTF_CONDITION_RESOLUTION
+        );
+    }
+
+    function _resolveEncoded(
+        uint256 sourceId,
+        uint128 nonce,
+        bytes memory encoded
+    ) internal {
+        (PolymarketSettlementPayload memory payload, ObservationStatus status, uint8 winningSlot) =
+            _decodeAndClassify(sourceId, encoded);
+
+        Settlement storage stored = _settlements[sourceId];
+        if (stored.status != ObservationStatus.None) revert SettlementAlreadyResolved(sourceId);
+
+        stored.status = status;
+        stored.winningSlot = winningSlot;
+        stored.recordedAt = uint64(block.timestamp);
+        stored.nonce = nonce;
+        stored.oracle = payload.oracle;
+        stored.logIndex = uint64(payload.logIndex);
+        stored.questionId = payload.questionId;
+        stored.txHash = payload.txHash;
+
+        emit PolymarketConditionResolved(
+            sourceId,
+            payload.conditionId,
+            payload.questionId,
+            nonce,
+            payload.oracle,
+            payload.txHash,
+            payload.logIndex,
+            status,
+            winningSlot,
+            payload.payoutNumerators
+        );
+    }
+
+    function _decodeAndClassify(
+        uint256 sourceId,
+        bytes memory encoded
+    ) internal view returns (PolymarketSettlementPayload memory payload, ObservationStatus status, uint8 winningSlot) {
+        MirrorConfig memory config = _mirrorConfigs[sourceId];
+        if (!config.exists) revert MirrorNotRegistered(sourceId);
+
+        uint256 expectedLength = (_ENCODED_PAYLOAD_BASE_WORDS + config.outcomeSlotCount) * 32;
+        if (encoded.length != expectedLength) revert InvalidSettlementPayload();
+
+        payload = abi.decode(encoded, (PolymarketSettlementPayload));
+        if (keccak256(encoded) != keccak256(abi.encode(payload))) revert InvalidSettlementPayload();
+        if (sourceId != payload.mirrorId) revert SourceIdMismatch(payload.mirrorId, sourceId);
+        if (payload.settlementKind != SETTLEMENT_KIND_CTF_CONDITION_RESOLUTION) {
+            revert InvalidSettlementKind(payload.settlementKind);
+        }
+        if (payload.polygonChainId != config.polygonChainId) {
+            revert ChainIdMismatch(config.polygonChainId, payload.polygonChainId);
+        }
+        if (payload.ctf != config.ctf) revert CtfMismatch(config.ctf, payload.ctf);
+        if (payload.conditionId != config.conditionId) {
+            revert ConditionMismatch(config.conditionId, payload.conditionId);
+        }
+        if (payload.outcomeSlotCount != config.outcomeSlotCount) {
+            revert OutcomeSlotCountMismatch(config.outcomeSlotCount, payload.outcomeSlotCount);
+        }
+        if (payload.payoutNumerators.length != payload.outcomeSlotCount) {
+            revert OutcomeSlotCountMismatch(payload.outcomeSlotCount, payload.payoutNumerators.length);
+        }
+        if (
+            payload.oracle == address(0) || payload.questionId == bytes32(0) || payload.txHash == bytes32(0)
+                || payload.logIndex > type(uint64).max
+        ) {
+            revert InvalidSettlementPayload();
+        }
+
+        bytes32 derivedConditionId =
+            keccak256(abi.encodePacked(payload.oracle, payload.questionId, payload.outcomeSlotCount));
+        if (derivedConditionId != payload.conditionId) {
+            revert ConditionIdentityMismatch(payload.conditionId, derivedConditionId);
+        }
+
+        uint256 positivePayoutCount;
+        winningSlot = type(uint8).max;
+        for (uint256 i; i < payload.payoutNumerators.length;) {
+            if (payload.payoutNumerators[i] > 0) {
+                ++positivePayoutCount;
+                // The registered outcome count is at most 32.
+                // forge-lint: disable-next-line(unsafe-typecast)
+                if (positivePayoutCount == 1) winningSlot = uint8(i);
+            }
+            unchecked {
+                ++i;
+            }
+        }
+        if (positivePayoutCount == 0) revert InvalidSettlementPayload();
+        if (positivePayoutCount == 1) return (payload, ObservationStatus.ResolvedWinner, winningSlot);
+        return (payload, ObservationStatus.ResolvedVoidable, type(uint8).max);
+    }
+
+    function _isRegisteredCondition(
+        uint256 mirrorId,
+        bytes32 conditionId
+    ) private view returns (bool) {
+        MirrorConfig storage config = _mirrorConfigs[mirrorId];
+        return config.exists && config.conditionId == conditionId;
+    }
+}

--- a/test/unit/oracle/PolymarketSettlementResolver.t.sol
+++ b/test/unit/oracle/PolymarketSettlementResolver.t.sol
@@ -1,0 +1,436 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import { Test } from "forge-std/Test.sol";
+import { Errors } from "../../../src/foundation/Errors.sol";
+import { SystemAddresses } from "../../../src/foundation/SystemAddresses.sol";
+import { NotAllowed } from "../../../src/foundation/SystemAccessControl.sol";
+import { INativeOracle } from "../../../src/oracle/INativeOracle.sol";
+import { NativeOracle } from "../../../src/oracle/NativeOracle.sol";
+import { IPolymarketSettlementResolver } from "../../../src/oracle/resolver/IPolymarketSettlementResolver.sol";
+import { PolymarketSettlementResolver } from "../../../src/oracle/resolver/PolymarketSettlementResolver.sol";
+
+contract PolymarketSettlementResolverTest is Test {
+    NativeOracle public oracle;
+    PolymarketSettlementResolver public resolver;
+
+    uint32 public constant SOURCE_TYPE_POLYMARKET_SETTLEMENT = 6;
+    uint256 public constant MIRROR_ID = 1_897_398;
+    uint256 public constant SECOND_MIRROR_ID = 1_897_399;
+    uint256 public constant POLYGON_CHAIN_ID = 137;
+    uint256 public constant SOURCE_BLOCK = 89_222_209;
+    uint256 public constant LOG_INDEX = 2_077;
+    uint256 public constant CALLBACK_GAS_LIMIT = 500_000;
+    uint256 public constant MAX_OUTCOME_SLOT_COUNT = 32;
+    uint8 public constant SETTLEMENT_KIND_CTF_CONDITION_RESOLUTION = 1;
+
+    address public constant CTF = 0x4D97DCd97eC945f40cF65F87097ACe5EA0476045;
+    address public constant UMA_ORACLE = 0xd91E80cF2E7be2e162c6513ceD06f1dD0dA35296;
+    bytes32 public constant QUESTION_ID = 0x49a5e94a4b5a400dcd720ca1875fcd49ba55c303e43bf091bc175df72f74f501;
+    bytes32 public constant TX_HASH = 0x97828bf9110f78c07f1ad5cff5415875b67b3fe032e19ee6aa2317355861aab2;
+
+    address public alice = makeAddr("alice");
+    bytes32 public conditionId;
+
+    function setUp() public {
+        vm.etch(SystemAddresses.NATIVE_ORACLE, address(new NativeOracle()).code);
+        oracle = NativeOracle(SystemAddresses.NATIVE_ORACLE);
+        resolver = new PolymarketSettlementResolver();
+        conditionId = _conditionId(UMA_ORACLE, QUESTION_ID, 2);
+
+        vm.startPrank(SystemAddresses.GOVERNANCE);
+        oracle.setDefaultCallback(SOURCE_TYPE_POLYMARKET_SETTLEMENT, address(resolver));
+        resolver.registerMirror(MIRROR_ID, POLYGON_CHAIN_ID, CTF, conditionId, 2);
+        vm.stopPrank();
+    }
+
+    function test_StoresTerminalWinnerAndSourceProgress() public {
+        vm.warp(1_000_000);
+        uint256[] memory payouts = _payouts(1, 0);
+
+        _record(MIRROR_ID, 1, SOURCE_BLOCK, _encode(_payload(MIRROR_ID, payouts)), CALLBACK_GAS_LIMIT);
+
+        (
+            IPolymarketSettlementResolver.ObservationStatus status,
+            uint8 winningSlot,
+            uint128 nonce,
+            uint64 recordedAt,
+            bytes32 txHash,
+            uint256 logIndex
+        ) = resolver.getSettlementObservation(MIRROR_ID, conditionId);
+        assertEq(uint8(status), uint8(IPolymarketSettlementResolver.ObservationStatus.ResolvedWinner));
+        assertEq(winningSlot, 0);
+        assertEq(nonce, 1);
+        assertEq(recordedAt, 1_000_000);
+        assertEq(txHash, TX_HASH);
+        assertEq(logIndex, LOG_INDEX);
+        assertTrue(resolver.isSettlementObserved(MIRROR_ID, conditionId));
+
+        INativeOracle.SourceProgress memory progress =
+            oracle.getSourceProgress(SOURCE_TYPE_POLYMARKET_SETTLEMENT, MIRROR_ID);
+        assertEq(progress.latestNonce, 1);
+        assertEq(progress.latestPosition, SOURCE_BLOCK);
+        assertEq(oracle.getRecord(SOURCE_TYPE_POLYMARKET_SETTLEMENT, MIRROR_ID, 1).recordedAt, 0);
+    }
+
+    function test_GetSettlementReturnsCanonicalMetadata() public {
+        _record(MIRROR_ID, 1, SOURCE_BLOCK, _encode(_payload(MIRROR_ID, _payouts(0, 1))), CALLBACK_GAS_LIMIT);
+
+        (
+            bool exists,
+            uint128 nonce,
+            uint256 polygonChainId,
+            address ctf,
+            address oracleAddress,
+            bytes32 questionId,
+            uint256 outcomeSlotCount,
+            bytes32 txHash,
+            uint256 logIndex,
+            uint8 settlementKind
+        ) = resolver.getSettlement(MIRROR_ID, conditionId);
+        assertTrue(exists);
+        assertEq(nonce, 1);
+        assertEq(polygonChainId, POLYGON_CHAIN_ID);
+        assertEq(ctf, CTF);
+        assertEq(oracleAddress, UMA_ORACLE);
+        assertEq(questionId, QUESTION_ID);
+        assertEq(outcomeSlotCount, 2);
+        assertEq(txHash, TX_HASH);
+        assertEq(logIndex, LOG_INDEX);
+        assertEq(settlementKind, resolver.SETTLEMENT_KIND_CTF_CONDITION_RESOLUTION());
+    }
+
+    function test_MaximumOutcomeCountFitsStandardCallbackGasLimit() public {
+        uint256 mirrorId = SECOND_MIRROR_ID;
+        bytes32 questionId = keccak256("maximum-outcome-question");
+        bytes32 maximumConditionId = _conditionId(UMA_ORACLE, questionId, MAX_OUTCOME_SLOT_COUNT);
+        vm.prank(SystemAddresses.GOVERNANCE);
+        resolver.registerMirror(mirrorId, POLYGON_CHAIN_ID, CTF, maximumConditionId, MAX_OUTCOME_SLOT_COUNT);
+
+        uint256[] memory payouts = new uint256[](MAX_OUTCOME_SLOT_COUNT);
+        payouts[MAX_OUTCOME_SLOT_COUNT - 1] = 1;
+        PolymarketSettlementResolver.PolymarketSettlementPayload memory payload = _payload(mirrorId, payouts);
+        payload.questionId = questionId;
+        payload.conditionId = maximumConditionId;
+        payload.outcomeSlotCount = MAX_OUTCOME_SLOT_COUNT;
+
+        _record(mirrorId, 1, SOURCE_BLOCK, _encode(payload), CALLBACK_GAS_LIMIT);
+
+        (IPolymarketSettlementResolver.ObservationStatus status, uint8 winningSlot,,,,) =
+            resolver.getSettlementObservation(mirrorId, maximumConditionId);
+        assertEq(uint8(status), uint8(IPolymarketSettlementResolver.ObservationStatus.ResolvedWinner));
+        assertEq(winningSlot, MAX_OUTCOME_SLOT_COUNT - 1);
+    }
+
+    function test_ClassifiesWinnerAtNonzeroSlot() public view {
+        (IPolymarketSettlementResolver.ObservationStatus status, uint8 winningSlot) =
+            resolver.classifySettlementPayload(MIRROR_ID, _encode(_payload(MIRROR_ID, _payouts(0, 7))));
+
+        assertEq(uint8(status), uint8(IPolymarketSettlementResolver.ObservationStatus.ResolvedWinner));
+        assertEq(winningSlot, 1);
+    }
+
+    function test_MultiplePositivePayoutsAreTerminalAndVoidable() public {
+        bytes memory encoded = _encode(_payload(MIRROR_ID, _payouts(1, 1)));
+        (IPolymarketSettlementResolver.ObservationStatus classified, uint8 classifiedSlot) =
+            resolver.classifySettlementPayload(MIRROR_ID, encoded);
+        assertEq(uint8(classified), uint8(IPolymarketSettlementResolver.ObservationStatus.ResolvedVoidable));
+        assertEq(classifiedSlot, type(uint8).max);
+
+        _record(MIRROR_ID, 1, SOURCE_BLOCK, encoded, CALLBACK_GAS_LIMIT);
+        (IPolymarketSettlementResolver.ObservationStatus stored, uint8 storedSlot,,,,) =
+            resolver.getSettlementObservation(MIRROR_ID, conditionId);
+        assertEq(uint8(stored), uint8(IPolymarketSettlementResolver.ObservationStatus.ResolvedVoidable));
+        assertEq(storedSlot, type(uint8).max);
+    }
+
+    function test_ArbitrarilyDelayedCanonicalSettlementRemainsValid() public {
+        vm.warp(100 * 365 days);
+        _record(MIRROR_ID, 1, SOURCE_BLOCK, _encode(_payload(MIRROR_ID, _payouts(1, 0))), CALLBACK_GAS_LIMIT);
+
+        (IPolymarketSettlementResolver.ObservationStatus status,,, uint64 recordedAt,,) =
+            resolver.getSettlementObservation(MIRROR_ID, conditionId);
+        assertEq(uint8(status), uint8(IPolymarketSettlementResolver.ObservationStatus.ResolvedWinner));
+        assertEq(recordedAt, block.timestamp);
+    }
+
+    function test_IndependentMirrorsDoNotShareSettlementState() public {
+        bytes32 secondQuestion = keccak256("second-question");
+        bytes32 secondCondition = _conditionId(UMA_ORACLE, secondQuestion, 2);
+        vm.prank(SystemAddresses.GOVERNANCE);
+        resolver.registerMirror(SECOND_MIRROR_ID, POLYGON_CHAIN_ID, CTF, secondCondition, 2);
+
+        PolymarketSettlementResolver.PolymarketSettlementPayload memory payload =
+            _payload(SECOND_MIRROR_ID, _payouts(0, 1));
+        payload.questionId = secondQuestion;
+        payload.conditionId = secondCondition;
+        _record(SECOND_MIRROR_ID, 1, SOURCE_BLOCK, _encode(payload), CALLBACK_GAS_LIMIT);
+
+        assertFalse(resolver.isSettlementObserved(MIRROR_ID, conditionId));
+        assertTrue(resolver.isSettlementObserved(SECOND_MIRROR_ID, secondCondition));
+        assertEq(oracle.getLatestNonce(SOURCE_TYPE_POLYMARKET_SETTLEMENT, MIRROR_ID), 0);
+        assertEq(oracle.getLatestNonce(SOURCE_TYPE_POLYMARKET_SETTLEMENT, SECOND_MIRROR_ID), 1);
+    }
+
+    function test_GetMirrorConfigReturnsImmutableIdentity() public view {
+        (bool exists, uint256 chainId, address ctf, bytes32 registeredCondition, uint256 slots) =
+            resolver.getMirrorConfig(MIRROR_ID);
+        assertTrue(exists);
+        assertEq(chainId, POLYGON_CHAIN_ID);
+        assertEq(ctf, CTF);
+        assertEq(registeredCondition, conditionId);
+        assertEq(slots, 2);
+    }
+
+    function test_UnknownOrWrongConditionReadsAsUnobserved() public view {
+        bytes32 wrongCondition = keccak256("wrong-condition");
+        assertFalse(resolver.isSettlementObserved(MIRROR_ID, wrongCondition));
+        assertFalse(resolver.isSettlementObserved(999, conditionId));
+        (IPolymarketSettlementResolver.ObservationStatus status, uint8 winningSlot,,,,) =
+            resolver.getSettlementObservation(MIRROR_ID, wrongCondition);
+        assertEq(uint8(status), uint8(IPolymarketSettlementResolver.ObservationStatus.None));
+        assertEq(winningSlot, type(uint8).max);
+    }
+
+    function test_RevertWhenRegisteringMirrorTwice() public {
+        vm.expectRevert(
+            abi.encodeWithSelector(PolymarketSettlementResolver.MirrorAlreadyRegistered.selector, MIRROR_ID)
+        );
+        vm.prank(SystemAddresses.GOVERNANCE);
+        resolver.registerMirror(MIRROR_ID, POLYGON_CHAIN_ID, CTF, conditionId, 2);
+    }
+
+    function test_RevertWhenRegisteringMirrorOutsideGovernance() public {
+        vm.expectRevert(abi.encodeWithSelector(NotAllowed.selector, alice, SystemAddresses.GOVERNANCE));
+        vm.prank(alice);
+        resolver.registerMirror(SECOND_MIRROR_ID, POLYGON_CHAIN_ID, CTF, conditionId, 2);
+    }
+
+    function test_RevertWhenMirrorIdExceedsRelayerIdentityWidth() public {
+        vm.expectRevert(PolymarketSettlementResolver.InvalidMirrorConfig.selector);
+        vm.prank(SystemAddresses.GOVERNANCE);
+        resolver.registerMirror(uint256(type(uint64).max) + 1, POLYGON_CHAIN_ID, CTF, conditionId, 2);
+    }
+
+    function test_RevertWhenMirrorIdentityFieldIsZeroOrForeign() public {
+        vm.startPrank(SystemAddresses.GOVERNANCE);
+        vm.expectRevert(PolymarketSettlementResolver.InvalidMirrorConfig.selector);
+        resolver.registerMirror(0, POLYGON_CHAIN_ID, CTF, conditionId, 2);
+        vm.expectRevert(PolymarketSettlementResolver.InvalidMirrorConfig.selector);
+        resolver.registerMirror(SECOND_MIRROR_ID, 1, CTF, conditionId, 2);
+        vm.expectRevert(PolymarketSettlementResolver.InvalidMirrorConfig.selector);
+        resolver.registerMirror(SECOND_MIRROR_ID, POLYGON_CHAIN_ID, address(0), conditionId, 2);
+        vm.expectRevert(PolymarketSettlementResolver.InvalidMirrorConfig.selector);
+        resolver.registerMirror(SECOND_MIRROR_ID, POLYGON_CHAIN_ID, CTF, bytes32(0), 2);
+        vm.stopPrank();
+    }
+
+    function test_RevertWhenOutcomeCountIsOutsideBounds() public {
+        vm.startPrank(SystemAddresses.GOVERNANCE);
+        vm.expectRevert(PolymarketSettlementResolver.InvalidMirrorConfig.selector);
+        resolver.registerMirror(SECOND_MIRROR_ID, POLYGON_CHAIN_ID, CTF, conditionId, 1);
+        vm.expectRevert(PolymarketSettlementResolver.InvalidMirrorConfig.selector);
+        resolver.registerMirror(SECOND_MIRROR_ID, POLYGON_CHAIN_ID, CTF, conditionId, MAX_OUTCOME_SLOT_COUNT + 1);
+        vm.stopPrank();
+    }
+
+    function test_RevertWhenCallbackCalledOutsideNativeOracle() public {
+        vm.expectRevert(abi.encodeWithSelector(NotAllowed.selector, alice, SystemAddresses.NATIVE_ORACLE));
+        vm.prank(alice);
+        resolver.onOracleEvent(
+            SOURCE_TYPE_POLYMARKET_SETTLEMENT, MIRROR_ID, 1, _encode(_payload(MIRROR_ID, _payouts(1, 0)))
+        );
+    }
+
+    function test_RevertWhenNativeOracleUsesWrongSourceType() public {
+        vm.expectRevert(abi.encodeWithSelector(PolymarketSettlementResolver.UnsupportedSourceType.selector, uint32(7)));
+        vm.prank(SystemAddresses.NATIVE_ORACLE);
+        resolver.onOracleEvent(7, MIRROR_ID, 1, _encode(_payload(MIRROR_ID, _payouts(1, 0))));
+    }
+
+    function test_UnregisteredMirrorRevertsAtomically() public {
+        uint256 unknownMirror = 999;
+        PolymarketSettlementResolver.PolymarketSettlementPayload memory payload =
+            _payload(unknownMirror, _payouts(1, 0));
+
+        vm.expectPartialRevert(Errors.OracleCallbackFailed.selector);
+        _record(unknownMirror, 1, SOURCE_BLOCK, _encode(payload), CALLBACK_GAS_LIMIT);
+        assertEq(oracle.getLatestNonce(SOURCE_TYPE_POLYMARKET_SETTLEMENT, unknownMirror), 0);
+    }
+
+    function test_SourceIdMismatchRevertsAtomically() public {
+        PolymarketSettlementResolver.PolymarketSettlementPayload memory payload =
+            _payload(MIRROR_ID + 1, _payouts(1, 0));
+
+        _expectAtomicFailure(MIRROR_ID, _encode(payload));
+    }
+
+    function test_ChainMismatchRevertsAtomically() public {
+        PolymarketSettlementResolver.PolymarketSettlementPayload memory payload = _payload(MIRROR_ID, _payouts(1, 0));
+        payload.polygonChainId = 1;
+        _expectAtomicFailure(MIRROR_ID, _encode(payload));
+    }
+
+    function test_CtfMismatchRevertsAtomically() public {
+        PolymarketSettlementResolver.PolymarketSettlementPayload memory payload = _payload(MIRROR_ID, _payouts(1, 0));
+        payload.ctf = makeAddr("other-ctf");
+        _expectAtomicFailure(MIRROR_ID, _encode(payload));
+    }
+
+    function test_ConditionMismatchRevertsAtomically() public {
+        PolymarketSettlementResolver.PolymarketSettlementPayload memory payload = _payload(MIRROR_ID, _payouts(1, 0));
+        payload.conditionId = keccak256("other-condition");
+        _expectAtomicFailure(MIRROR_ID, _encode(payload));
+    }
+
+    function test_DerivedConditionIdentityMismatchRevertsAtomically() public {
+        PolymarketSettlementResolver.PolymarketSettlementPayload memory payload = _payload(MIRROR_ID, _payouts(1, 0));
+        payload.questionId = keccak256("foreign-question");
+        _expectAtomicFailure(MIRROR_ID, _encode(payload));
+    }
+
+    function test_OutcomeCountMismatchRevertsAtomically() public {
+        PolymarketSettlementResolver.PolymarketSettlementPayload memory payload = _payload(MIRROR_ID, _payouts(1, 0));
+        payload.outcomeSlotCount = 3;
+        _expectAtomicFailure(MIRROR_ID, _encode(payload));
+    }
+
+    function test_AllZeroPayoutRevertsAtomically() public {
+        _expectAtomicFailure(MIRROR_ID, _encode(_payload(MIRROR_ID, _payouts(0, 0))));
+    }
+
+    function test_PayoutLengthMismatchRevertsAtomically() public {
+        uint256[] memory payouts = new uint256[](3);
+        payouts[0] = 1;
+        _expectAtomicFailure(MIRROR_ID, _encode(_payload(MIRROR_ID, payouts)));
+    }
+
+    function test_InvalidSettlementKindRevertsAtomically() public {
+        PolymarketSettlementResolver.PolymarketSettlementPayload memory payload = _payload(MIRROR_ID, _payouts(1, 0));
+        payload.settlementKind = 2;
+        _expectAtomicFailure(MIRROR_ID, _encode(payload));
+    }
+
+    function test_ZeroProvenanceRevertsAtomically() public {
+        PolymarketSettlementResolver.PolymarketSettlementPayload memory payload = _payload(MIRROR_ID, _payouts(1, 0));
+        payload.txHash = bytes32(0);
+        _expectAtomicFailure(MIRROR_ID, _encode(payload));
+    }
+
+    function test_ZeroOracleOrQuestionRevertsAtomically() public {
+        PolymarketSettlementResolver.PolymarketSettlementPayload memory payload = _payload(MIRROR_ID, _payouts(1, 0));
+        payload.oracle = address(0);
+        _expectAtomicFailure(MIRROR_ID, _encode(payload));
+
+        payload = _payload(MIRROR_ID, _payouts(1, 0));
+        payload.questionId = bytes32(0);
+        _expectAtomicFailure(MIRROR_ID, _encode(payload));
+    }
+
+    function test_LogIndexOverflowRevertsAtomically() public {
+        PolymarketSettlementResolver.PolymarketSettlementPayload memory payload = _payload(MIRROR_ID, _payouts(1, 0));
+        payload.logIndex = uint256(type(uint64).max) + 1;
+        _expectAtomicFailure(MIRROR_ID, _encode(payload));
+    }
+
+    function test_MalformedPayloadRevertsAtomically() public {
+        _expectAtomicFailure(MIRROR_ID, hex"deadbeef");
+    }
+
+    function test_NonCanonicalTrailingBytesRevertAtomically() public {
+        bytes memory canonical = _encode(_payload(MIRROR_ID, _payouts(1, 0)));
+        _expectAtomicFailure(MIRROR_ID, bytes.concat(canonical, bytes32(uint256(1))));
+    }
+
+    function test_CallbackGasFailureLeavesNoSettlementOrProgress() public {
+        vm.expectPartialRevert(Errors.OracleCallbackFailed.selector);
+        _record(MIRROR_ID, 1, SOURCE_BLOCK, _encode(_payload(MIRROR_ID, _payouts(1, 0))), 1);
+        _assertUndelivered(MIRROR_ID, conditionId);
+    }
+
+    function test_SecondSettlementCannotOverwriteTerminalState() public {
+        bytes memory first = _encode(_payload(MIRROR_ID, _payouts(1, 0)));
+        _record(MIRROR_ID, 1, SOURCE_BLOCK, first, CALLBACK_GAS_LIMIT);
+
+        vm.expectPartialRevert(Errors.OracleCallbackFailed.selector);
+        _record(MIRROR_ID, 2, SOURCE_BLOCK + 1, _encode(_payload(MIRROR_ID, _payouts(0, 1))), CALLBACK_GAS_LIMIT);
+
+        (IPolymarketSettlementResolver.ObservationStatus status, uint8 winningSlot, uint128 nonce,,,) =
+            resolver.getSettlementObservation(MIRROR_ID, conditionId);
+        assertEq(uint8(status), uint8(IPolymarketSettlementResolver.ObservationStatus.ResolvedWinner));
+        assertEq(winningSlot, 0);
+        assertEq(nonce, 1);
+        assertEq(oracle.getLatestNonce(SOURCE_TYPE_POLYMARKET_SETTLEMENT, MIRROR_ID), 1);
+    }
+
+    function _expectAtomicFailure(
+        uint256 sourceId,
+        bytes memory payload
+    ) internal {
+        vm.expectPartialRevert(Errors.OracleCallbackFailed.selector);
+        _record(sourceId, 1, SOURCE_BLOCK, payload, CALLBACK_GAS_LIMIT);
+        _assertUndelivered(sourceId, conditionId);
+    }
+
+    function _assertUndelivered(
+        uint256 sourceId,
+        bytes32 expectedCondition
+    ) internal view {
+        assertFalse(resolver.isSettlementObserved(sourceId, expectedCondition));
+        assertEq(oracle.getLatestNonce(SOURCE_TYPE_POLYMARKET_SETTLEMENT, sourceId), 0);
+        assertEq(oracle.getRecord(SOURCE_TYPE_POLYMARKET_SETTLEMENT, sourceId, 1).recordedAt, 0);
+    }
+
+    function _record(
+        uint256 sourceId,
+        uint128 nonce,
+        uint256 sourcePosition,
+        bytes memory payload,
+        uint256 callbackGasLimit
+    ) internal {
+        vm.prank(SystemAddresses.SYSTEM_CALLER);
+        oracle.record(SOURCE_TYPE_POLYMARKET_SETTLEMENT, sourceId, nonce, sourcePosition, payload, callbackGasLimit);
+    }
+
+    function _payload(
+        uint256 mirrorId,
+        uint256[] memory payouts
+    ) internal view returns (PolymarketSettlementResolver.PolymarketSettlementPayload memory) {
+        return PolymarketSettlementResolver.PolymarketSettlementPayload({
+            mirrorId: mirrorId,
+            polygonChainId: POLYGON_CHAIN_ID,
+            ctf: CTF,
+            oracle: UMA_ORACLE,
+            conditionId: conditionId,
+            questionId: QUESTION_ID,
+            outcomeSlotCount: 2,
+            payoutNumerators: payouts,
+            txHash: TX_HASH,
+            logIndex: LOG_INDEX,
+            settlementKind: SETTLEMENT_KIND_CTF_CONDITION_RESOLUTION
+        });
+    }
+
+    function _encode(
+        PolymarketSettlementResolver.PolymarketSettlementPayload memory payload
+    ) internal pure returns (bytes memory) {
+        return abi.encode(payload);
+    }
+
+    function _conditionId(
+        address conditionOracle,
+        bytes32 questionId,
+        uint256 outcomeSlotCount
+    ) internal pure returns (bytes32) {
+        return keccak256(abi.encodePacked(conditionOracle, questionId, outcomeSlotCount));
+    }
+
+    function _payouts(
+        uint256 first,
+        uint256 second
+    ) internal pure returns (uint256[] memory payouts) {
+        payouts = new uint256[](2);
+        payouts[0] = first;
+        payouts[1] = second;
+    }
+}


### PR DESCRIPTION
## Summary

- add the source type `6` resolver boundary for finalized Polygon CTF `ConditionResolution` events
- bind each governance-registered mirror to immutable `(chainId, CTF, conditionId, outcomeSlotCount)` identity
- validate exact canonical ABI bytes, event provenance, and the derived CTF condition ID before recording terminal state
- classify one positive payout slot as `ResolvedWinner` and multiple positive slots as source-derived `ResolvedVoidable`
- keep terminal storage fixed-size; the full payout vector is emitted but is not duplicated in permanent storage

## Protocol semantics

- callback delivery is atomic with `NativeOracle`: malformed, mismatched, duplicate, or underfunded callbacks do not advance source progress
- there is no raw-payload replay or `Pending` state because current `NativeOracle` deliveries do not retain callback payloads
- there is no Gravity-local settlement deadline; a finalized canonical Polygon resolution remains valid even when observed later
- `mirrorId` must fit the relayer URI's `uint64` source identity
- the standard `500,000` callback gas limit supports the configured maximum of 32 outcomes; this PR does not change callback gas policy

## Responsibility boundary

This PR only defines the execution-layer resolver and its read interface. Polygon RPC access, finalized-block selection, event ordering, cursor persistence, and canonical payload construction remain responsibilities of the later `gravity-reth` provider PR.

It intentionally does **not** include:

- a Polygon/Polymarket fetcher
- prediction-market product contracts
- SDK E2E orchestration
- deployment or genesis configuration

## Canonical payload

```solidity
struct PolymarketSettlementPayload {
    uint256 mirrorId;
    uint256 polygonChainId;
    address ctf;
    address oracle;
    bytes32 conditionId;
    bytes32 questionId;
    uint256 outcomeSlotCount;
    uint256[] payoutNumerators;
    bytes32 txHash;
    uint256 logIndex;
    uint8 settlementKind;
}
```

## Verification

- `forge test --summary`: 1,077 passed, 0 failed, 0 skipped
- resolver suite: 33 passed, including max 32 outcomes under a 500,000 callback gas limit
- oracle suites: 314 passed before the final focused gas-bound addition; the full suite above includes the final state
- `forge build --sizes`: resolver runtime 3,937 bytes, 20,639 bytes below the EIP-170 limit
- `forge fmt --check`: passed for all added Solidity files
- sensitive-path and secret-name scan: clean

## Tracking

- Split plan: Galxe/gravity-audit#1038
- Related audit semantics: Galxe/gravity-audit#946, Galxe/gravity-audit#947, Galxe/gravity-audit#1036
- Depends on merged `NativeOracle` core PR #113 and price resolver pattern PR #114
