### PR TITLE
perf(oracle): pack price feed rounds

### DIFF
--- a/spec_v2/oracle_price_feed_resolver.spec.md
+++ b/spec_v2/oracle_price_feed_resolver.spec.md
@@ -17,31 +17,42 @@ does not perform HTTP requests or aggregate validator observations.
 ## Source Identity
 
 Price feeds use source type `3`. Each configured instrument has a stable
-`sourceId`, and that value must equal `PricePayload.feedId`. NativeOracle tracks
+`sourceId`, and that value must equal the packed `feedId`. NativeOracle tracks
 delivery progress independently for every `(sourceType, sourceId)` pair.
 
-## Price Payload ABI
+`OracleTaskConfig` permanently binds each price-feed `sourceId` to the hash of
+its first task config. Re-submitting identical bytes is allowed, but changing
+or reordering any config bytes requires a new feed ID, including after task
+removal. This deliberately fail-closed rule prevents a historical feed from
+being silently rebound to another instrument. Other source types remain
+reconfigurable.
 
-```solidity
-struct PricePayload {
-    uint256 feedId;
-    uint64 roundId;
-    uint64 resolvedAt;
-    uint8 decimals;
-    int256 price;
-}
+## Packed V1 Payload
+
+The callback body is exactly one big-endian 32-byte word:
+
+```text
+bits 255..248 : version       uint8   (must be 1)
+bits 247..184 : feedId        uint64
+bits 183..152 : roundId       uint32
+bits 151..104 : resolvedAtMs  uint48
+bits 103..8   : price         uint96  (fixed 8 decimals)
+bits 7..0     : flags         uint8   (must be 0)
 ```
 
 For the Binance index-kline provider:
 
 - `roundId = bucketStartMs / intervalMs`
-- `resolvedAt = bucketEndMs`
-- `price` is the decimal `close` field scaled to the configured decimals
+- `resolvedAtMs = bucketEndMs`
+- `price` is the positive decimal `close` field scaled to 8 decimals
 - the NativeOracle delivery nonce is independent from `roundId` and remains
   sequential for the feed
 
-The canonical payload is `abi.encode(PricePayload)`. Provider-specific URI
-parsing and exact closed-bucket checks are specified with the reth provider.
+The inner callback body is 32 bytes. The unchanged relayer uses Alloy's
+canonical dynamic-tuple encoding for `(deliveryNonce, sourcePosition,
+callbackBody)`, including its leading tuple offset. The complete wrapper is 192
+bytes for a 32-byte callback body. Provider-specific URI parsing, decimal
+truncation, and exact closed-bucket checks are specified with the reth provider.
 
 ## Contract Validation
 
@@ -49,22 +60,34 @@ The resolver accepts a payload only when:
 
 - the caller is the NativeOracle system contract
 - `sourceType == 3`
-- `sourceId == feedId`
+- payload length is exactly 32 bytes
+- `version == 1` and `flags == 0`
+- `sourceId` fits `uint64` and equals `feedId`
 - `roundId` is nonzero and greater than the latest accepted round
-- `resolvedAt` is nonzero and greater than the latest accepted timestamp
-- decimals do not exceed 18
+- `resolvedAtMs` is nonzero and greater than the latest accepted timestamp
 - price is positive
 
-Malformed payloads revert during ABI decoding. Any callback failure reverts the
-entire NativeOracle delivery, so source progress does not advance and the same
-delivery nonce remains retryable.
+Legacy 160-byte callback bodies, trailing bytes, unknown versions, and nonzero
+flags are rejected. Any callback failure reverts the entire NativeOracle
+delivery, so source progress does not advance and the same delivery nonce
+remains retryable.
 
 ## Storage And History
 
-`latestPrice(feedId)` exposes one fixed-size latest record per feed. A successful
-new round overwrites the preceding record. The resolver does not retain raw
-payloads or historical round mappings; historical values remain available from
-`PriceResolved` logs and the authoritative upstream source.
+`latestPrice(feedId)` exposes one single-slot record per feed:
+
+```solidity
+struct PriceRound {
+    uint32 roundId;
+    uint48 resolvedAtMs;
+    uint96 price;
+}
+```
+
+`roundId != 0` indicates existence and `PRICE_DECIMALS` is the constant `8`.
+A successful new round overwrites the preceding record. The resolver does not
+retain raw payloads or historical round mappings; historical values remain
+available from `PriceResolved` logs and the authoritative upstream source.
 
 NativeOracle never retains new raw `DataRecord` payloads; the callback return
 value is a deprecated compatibility field and does not control storage. This
@@ -85,7 +108,7 @@ versioned source type and payload if introduced later.
 forge test --match-path 'test/unit/oracle/PriceFeedResolver.t.sol'
 ```
 
-The suite covers latest-round storage, independent feeds, bounded storage,
-source identity, caller authorization, round and timestamp replay protection,
-price and decimal validation, malformed payloads, callback gas failure, and
-atomic retry behavior.
+The suite covers the cross-language golden vector, exact payload length,
+version and flags, maximum field widths, one-slot storage, source identity,
+caller authorization, round and timestamp replay protection, zero price,
+legacy payload rejection, callback gas failure, and atomic retry behavior.

--- a/src/oracle/OracleTaskConfig.sol
+++ b/src/oracle/OracleTaskConfig.sol
@@ -25,6 +25,8 @@ contract OracleTaskConfig is IOracleTaskConfig {
     error RelayerTaskAlreadyConfigured(
         uint32 sourceType, uint256 sourceId, bytes32 existingTaskName, bytes32 requestedTaskName
     );
+    error PriceFeedSourceIdOverflow(uint256 sourceId);
+    error PriceFeedConfigImmutable(uint256 sourceId, bytes32 expectedConfigHash, bytes32 providedConfigHash);
 
     // ========================================================================
     // STATE
@@ -41,6 +43,10 @@ contract OracleTaskConfig is IOracleTaskConfig {
 
     /// @notice Registered source IDs per source type: sourceType -> set of sourceIds
     mapping(uint32 => EnumerableSet.UintSet) private _registeredSourceIds;
+
+    /// @notice Permanently binds a price feed ID to its first configured task bytes.
+    /// @dev Removing a task intentionally does not release this binding. A semantic change must use a new feed ID.
+    mapping(uint256 feedId => bytes32 configHash) public priceFeedConfigHash;
 
     // ========================================================================
     // TASK MANAGEMENT (Governance Only)
@@ -62,6 +68,17 @@ contract OracleTaskConfig is IOracleTaskConfig {
         EnumerableSet.Bytes32Set storage taskNames = _taskNames[sourceType][sourceId];
         if (_isRelayerBackedSourceType(sourceType) && !taskNames.contains(taskName) && taskNames.length() != 0) {
             revert RelayerTaskAlreadyConfigured(sourceType, sourceId, taskNames.at(0), taskName);
+        }
+
+        if (sourceType == SOURCE_TYPE_PRICE_FEED) {
+            if (sourceId > type(uint64).max) revert PriceFeedSourceIdOverflow(sourceId);
+            bytes32 providedConfigHash = keccak256(config);
+            bytes32 expectedConfigHash = priceFeedConfigHash[sourceId];
+            if (expectedConfigHash == bytes32(0)) {
+                priceFeedConfigHash[sourceId] = providedConfigHash;
+            } else if (providedConfigHash != expectedConfigHash) {
+                revert PriceFeedConfigImmutable(sourceId, expectedConfigHash, providedConfigHash);
+            }
         }
 
         // Register source type and source ID for enumeration (no-op if already exists)

--- a/src/oracle/resolver/PriceFeedResolver.sol
+++ b/src/oracle/resolver/PriceFeedResolver.sol
@@ -7,48 +7,40 @@ import { requireAllowed } from "../../foundation/SystemAccessControl.sol";
 
 /// @title PriceFeedResolver
 /// @author Gravity Team
-/// @notice Stores the latest consensus-approved price round for each configured feed.
+/// @notice Stores the latest consensus-approved Binance index-price round for each feed.
 contract PriceFeedResolver is IOracleCallback {
-    struct PricePayload {
-        uint256 feedId;
-        uint64 roundId;
-        uint64 resolvedAt;
-        uint8 decimals;
-        int256 price;
-    }
-
     struct PriceRound {
-        bool exists;
-        uint64 roundId;
-        uint64 resolvedAt;
-        uint8 decimals;
-        int256 price;
+        uint32 roundId;
+        uint48 resolvedAtMs;
+        uint96 price;
     }
 
     /// @notice NativeOracle source type reserved for deterministic price feeds.
     uint32 public constant SOURCE_TYPE_PRICE_FEED = 3;
-    /// @notice Maximum accepted fixed-point precision.
-    uint8 public constant MAX_PRICE_DECIMALS = 18;
+    /// @notice Decimal precision implied by packed payload version 1.
+    uint8 public constant PRICE_DECIMALS = 8;
+    /// @notice Binance index-price packed payload version.
+    uint8 public constant PAYLOAD_VERSION = 1;
 
     /// @notice Latest accepted round for each feed identifier.
-    mapping(uint256 feedId => PriceRound round) public latestPrice;
+    mapping(uint64 feedId => PriceRound round) public latestPrice;
 
     /// @notice Emitted after a newer price round is accepted.
     /// @param feedId Stable feed identifier matching the NativeOracle source ID.
-    /// @param roundId Provider-defined monotonically increasing round identifier.
-    /// @param price Positive fixed-point price.
-    /// @param decimals Number of decimal places in `price`.
-    /// @param resolvedAt Provider-defined monotonically increasing resolution timestamp.
-    event PriceResolved(
-        uint256 indexed feedId, uint64 indexed roundId, int256 price, uint8 decimals, uint64 resolvedAt
-    );
+    /// @param roundId Binance bucket open time divided by its interval in milliseconds.
+    /// @param price Positive fixed-point price with `PRICE_DECIMALS` decimals.
+    /// @param resolvedAtMs Binance bucket close time in milliseconds.
+    event PriceResolved(uint64 indexed feedId, uint32 indexed roundId, uint96 price, uint48 resolvedAtMs);
 
     error UnsupportedSourceType(uint32 sourceType);
-    error SourceIdMismatch(uint256 expected, uint256 provided);
-    error StaleRound(uint64 latestRoundId, uint64 providedRoundId);
-    error StaleResolvedAt(uint64 latestResolvedAt, uint64 providedResolvedAt);
-    error InvalidPrice(int256 price);
-    error InvalidDecimals(uint8 decimals);
+    error InvalidPayloadLength(uint256 length);
+    error UnsupportedPayloadVersion(uint8 version);
+    error UnsupportedPayloadFlags(uint8 flags);
+    error SourceIdOverflow(uint256 sourceId);
+    error SourceIdMismatch(uint64 expectedSourceId, uint64 providedFeedId);
+    error StaleRound(uint32 latestRoundId, uint32 providedRoundId);
+    error StaleResolvedAt(uint48 latestResolvedAtMs, uint48 providedResolvedAtMs);
+    error InvalidPrice(uint96 price);
 
     /// @inheritdoc IOracleCallback
     function onOracleEvent(
@@ -59,35 +51,38 @@ contract PriceFeedResolver is IOracleCallback {
     ) external override returns (bool shouldStore) {
         requireAllowed(SystemAddresses.NATIVE_ORACLE);
         if (sourceType != SOURCE_TYPE_PRICE_FEED) revert UnsupportedSourceType(sourceType);
+        if (payload.length != 32) revert InvalidPayloadLength(payload.length);
+        if (sourceId > type(uint64).max) revert SourceIdOverflow(sourceId);
 
-        _resolvePrice(sourceId, abi.decode(payload, (PricePayload)));
+        uint256 word;
+        assembly ("memory-safe") {
+            word := calldataload(payload.offset)
+        }
+
+        uint8 version = uint8(word >> 248);
+        if (version != PAYLOAD_VERSION) revert UnsupportedPayloadVersion(version);
+
+        uint8 flags = uint8(word);
+        if (flags != 0) revert UnsupportedPayloadFlags(flags);
+
+        uint64 feedId = uint64(word >> 184);
+        uint32 roundId = uint32(word >> 152);
+        uint48 resolvedAtMs = uint48(word >> 104);
+        uint96 price = uint96(word >> 8);
+        uint64 narrowedSourceId = uint64(sourceId);
+        if (feedId != narrowedSourceId) revert SourceIdMismatch(narrowedSourceId, feedId);
+
+        PriceRound memory current = latestPrice[feedId];
+        if (roundId == 0 || roundId <= current.roundId) {
+            revert StaleRound(current.roundId, roundId);
+        }
+        if (resolvedAtMs == 0 || resolvedAtMs <= current.resolvedAtMs) {
+            revert StaleResolvedAt(current.resolvedAtMs, resolvedAtMs);
+        }
+        if (price == 0) revert InvalidPrice(price);
+
+        latestPrice[feedId] = PriceRound({ roundId: roundId, resolvedAtMs: resolvedAtMs, price: price });
+        emit PriceResolved(feedId, roundId, price, resolvedAtMs);
         return false;
-    }
-
-    function _resolvePrice(
-        uint256 sourceId,
-        PricePayload memory payload
-    ) internal {
-        if (sourceId != payload.feedId) revert SourceIdMismatch(payload.feedId, sourceId);
-
-        PriceRound memory current = latestPrice[payload.feedId];
-        if (payload.roundId == 0 || payload.roundId <= current.roundId) {
-            revert StaleRound(current.roundId, payload.roundId);
-        }
-        if (payload.resolvedAt <= current.resolvedAt) {
-            revert StaleResolvedAt(current.resolvedAt, payload.resolvedAt);
-        }
-        if (payload.decimals > MAX_PRICE_DECIMALS) revert InvalidDecimals(payload.decimals);
-        if (payload.price <= 0) revert InvalidPrice(payload.price);
-
-        latestPrice[payload.feedId] = PriceRound({
-            exists: true,
-            roundId: payload.roundId,
-            resolvedAt: payload.resolvedAt,
-            decimals: payload.decimals,
-            price: payload.price
-        });
-
-        emit PriceResolved(payload.feedId, payload.roundId, payload.price, payload.decimals, payload.resolvedAt);
     }
 }

--- a/test/unit/oracle/OracleTaskConfig.t.sol
+++ b/test/unit/oracle/OracleTaskConfig.t.sol
@@ -127,6 +127,81 @@ contract OracleTaskConfigTest is Test {
         _assertSecondRelayerTaskRejected(SOURCE_TYPE_POLYMARKET_SETTLEMENT, 3);
     }
 
+    function test_SetTask_PriceFeedConfigIsPermanentlyBoundToSourceId() public {
+        uint256 feedId = 2001;
+        bytes memory config = bytes(
+            "gravity://3/2001/price_feed?provider=binance_index_kline_v1&pair=TSLAUSDT&interval=1m&bucketStartMs=1710000000000&decimals=8"
+        );
+
+        vm.startPrank(governance);
+        taskConfig.setTask(SOURCE_TYPE_PRICE_FEED, feedId, TASK_EVENTS, config);
+        taskConfig.setTask(SOURCE_TYPE_PRICE_FEED, feedId, TASK_EVENTS, config);
+        taskConfig.removeTask(SOURCE_TYPE_PRICE_FEED, feedId, TASK_EVENTS);
+        taskConfig.setTask(SOURCE_TYPE_PRICE_FEED, feedId, TASK_EVENTS, config);
+        vm.stopPrank();
+
+        assertEq(taskConfig.priceFeedConfigHash(feedId), keccak256(config));
+    }
+
+    function test_SetTask_RejectsPriceFeedSemanticReconfiguration() public {
+        uint256 feedId = 2001;
+        bytes memory originalConfig = bytes("pair=TSLAUSDT");
+        bytes memory changedConfig = bytes("pair=BTCUSDT");
+
+        vm.prank(governance);
+        taskConfig.setTask(SOURCE_TYPE_PRICE_FEED, feedId, TASK_EVENTS, originalConfig);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                OracleTaskConfig.PriceFeedConfigImmutable.selector,
+                feedId,
+                keccak256(originalConfig),
+                keccak256(changedConfig)
+            )
+        );
+        vm.prank(governance);
+        taskConfig.setTask(SOURCE_TYPE_PRICE_FEED, feedId, TASK_EVENTS, changedConfig);
+    }
+
+    function test_SetTask_RejectsPriceFeedRebindingAfterRemoval() public {
+        uint256 feedId = 2001;
+        bytes memory originalConfig = bytes("pair=TSLAUSDT");
+        bytes memory changedConfig = bytes("pair=BTCUSDT");
+
+        vm.startPrank(governance);
+        taskConfig.setTask(SOURCE_TYPE_PRICE_FEED, feedId, TASK_EVENTS, originalConfig);
+        taskConfig.removeTask(SOURCE_TYPE_PRICE_FEED, feedId, TASK_EVENTS);
+        vm.stopPrank();
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                OracleTaskConfig.PriceFeedConfigImmutable.selector,
+                feedId,
+                keccak256(originalConfig),
+                keccak256(changedConfig)
+            )
+        );
+        vm.prank(governance);
+        taskConfig.setTask(SOURCE_TYPE_PRICE_FEED, feedId, TASK_EVENTS, changedConfig);
+    }
+
+    function test_SetTask_RejectsPriceFeedSourceIdOverflow() public {
+        uint256 sourceId = uint256(type(uint64).max) + 1;
+
+        vm.expectRevert(abi.encodeWithSelector(OracleTaskConfig.PriceFeedSourceIdOverflow.selector, sourceId));
+        vm.prank(governance);
+        taskConfig.setTask(SOURCE_TYPE_PRICE_FEED, sourceId, TASK_EVENTS, bytes("price config"));
+    }
+
+    function test_SetTask_OtherSourceTypesRemainReconfigurable() public {
+        vm.startPrank(governance);
+        taskConfig.setTask(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, TASK_EVENTS, bytes("config v1"));
+        taskConfig.setTask(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, TASK_EVENTS, bytes("config v2"));
+        vm.stopPrank();
+
+        assertEq(taskConfig.getTask(SOURCE_TYPE_BLOCKCHAIN, ETHEREUM_SOURCE_ID, TASK_EVENTS).config, bytes("config v2"));
+    }
+
     function test_SetTask_MultipleSources() public {
         bytes memory ethConfig = abi.encode("ethereum config");
         bytes memory arbConfig = abi.encode("arbitrum config");
@@ -338,6 +413,7 @@ contract OracleTaskConfigTest is Test {
         bytes memory config
     ) public {
         vm.assume(config.length > 0);
+        vm.assume(sourceType != SOURCE_TYPE_PRICE_FEED || sourceId <= type(uint64).max);
 
         vm.prank(governance);
         taskConfig.setTask(sourceType, sourceId, taskName, config);
@@ -356,6 +432,7 @@ contract OracleTaskConfigTest is Test {
         bytes memory config
     ) public {
         vm.assume(config.length > 0);
+        vm.assume(sourceType != SOURCE_TYPE_PRICE_FEED || sourceId <= type(uint64).max);
 
         vm.prank(governance);
         taskConfig.setTask(sourceType, sourceId, taskName, config);
@@ -409,6 +486,8 @@ contract OracleTaskConfigTest is Test {
         uint256 sourceId2
     ) public {
         vm.assume(sourceType1 != sourceType2 || sourceId1 != sourceId2);
+        vm.assume(sourceType1 != SOURCE_TYPE_PRICE_FEED || sourceId1 <= type(uint64).max);
+        vm.assume(sourceType2 != SOURCE_TYPE_PRICE_FEED || sourceId2 <= type(uint64).max);
 
         bytes memory config1 = abi.encode("config1");
         bytes memory config2 = abi.encode("config2");

--- a/test/unit/oracle/PriceFeedResolver.t.sol
+++ b/test/unit/oracle/PriceFeedResolver.t.sol
@@ -14,12 +14,10 @@ contract PriceFeedResolverTest is Test {
     PriceFeedResolver public resolver;
 
     uint32 public constant SOURCE_TYPE_PRICE_FEED = 3;
-    uint256 public constant FEED_ID = 1;
+    uint64 public constant FEED_ID = 1;
     uint256 public constant CALLBACK_GAS_LIMIT = 500_000;
 
-    event PriceResolved(
-        uint256 indexed feedId, uint64 indexed roundId, int256 price, uint8 decimals, uint64 resolvedAt
-    );
+    event PriceResolved(uint64 indexed feedId, uint32 indexed roundId, uint96 price, uint48 resolvedAtMs);
 
     function setUp() public {
         vm.etch(SystemAddresses.NATIVE_ORACLE, address(new NativeOracle()).code);
@@ -30,19 +28,18 @@ contract PriceFeedResolverTest is Test {
         oracle.setDefaultCallback(SOURCE_TYPE_PRICE_FEED, address(resolver));
     }
 
-    function test_StoresLatestPriceAndSourceProgress() public {
-        bytes memory payload = _payload(FEED_ID, 1, 1_010, 8, 196_12500000);
+    function test_StoresPackedV1PriceAndSourceProgress() public {
+        bytes memory payload = _payload(FEED_ID, 1, 1_010, 196_12500000, 1, 0);
 
         vm.expectEmit(true, true, false, true, address(resolver));
-        emit PriceResolved(FEED_ID, 1, 196_12500000, 8, 1_010);
+        emit PriceResolved(FEED_ID, 1, 196_12500000, 1_010);
         _record(FEED_ID, 1, 1_010, payload, CALLBACK_GAS_LIMIT);
 
-        (bool exists, uint64 roundId, uint64 resolvedAt, uint8 decimals, int256 price) = resolver.latestPrice(FEED_ID);
-        assertTrue(exists);
+        (uint32 roundId, uint48 resolvedAtMs, uint96 price) = resolver.latestPrice(FEED_ID);
         assertEq(roundId, 1);
-        assertEq(resolvedAt, 1_010);
-        assertEq(decimals, 8);
+        assertEq(resolvedAtMs, 1_010);
         assertEq(price, 196_12500000);
+        assertEq(resolver.PRICE_DECIMALS(), 8);
 
         INativeOracle.SourceProgress memory progress = oracle.getSourceProgress(SOURCE_TYPE_PRICE_FEED, FEED_ID);
         assertEq(progress.latestNonce, 1);
@@ -50,14 +47,47 @@ contract PriceFeedResolverTest is Test {
         assertEq(oracle.getRecord(SOURCE_TYPE_PRICE_FEED, FEED_ID, 1).recordedAt, 0);
     }
 
-    function test_NextRoundOverwritesLatestPriceWithoutHistory() public {
-        _record(FEED_ID, 1, 1_010, _payload(FEED_ID, 1, 1_010, 8, 196_12500000), CALLBACK_GAS_LIMIT);
-        _record(FEED_ID, 2, 2_010, _payload(FEED_ID, 2, 2_010, 8, 197_50000000), CALLBACK_GAS_LIMIT);
+    function test_GoldenVector() public pure {
+        bytes memory payload = _payload(2001, 28_500_000, 1_710_000_059_999, 40_067_545_000, 1, 0);
 
-        (bool exists, uint64 roundId, uint64 resolvedAt,, int256 price) = resolver.latestPrice(FEED_ID);
-        assertTrue(exists);
+        assertEq(payload, hex"0100000000000007d101b2e020018e23f2365f0000000000000009543637a800");
+    }
+
+    function test_PriceRoundOccupiesOneStorageSlot() public {
+        uint32 roundId = 28_500_000;
+        uint48 resolvedAtMs = 1_710_000_059_999;
+        uint96 price = 40_067_545_000;
+        _record(FEED_ID, 1, resolvedAtMs, _payload(FEED_ID, roundId, resolvedAtMs, price, 1, 0), CALLBACK_GAS_LIMIT);
+
+        bytes32 valueSlot = keccak256(abi.encode(uint256(FEED_ID), uint256(0)));
+        uint256 expected = uint256(roundId) | (uint256(resolvedAtMs) << 32) | (uint256(price) << 80);
+        assertEq(uint256(vm.load(address(resolver), valueSlot)), expected);
+        assertEq(uint256(vm.load(address(resolver), bytes32(uint256(valueSlot) + 1))), 0);
+    }
+
+    function test_MaximumFieldWidthsAreAccepted() public {
+        uint64 feedId = type(uint64).max;
+        _record(
+            feedId,
+            1,
+            type(uint48).max,
+            _payload(feedId, type(uint32).max, type(uint48).max, type(uint96).max, 1, 0),
+            CALLBACK_GAS_LIMIT
+        );
+
+        (uint32 roundId, uint48 resolvedAtMs, uint96 price) = resolver.latestPrice(feedId);
+        assertEq(roundId, type(uint32).max);
+        assertEq(resolvedAtMs, type(uint48).max);
+        assertEq(price, type(uint96).max);
+    }
+
+    function test_NextRoundOverwritesLatestPriceWithoutHistory() public {
+        _record(FEED_ID, 1, 1_010, _payload(FEED_ID, 1, 1_010, 196_12500000, 1, 0), CALLBACK_GAS_LIMIT);
+        _record(FEED_ID, 2, 2_010, _payload(FEED_ID, 2, 2_010, 197_50000000, 1, 0), CALLBACK_GAS_LIMIT);
+
+        (uint32 roundId, uint48 resolvedAtMs, uint96 price) = resolver.latestPrice(FEED_ID);
         assertEq(roundId, 2);
-        assertEq(resolvedAt, 2_010);
+        assertEq(resolvedAtMs, 2_010);
         assertEq(price, 197_50000000);
         assertEq(oracle.getLatestNonce(SOURCE_TYPE_PRICE_FEED, FEED_ID), 2);
         assertEq(oracle.getRecord(SOURCE_TYPE_PRICE_FEED, FEED_ID, 1).recordedAt, 0);
@@ -65,95 +95,115 @@ contract PriceFeedResolverTest is Test {
     }
 
     function test_IndependentFeedsDoNotOverwriteEachOther() public {
-        uint256 secondFeedId = 2;
-        _record(FEED_ID, 1, 1_010, _payload(FEED_ID, 1, 1_010, 8, 196_12500000), CALLBACK_GAS_LIMIT);
-        _record(secondFeedId, 1, 1_010, _payload(secondFeedId, 1, 1_010, 6, 28_500000), CALLBACK_GAS_LIMIT);
+        uint64 secondFeedId = 2;
+        _record(FEED_ID, 1, 1_010, _payload(FEED_ID, 1, 1_010, 196_12500000, 1, 0), CALLBACK_GAS_LIMIT);
+        _record(secondFeedId, 1, 1_010, _payload(secondFeedId, 1, 1_010, 28_50000000, 1, 0), CALLBACK_GAS_LIMIT);
 
-        (,,,, int256 firstPrice) = resolver.latestPrice(FEED_ID);
-        (bool exists, uint64 roundId,, uint8 decimals, int256 secondPrice) = resolver.latestPrice(secondFeedId);
+        (,, uint96 firstPrice) = resolver.latestPrice(FEED_ID);
+        (uint32 roundId,, uint96 secondPrice) = resolver.latestPrice(secondFeedId);
         assertEq(firstPrice, 196_12500000);
-        assertTrue(exists);
         assertEq(roundId, 1);
-        assertEq(decimals, 6);
-        assertEq(secondPrice, 28_500000);
+        assertEq(secondPrice, 28_50000000);
+    }
+
+    function test_RevertsForInvalidPayloadLength() public {
+        _expectDirectRevert(
+            abi.encodeWithSelector(PriceFeedResolver.InvalidPayloadLength.selector, 31), FEED_ID, new bytes(31)
+        );
+        _expectDirectRevert(
+            abi.encodeWithSelector(PriceFeedResolver.InvalidPayloadLength.selector, 33), FEED_ID, new bytes(33)
+        );
+    }
+
+    function test_RevertsForUnknownVersion() public {
+        _expectDirectRevert(
+            abi.encodeWithSelector(PriceFeedResolver.UnsupportedPayloadVersion.selector, uint8(2)),
+            FEED_ID,
+            _payload(FEED_ID, 1, 1_010, 196_12500000, 2, 0)
+        );
+    }
+
+    function test_RevertsForNonzeroFlags() public {
+        _expectDirectRevert(
+            abi.encodeWithSelector(PriceFeedResolver.UnsupportedPayloadFlags.selector, uint8(1)),
+            FEED_ID,
+            _payload(FEED_ID, 1, 1_010, 196_12500000, 1, 1)
+        );
+    }
+
+    function test_RevertsForSourceIdOverflow() public {
+        uint256 sourceId = uint256(type(uint64).max) + 1;
+        _expectDirectRevert(
+            abi.encodeWithSelector(PriceFeedResolver.SourceIdOverflow.selector, sourceId),
+            sourceId,
+            _payload(FEED_ID, 1, 1_010, 196_12500000, 1, 0)
+        );
+    }
+
+    function test_RevertsForSourceIdMismatch() public {
+        _expectDirectRevert(
+            abi.encodeWithSelector(PriceFeedResolver.SourceIdMismatch.selector, uint64(FEED_ID + 1), FEED_ID),
+            FEED_ID + 1,
+            _payload(FEED_ID, 1, 1_010, 196_12500000, 1, 0)
+        );
     }
 
     function test_ZeroRoundRevertsAtomically() public {
         vm.expectPartialRevert(Errors.OracleCallbackFailed.selector);
-        _record(FEED_ID, 1, 1_010, _payload(FEED_ID, 0, 1_010, 8, 196_12500000), CALLBACK_GAS_LIMIT);
+        _record(FEED_ID, 1, 1_010, _payload(FEED_ID, 0, 1_010, 196_12500000, 1, 0), CALLBACK_GAS_LIMIT);
         _assertUnchanged();
     }
 
     function test_ZeroResolvedAtRevertsAtomically() public {
         vm.expectPartialRevert(Errors.OracleCallbackFailed.selector);
-        _record(FEED_ID, 1, 1, _payload(FEED_ID, 1, 0, 8, 196_12500000), CALLBACK_GAS_LIMIT);
+        _record(FEED_ID, 1, 1, _payload(FEED_ID, 1, 0, 196_12500000, 1, 0), CALLBACK_GAS_LIMIT);
         _assertUnchanged();
     }
 
     function test_ZeroPriceRevertsAtomically() public {
         vm.expectPartialRevert(Errors.OracleCallbackFailed.selector);
-        _record(FEED_ID, 1, 1_010, _payload(FEED_ID, 1, 1_010, 8, 0), CALLBACK_GAS_LIMIT);
-        _assertUnchanged();
-    }
-
-    function test_NegativePriceRevertsAtomically() public {
-        vm.expectPartialRevert(Errors.OracleCallbackFailed.selector);
-        _record(FEED_ID, 1, 1_010, _payload(FEED_ID, 1, 1_010, 8, -1), CALLBACK_GAS_LIMIT);
-        _assertUnchanged();
-    }
-
-    function test_ExcessiveDecimalsRevertsAtomically() public {
-        bytes memory payload = _payload(FEED_ID, 1, 1_010, resolver.MAX_PRICE_DECIMALS() + 1, 196_12500000);
-
-        vm.expectPartialRevert(Errors.OracleCallbackFailed.selector);
-        _record(FEED_ID, 1, 1_010, payload, CALLBACK_GAS_LIMIT);
+        _record(FEED_ID, 1, 1_010, _payload(FEED_ID, 1, 1_010, 0, 1, 0), CALLBACK_GAS_LIMIT);
         _assertUnchanged();
     }
 
     function test_StaleRoundRevertsWithoutAdvancingProgress() public {
-        _record(FEED_ID, 1, 2_010, _payload(FEED_ID, 2, 2_010, 8, 197_50000000), CALLBACK_GAS_LIMIT);
+        _record(FEED_ID, 1, 2_010, _payload(FEED_ID, 2, 2_010, 197_50000000, 1, 0), CALLBACK_GAS_LIMIT);
 
         vm.expectPartialRevert(Errors.OracleCallbackFailed.selector);
-        _record(FEED_ID, 2, 3_010, _payload(FEED_ID, 1, 3_010, 8, 196_12500000), CALLBACK_GAS_LIMIT);
+        _record(FEED_ID, 2, 3_010, _payload(FEED_ID, 1, 3_010, 196_12500000, 1, 0), CALLBACK_GAS_LIMIT);
 
-        (, uint64 roundId, uint64 resolvedAt,, int256 price) = resolver.latestPrice(FEED_ID);
+        (uint32 roundId, uint48 resolvedAtMs, uint96 price) = resolver.latestPrice(FEED_ID);
         assertEq(roundId, 2);
-        assertEq(resolvedAt, 2_010);
+        assertEq(resolvedAtMs, 2_010);
         assertEq(price, 197_50000000);
         assertEq(oracle.getLatestNonce(SOURCE_TYPE_PRICE_FEED, FEED_ID), 1);
     }
 
     function test_StaleResolvedAtRevertsWithoutAdvancingProgress() public {
-        _record(FEED_ID, 1, 2_010, _payload(FEED_ID, 1, 2_010, 8, 196_12500000), CALLBACK_GAS_LIMIT);
+        _record(FEED_ID, 1, 2_010, _payload(FEED_ID, 1, 2_010, 196_12500000, 1, 0), CALLBACK_GAS_LIMIT);
 
         vm.expectPartialRevert(Errors.OracleCallbackFailed.selector);
-        _record(FEED_ID, 2, 2_010, _payload(FEED_ID, 2, 2_010, 8, 197_50000000), CALLBACK_GAS_LIMIT);
+        _record(FEED_ID, 2, 2_010, _payload(FEED_ID, 2, 2_010, 197_50000000, 1, 0), CALLBACK_GAS_LIMIT);
         assertEq(oracle.getLatestNonce(SOURCE_TYPE_PRICE_FEED, FEED_ID), 1);
     }
 
-    function test_SourceIdMismatchRevertsAtomically() public {
-        vm.expectPartialRevert(Errors.OracleCallbackFailed.selector);
-        _record(FEED_ID + 1, 1, 1_010, _payload(FEED_ID, 1, 1_010, 8, 196_12500000), CALLBACK_GAS_LIMIT);
-
-        (bool exists,,,,) = resolver.latestPrice(FEED_ID);
-        assertFalse(exists);
-        assertEq(oracle.getLatestNonce(SOURCE_TYPE_PRICE_FEED, FEED_ID + 1), 0);
-    }
-
-    function test_MalformedPayloadRevertsAtomically() public {
-        vm.expectPartialRevert(Errors.OracleCallbackFailed.selector);
-        _record(FEED_ID, 1, 1_010, hex"1234", CALLBACK_GAS_LIMIT);
-        _assertUnchanged();
+    function test_OldAbiPayloadIsRejected() public {
+        bytes memory oldPayload = abi.encode(uint256(FEED_ID), uint64(1), uint64(1_010), uint8(8), int256(196_12500000));
+        _expectDirectRevert(
+            abi.encodeWithSelector(PriceFeedResolver.InvalidPayloadLength.selector, oldPayload.length),
+            FEED_ID,
+            oldPayload
+        );
     }
 
     function test_CallbackGasFailureLeavesNoPriceOrProgress() public {
         vm.expectPartialRevert(Errors.OracleCallbackFailed.selector);
-        _record(FEED_ID, 1, 1_010, _payload(FEED_ID, 1, 1_010, 8, 196_12500000), 1);
+        _record(FEED_ID, 1, 1_010, _payload(FEED_ID, 1, 1_010, 196_12500000, 1, 0), 1);
         _assertUnchanged();
     }
 
     function test_RevertWhenCallbackCalledOutsideNativeOracle() public {
-        bytes memory payload = _payload(FEED_ID, 1, 1_010, 8, 196_12500000);
+        bytes memory payload = _payload(FEED_ID, 1, 1_010, 196_12500000, 1, 0);
         address caller = makeAddr("caller");
 
         vm.expectRevert(abi.encodeWithSelector(NotAllowed.selector, caller, SystemAddresses.NATIVE_ORACLE));
@@ -164,12 +214,24 @@ contract PriceFeedResolverTest is Test {
     function test_RevertWhenNativeOracleUsesWrongSourceType() public {
         vm.expectRevert(abi.encodeWithSelector(PriceFeedResolver.UnsupportedSourceType.selector, uint32(4)));
         vm.prank(SystemAddresses.NATIVE_ORACLE);
-        resolver.onOracleEvent(4, FEED_ID, 1, _payload(FEED_ID, 1, 1_010, 8, 196_12500000));
+        resolver.onOracleEvent(4, FEED_ID, 1, _payload(FEED_ID, 1, 1_010, 196_12500000, 1, 0));
+    }
+
+    function _expectDirectRevert(
+        bytes memory reason,
+        uint256 sourceId,
+        bytes memory payload
+    ) internal {
+        vm.expectRevert(reason);
+        vm.prank(SystemAddresses.NATIVE_ORACLE);
+        resolver.onOracleEvent(SOURCE_TYPE_PRICE_FEED, sourceId, 1, payload);
     }
 
     function _assertUnchanged() internal view {
-        (bool exists,,,,) = resolver.latestPrice(FEED_ID);
-        assertFalse(exists);
+        (uint32 roundId, uint48 resolvedAtMs, uint96 price) = resolver.latestPrice(FEED_ID);
+        assertEq(roundId, 0);
+        assertEq(resolvedAtMs, 0);
+        assertEq(price, 0);
         assertEq(oracle.getLatestNonce(SOURCE_TYPE_PRICE_FEED, FEED_ID), 0);
         assertEq(oracle.getRecord(SOURCE_TYPE_PRICE_FEED, FEED_ID, 1).recordedAt, 0);
     }
@@ -186,16 +248,15 @@ contract PriceFeedResolverTest is Test {
     }
 
     function _payload(
-        uint256 feedId,
-        uint64 roundId,
-        uint64 resolvedAt,
-        uint8 decimals,
-        int256 price
+        uint64 feedId,
+        uint32 roundId,
+        uint48 resolvedAtMs,
+        uint96 price,
+        uint8 version,
+        uint8 flags
     ) internal pure returns (bytes memory) {
-        return abi.encode(
-            PriceFeedResolver.PricePayload({
-                feedId: feedId, roundId: roundId, resolvedAt: resolvedAt, decimals: decimals, price: price
-            })
-        );
+        uint256 word = uint256(version) << 248 | uint256(feedId) << 184 | uint256(roundId) << 152
+            | uint256(resolvedAtMs) << 104 | uint256(price) << 8 | uint256(flags);
+        return abi.encodePacked(bytes32(word));
     }
 }


### PR DESCRIPTION
## Summary

Implements the contract half of Galxe/gravity-audit#1092 before the price-feed feature is activated:

- accept only the canonical 32-byte packed Price Feed V1 callback body
- fix price precision at 8 decimals and use unsigned bounded fields
- store each latest round in one mapping value slot
- enforce exact length, version, flags, source identity, monotonic round/time, and positive price
- permanently bind each source type 3 feed ID to its first task config hash
- reject the undeployed legacy 160-byte callback body

Packed layout:

```text
version:u8 | feedId:u64 | roundId:u32 | resolvedAtMs:u48 | price:u96 | flags:u8
```

Golden inner payload:

```text
0100000000000007d101b2e020018e23f2365f0000000000000009543637a800
```

## Design notes

This is intentionally a packed-only predeployment change. No legacy decoder, storage migration, or old getter/event compatibility is added.

The config binding is deliberately stricter than the minimum semantic invariant in #1092: all raw config bytes are immutable for a price-feed ID, including `graceMs`. Any config change must use a new feed ID. This avoids parsing provider URIs on chain and fails closed against historical feed reinterpretation.

Polymarket contracts are unchanged.

## Verification

- `forge fmt --check`
- `forge test --match-path 'test/unit/oracle/PriceFeedResolver.t.sol'`: 20 passed
- `forge test --match-path 'test/unit/oracle/OracleTaskConfig.t.sol'`: 36 passed
- all oracle unit suites: 325 passed
- full Forge suite: 0 failures
- `forge inspect ... storage-layout --json`: `PriceRound` occupies one slot

## Rollout

Merge this contract format first, then the matching gravity-reth producer, then update gravity-sdk E2E/soak coverage. Do not enable a price-feed task until all participating validators run the packed producer.